### PR TITLE
Added X-Okapi-Tenant header to calls made to TenantAPI

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/web/TenantWebService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/web/TenantWebService.java
@@ -283,6 +283,7 @@ public class TenantWebService {
               }
               headers.put("Accept", "*/*");
               headers.put("Content-Type", "application/json; charset=UTF-8");
+              headers.put("X-Okapi-Tenant", id);
               String body = "{}"; // dummy
               OkapiClient cli = new OkapiClient(baseurl, vertx, headers);
               cli.request(HttpMethod.POST, tenInt, body, cres->{


### PR DESCRIPTION
The Tenant API as it currently exists requires an X-Okapi-Tenant header to inform it which tenant to initialize.