### PR TITLE
Synchronise copies of contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,13 +2,13 @@
 
 ## Git and branches
 
-We are trying to follow "GitHub Flow" - see
-[here](http://scottchacon.com/2011/08/31/github-flow.html)
+For all FOLIO code repositories, we are trying to follow
+[GitHub Flow](https://guides.github.com/introduction/flow/).
 
 In short, the master branch is always the head of latest development. Anything
 merged into master should be of such good quality that at any time a snapshot
 from master passes all tests, and can be deployed. That is not to say that it
-will be free of bugs, we are not superhuman.
+will be free of bugs; we are not superhuman.
 
 All real work should be done in feature branches. It is still OK to make a
 small trivial change directly in the master. Stuff like editing the README.
@@ -18,8 +18,9 @@ small trivial change directly in the master. Stuff like editing the README.
 
 Feature branches should be branched off from the master. The naming of those
 is not strict, but if you start a branch to fix issue okapi-xxx filed in
-[issues.folio.org](https://issues.folio.org/) , you might well call the
-branch _okapi-xxx_:
+[issues.folio.org](https://issues.folio.org/) then you might well call the
+branch _okapi-xxx_ (or if you want to be more descriptive, something
+like _okapi-xxx-contribution-guidelines_):
 
     git checkout -b okapi-xxx
 
@@ -32,7 +33,7 @@ you will write decent commit messages explaining what you have done.
 
 The first time you want to push your branch to GitHub, you may encounter an
 error _The current branch okapi-xxx has no upstream branch_. Git tells you
-what to do, namely
+what to do, namely:
 
     git push --set-upstream origin okapi-xxx
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,6 @@ will be free of bugs; we are not superhuman.
 All real work should be done in feature branches. It is still OK to make a
 small trivial change directly in the master. Stuff like editing the README.
 
-
 ### Feature branches
 
 Feature branches should be branched off from the master. The naming of those
@@ -60,7 +59,6 @@ It should show you that it is _able to merge_, so click on the "Create Pull
 Request" button under the comment box. Once the request is created, assign it
 to someone else.
 
-
 ### Merging pull requests
 
 When someone has assigned a pull request to you, check out the branch, and
@@ -98,11 +96,11 @@ When done, you probably want to delete the local branch from your own machine
 The exact procedure for making a release is not yet specified. It is likely to
 be something like we are doing for other software:
 
-* Freeze the master for a short while
-* Make a release branch
-* Make changes specific for this release in the branch
-* Tag a version
-* Package and release it
+- Freeze the master for a short while
+- Make a release branch
+- Make changes specific for this release in the branch
+- Tag a version
+- Package and release it
 
 Later, if there are bugs in the released version, work can continue on the
 version branch, and we can release a new minor version from the branch. Some
@@ -111,43 +109,44 @@ master, as need be.
 
 ## Version numbers
 
-Since (almost?) all our stuff is web services, we need to keep two kind of
+Since (almost) all our stuff is web services, we need to keep two kind of
 version numbers, one for the API, and one for the implementation code. To
 make matters worse, a module may implement several interfaces.
 
-
 ### API versions
 
-The API versions are the most important. They are two-part numbers, as in 3.14.
+The API versions are the most important. They are two-part numbers,
+such as `3.14`
 
 The rules are simple:
 
-* If you only add things to the interface, you increment the minor number,
+- If you only add things to the interface, you increment the minor number,
   because the API is backwards compatible.
-* If you remove or change anything, you must increment the major number, because
-  now your API is no longer backwards compatible.
+- If you remove or change anything, you must increment the major number,
+  because now your API is no longer backwards compatible.
 
-For example, you can add a new function to 3.14, and call it 3.15. Any module
-that requires 3.14 can also use 3.15. But if you remove anything from the API,
-or change the meaning of a parameter, you need to bump the API version to 4.1.
+For example, you can add a new function to `3.14`, and call it `3.15`.
+Any module that requires `3.14` can also use `3.15`. But if you remove
+anything from the API, or change the meaning of a parameter, you need to
+bump the API version to `4.1`
 
 ### Implementation versions
 
-The module versions are in 3 parts, like 3.14.15
+The module versions are three-part part numbers, such as `3.14.15`
 
-* The last part should be incremented if you haven't changed anything in the API,
-  but only fixed bugs, etc.
-* The middle part should be incremented if you added something to the API, and
+- The last part should be incremented if you haven't changed anything in
+  the API, but only fixed bugs, etc.
+- The middle part should be incremented if you added something to the API, and
   incremented the minor API version.
-* The major part should be incremented if you made a backwards incompatible change
-  to the API, and incremented its major number.
-
+- The major part should be incremented if you made a backwards incompatible
+  change to the API, and incremented its major number.
 
 ### The simple case
 
 In the most simple case, a module implements just one interface. Then we can
-keep the two versions in sync, so module version 3.14.01 implements the interface
-3.14, and the last part shows that this is the first version that does so.
+keep the two versions in sync, so module version `3.14.01` implements the
+interface `3.14`, and the last part shows that this is the first version
+that does so.
 
 ### Complex cases
 
@@ -156,46 +155,47 @@ of any of them. In that case the version numbering is necessarily more complex.
 There does not have to be any correlation between the module version and the
 version of the interfaces it implements.
 
-For example, if the circulation module version 3.14.1 can implement the checkout
-API version 1.4 and the checkin API version 2.7. The rules are still the same:
+For example, if the circulation module version `3.14.1` can implement the
+checkout API version `1.4` and the checkin API version `2.7` then the
+rules are still the same:
 
-* If you don't change any API, increment the last part to 3.14.2
-* If you add new features to _any_ API, increment the middle part to 3.15.1
-* If you make any backwards incompatible change to _any_ API, or drop _any_
-  API at all, increment the module version to 4.1.1
+- If you don't change any API, increment the last part to `3.14.2`
+- If you add new features to _any_ API, increment the middle part to `3.15.1`
+- If you make any backwards incompatible change to _any_ API, or drop _any_
+  API at all, increment the module version to `4.1.1`
 
 The most common case is probably when we need to add a new, incompatible API
 to a module, but want to keep the old one too. In such cases we only increment
-the module version to 3.15.1, but mark that it provides the API versions 3.14
-and 4.1.
+the module version to `3.15.1` but mark that it provides the API versions
+`3.14` and `4.1`
 
 ### Dot one, not zero
+
 The version numbers that end in zero are special, they are reserved for filing
 issues for the next version. If you have a small thing you want to add next
-time we change the minor version, label the issue with something like v3.15.0
-or even v4.0.0 if the change is not backwards compatible. When the change gets
-implemented, we bump the version number to 3.15.1 or 4.1.1.
+time we change the minor version, label the issue with something like `v3.15.0`
+or even `v4.0.0` if the change is not backwards compatible. When the change
+gets implemented, we bump the version number to `3.15.1` or `4.1.1`
 
-Do not release modules with a version number ending in `.0`.
-
+Do not release modules with a version number ending in `.0`
 
 ## Coding style
 
 For Java code, we basically try to adhere to Sun Java coding
 [conventions](http://www.oracle.com/technetwork/java/codeconvtoc-136057.html)
-(That document is old and unmaintained, but seems to be good enough as it is)
+(that document is old and unmaintained, but seems to be good enough as it is).
 
 There are a few exceptions:
 
-* We indent with two spaces only, because vert.x uses deeply nested callbacks.
-* We _don't_ use tab characters for indents, only spaces
+- We indent with two spaces only, because vert.x uses deeply nested callbacks.
+- We _don't_ use tab characters for indents, only spaces.
 
 Remember to set your IDE to remove trailing spaces on saving files,
 since those produce unnecessary diffs in Git.
 
 ## License
 
-Licensed under the Apache License, Version 2.0 (see [LICENSE](LICENSE)).
+Licensed under the Apache License, Version 2.0 (see [LICENSE](../LICENSE)).
 See [background](http://www.apache.org/licenses/) information.
 
 ## Tests
@@ -214,6 +214,6 @@ nice and run a ```mvn install``` on your own machine before every
 
 ## RAML
 
-We keep the API specs in RAML files under okapi-core/src/main/raml/. Remember to
-update those if you ever change anything in the API. And update the documentation
-too, of course.
+We keep the API specs in RAML files under okapi-core/src/main/raml/.
+Remember to update those if you ever change anything in the API.
+And update the documentation too, of course.

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -1408,7 +1408,7 @@ The `cmdlineStart` is a shell script that spawns and puts a service in the backg
 the corresponding service.
 
 * Docker: The `dockerImage` property specifies an existing image. Okapi manages a container based on this image.
-This option require that the `dockerUrl` points to a Docker Daemon accessible via HTTP.
+This option requires that the `dockerUrl` points to a Docker Daemon accessible via HTTP.
 
 It is also possible to refer to an already-launched process (maybe running in your
 development IDE), by POSTing a DeploymentDescriptor to /_/discovery, with no nodeId


### PR DESCRIPTION
Synchronise copies of doc "CONTRIBUTING.md" and "folio-org.github.io/community/contrib-code.md".
Apply some consistent Markdown style.