### PR TITLE
Added checks for content-type in sample-module, and tests

### DIFF
--- a/okapi-core/src/test/java/okapi/DeployModuleTest.java
+++ b/okapi-core/src/test/java/okapi/DeployModuleTest.java
@@ -429,12 +429,14 @@ public class DeployModuleTest {
         body.appendBuffer(x);
       });
       response.endHandler(x -> {
-        context.assertEquals("Hello Okapi", body.toString());
+        //context.assertEquals("Hello Okapi", body.toString());
+        context.assertEquals("Hello  (XML) Okapi", body.toString());
         useNoPath(context, async);
       });
     });
     req.headers().add("X-Okapi-Token", okapiToken);
     req.putHeader("X-Okapi-Tenant", okapiTenant);
+    req.putHeader("Content-Type", "text/xml");  
     req.end("Okapi");
   }
 
@@ -551,7 +553,8 @@ public class DeployModuleTest {
       context.assertEquals(200, response.statusCode());
       String headers = response.headers().entries().toString();
       System.out.println("useWithGet2 headers " + headers);
-      context.assertTrue(headers != null && headers.matches(".*X-Okapi-Trace=GET sample-module2:200.*"));
+      context.assertTrue(headers != null
+        && headers.matches(".*X-Okapi-Trace=GET sample-module2:200.*"));
       response.handler(x -> {
         context.assertEquals("It works", x.toString());
       });
@@ -614,6 +617,8 @@ public class DeployModuleTest {
   }
 
   // Repeat the Get test, to see timing headers of a system that has been warmed up
+  // Also, pass a content-type that claims to be XML, the sample will see this and
+  // respond with a different message
   public void useItWithGet3(TestContext context, Async async) {
     System.out.println("useItWithGet3");
     HttpClientRequest req = httpClient.get(port, "localhost", "/sample", response -> {
@@ -623,7 +628,9 @@ public class DeployModuleTest {
       // context.assertTrue(headers.matches(".*X-Okapi-Trace=GET auth:202.*")); 
       context.assertTrue(headers.matches(".*X-Okapi-Trace=GET sample-module2:200.*"));
       response.handler(x -> {
-        context.assertEquals("It works", x.toString());
+        System.out.println("useItWithGet3: '" + x + "'");
+        //context.assertEquals("It works", x.toString());
+        context.assertEquals("It works (XML) ", x.toString());
       });
       response.endHandler(x -> {
         deleteTenant(context, async);
@@ -631,6 +638,7 @@ public class DeployModuleTest {
     });
     req.headers().add("X-Okapi-Token", okapiToken);
     req.putHeader("X-Okapi-Tenant", okapiTenant);
+    req.putHeader("Content-Type", "text/xml");  
     req.end();
   }
 

--- a/okapi-sample-module/src/main/java/okapi/MainVerticle.java
+++ b/okapi-sample-module/src/main/java/okapi/MainVerticle.java
@@ -21,13 +21,19 @@ public class MainVerticle extends AbstractVerticle {
 
   public void my_stream_handle(RoutingContext ctx) {
     ctx.response().setStatusCode(200);
+    final String ctype = ctx.request().headers().get("Content-Type");
+    String xmlMsg = "";
+    if ( ctype != null && ctype.toLowerCase().contains("xml"))
+      xmlMsg = " (XML) ";
+    final String xmlMsg2 = xmlMsg;
+    //System.out.println("Sample: ctype='" + ctype + "'");
     if (ctx.request().method().equals(HttpMethod.GET)) {
       ctx.request().endHandler(x -> {
-        ctx.response().end("It works");
+        ctx.response().end("It works" + xmlMsg2);
       });
     } else {
       ctx.response().setChunked(true);
-      ctx.response().write("Hello ");
+      ctx.response().write("Hello " + xmlMsg2);
       ctx.request().handler(x -> {
         ctx.response().write(x);
       });


### PR DESCRIPTION
Both GET and POST seem to pass the content-type along just fine.
Fixes gh-37
