### PR TITLE
addition of git-commit-id and docker-maven plugins to Maven POMs

### DIFF
--- a/okapi-core/pom.xml
+++ b/okapi-core/pom.xml
@@ -151,6 +151,15 @@
           </systemPropertyVariables>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>com.spotify</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
+        <configuration>
+          <skipDockerBuild>false</skipDockerBuild>
+          <skipDockerTag>false</skipDockerTag>
+        </configuration>
+      </plugin>
+
     </plugins>
   </build>
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <vertx-version>3.2.1</vertx-version>
+    <docker.registry>docker.indexdata.com:5000</docker.registry>
   </properties>
 
   <build>
@@ -73,6 +74,55 @@
                 </configuration>
             </execution>
         </executions>
+      </plugin>
+     <plugin>
+        <groupId>pl.project13.maven</groupId>
+        <artifactId>git-commit-id-plugin</artifactId>
+        <version>2.2.1</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
+          <!-- <dateFormatTimeZone>${user.timezone}</dateFormatTimeZone> -->
+          <dateFormatTimeZone>UTC</dateFormatTimeZone> -->
+          <verbose>false</verbose>
+          <generateGitPropertiesFile>true</generateGitPropertiesFile>
+          <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+          <injectAllReactorProjects>true</injectAllReactorProjects>
+          <skip>false</skip>
+          <runOnlyOnce>false</runOnlyOnce>
+        </configuration>
+      </plugin>
+     <plugin>
+        <groupId>com.spotify</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
+        <version>0.4.5</version>
+        <configuration>
+          <skipDockerBuild>true</skipDockerBuild>
+          <skipDockerTag>true</skipDockerTag>
+          <dockerDirectory>${basedir}</dockerDirectory>
+          <serverId>docker_registry</serverId>
+          <registryUrl>https://${docker.registry}/v2/</registryUrl>
+          <imageName>${project.artifactId}</imageName>
+          <imageTags>
+            <imageTag>${git.commit.id.abbrev}</imageTag>
+            <imageTag>latest</imageTag>
+          </imageTags>
+          <image>${project.artifactId}:${git.commit.id.abbrev}</image>
+          <newName>${docker.registry}/${project.artifactId}:${git.commit.id.abbrev}</newName>
+          <resources>
+            <resource>
+              <targetPath>/</targetPath>
+              <directory>${project.build.directory}</directory>
+              <include>${project.outputFile}</include>
+            </resource>
+          </resources>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Addition of two Maven plugins to the top-level POM in the okapi project parent 
directory and okapi-core child POM. 
- git-commit-id-plugin from pl.project13.maven 
  
  This plugin creates a 'git.properties' file for each sub-module in 
  target/classes. http://mvnrepository.com/artifact/pl.project13.maven/git-commit-id-plugin
- docker-maven-plugin from com.spotify
  
  This plugin creates docker images, tags, and pushes them to Docker registries.
  https://github.com/spotify/docker-maven-plugin

Both plugins are available in the Maven Central repository.

USAGE:

mvn package docker:build
- Builds local docker image called 'okapi-core' for Okapi based on Dockerfile 
  located at okapi-core/Dockerfile.
- Tags image with 'latest' and most recent abbreviated git commit id.

mvn package docker:tag -DpushImage
- renames the image from 'okapi-core' so that it can be pushed to our private Docker registry
  (currently 'docker.indexdata.com:5000') and pushes the image to the Docker repository tagged 
  with the git commit id. 

Notes:  
- Docker is required on the Maven host in order to build Docker images.  If building with a Maven
  Docker container, the runtime command would look something like this:

docker run -it --rm --name mvnbuild -v $PWD:/usr/src/okapi -v /home/${USER}/.m2:/root/.m2 \
 -v /run/docker.sock:/run/docker.sock -w /usr/src/okapi maven:3.3.3-jdk-8 mvn  package docker:build

The Maven container requires access to the Docker API.  In the example above, we mount the host
Docker socket to the containter.
- The registry, 'docker.indexdata.com:5000', requires authentication.  In order to push an 
  image to the registry, configure your local maven settings.xml with the server id and 
  credentials. 

```
<settings>
  <servers>
     <server>
        <id>docker_registry</id>
        <username>indexdata</username>
        <password>{ENCRYPTED_MAVEN_PASSWORD_STRING}</password>
        <configuration>
          <email>none</email>
        </configuration>
     </server>
  </servers>
</settings>
```

The Docker registry is defined in the top-level POM as a Maven property:

```
<properties>
  <docker.registry>docker.indexdata.com:5000</docker.registry>
</properties>
```

KNOWN ISSUES:
- It would be great to be able to push the image with the 'latest' tag in addition to the git commit id,
  however, the plugin does not need to be able to support renaming images with multiple tags.
  To push a new tag manually:

docker tag okapi-core:latest docker.indexdata.com:5000/okapi-core:latest
docker push docker.indexdata.com:5000/okapi-core:latest
