### PR TITLE
Okapi 267 permsets

### DIFF
--- a/doc/guide.md
+++ b/doc/guide.md
@@ -874,6 +874,12 @@ cat > /tmp/okapi-proxy-test-basic.json <<END
         "type" : "request-response"
         } ]
     } ],
+    "permissionSets" : [ {
+      "permissionName" : "test-basic.everything",
+      "displayName" : "every possible permission",
+      "description" : "All permissions combined",
+      "subPermissions" : [ "test-basic.needed", "test-basic.extra" ]
+      } ],
     "launchDescriptor" : {
       "exec" : "java -Dport=%p -jar okapi-test-module/target/okapi-test-module-fat.jar"
     }
@@ -891,6 +897,9 @@ that the module is supposed to provide a full response. The level is used to
 specify the order in which the request will be sent to multiple modules, as
 will be seen later.
 
+We will come back to the permission things later, when we look at the auth
+module.
+
 The second interface this modules provides is called "_tenant". This is a
 "system" interface, as can be seen in the interfaceType, and by convention
 its name starts with an underscore. Okapi will make a request to this interface
@@ -900,8 +909,9 @@ for all kind of initialization, for example creating tables in a database.
 The module could also require some interfaces to be present, but since this is
 the first module we add, we don't require anything else.
 
-We will come back to the permission things later, when we look at the auth
-module.
+The permissionSets declares a shorthand for admins to give permissions to users.
+These will percolate to the permission management in the auth module (not in
+our trivial sample auth, the but the real life version).
 
 The launchDescriptor tells Okapi how this module is to be started and stopped.
 In this version we use a simple `exec` command line, remember the PID, and
@@ -950,6 +960,7 @@ Content-Length: 733
   }
 }
 ```
+<!-- TODO - the response is out of date.  -->
 
 Okapi responds with a "201 Created", and reports back the same JSON. There is
 also a Location header that shows the address of this module, if we want to

--- a/okapi-core/src/main/java/org/folio/okapi/bean/ModuleDescriptor.java
+++ b/okapi-core/src/main/java/org/folio/okapi/bean/ModuleDescriptor.java
@@ -3,7 +3,8 @@ package org.folio.okapi.bean;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import java.util.ArrayList;
@@ -28,11 +29,12 @@ public class ModuleDescriptor {
   private ModuleInterface[] requires;
   private ModuleInterface[] provides;
   private RoutingEntry[] routingEntries;
-  private String[] modulePermissions;
+  private Permission[] permissionSets;
+  private String[] modulePermissions; /* DEPRECATED */
   private UiModuleDescriptor uiDescriptor;
   private LaunchDescriptor launchDescriptor;
 
-  private String tenantInterface;
+  private String tenantInterface; /* DEPRECATED */
 
   public ModuleDescriptor() {
   }
@@ -50,6 +52,7 @@ public class ModuleDescriptor {
     this.routingEntries = other.routingEntries;
     this.requires = other.requires;
     this.provides = other.provides;
+    this.permissionSets = other.permissionSets;
     this.modulePermissions = other.modulePermissions;
     this.uiDescriptor = other.uiDescriptor;
     this.launchDescriptor = other.launchDescriptor;
@@ -238,5 +241,12 @@ public class ModuleDescriptor {
     this.tenantInterface = tenantInterface;
   }
 
+  public Permission[] getPermissionSets() {
+    return permissionSets;
+  }
+
+  public void setPermissionSets(Permission[] permissionSets) {
+    this.permissionSets = permissionSets;
+  }
 
 }

--- a/okapi-core/src/main/java/org/folio/okapi/bean/Permission.java
+++ b/okapi-core/src/main/java/org/folio/okapi/bean/Permission.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2015-2017, Index Data
+ * All rights reserved.
+ * See the file LICENSE for details.
+ */
+package org.folio.okapi.bean;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Permission {
+  private String permissionName;
+  private String displayName;
+  private String description;
+  private String[] subPermissions;
+
+  public Permission() {
+  }
+
+  public Permission(Permission other) {
+    this.permissionName = other.permissionName;
+    this.displayName = other.displayName;
+    this.description = other.description;
+    this.subPermissions = other.subPermissions;
+  }
+
+  public String getPermissionName() {
+    return permissionName;
+  }
+
+  public void setPermissionName(String permissionName) {
+    this.permissionName = permissionName;
+  }
+
+  public String getDisplayName() {
+    return displayName;
+  }
+
+  public void setDisplayName(String displayName) {
+    this.displayName = displayName;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public String[] getSubPermissions() {
+    return subPermissions;
+  }
+
+  public void setSubPermissions(String[] subPermissions) {
+    this.subPermissions = subPermissions;
+  }
+
+}

--- a/okapi-core/src/main/raml/ModuleDescriptor.json
+++ b/okapi-core/src/main/raml/ModuleDescriptor.json
@@ -44,6 +44,12 @@
             "items": {
               "$ref": "RoutingEntry.json"
             }
+          },
+          "permissionSets": {
+            "type": ["array", "null"],
+            "items": {
+              "$ref": "Permission.json"
+            }
           }
         }
       }

--- a/okapi-core/src/main/raml/Permission.json
+++ b/okapi-core/src/main/raml/Permission.json
@@ -1,0 +1,21 @@
+{
+  "title": "Permissions Definition Schema",
+  "type": "object",
+  "properties": {
+    "permissionName": {
+      "type": "string"
+    },
+    "displayName": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "subPermissions": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/okapi-core/src/main/raml/okapi.raml
+++ b/okapi-core/src/main/raml/okapi.raml
@@ -21,7 +21,7 @@ schemas:
   - NodeDescriptorList: !include NodeDescriptorList.json
   - EnvEntry: !include EnvEntry.json
   - EnvEntryList: !include EnvEntryList.json
-
+  - Permission: !include Permission.json
 
 # DEPLOYMENT SERVICE
 /_/deployment/modules:

--- a/okapi-core/src/test/java/okapi/ModuleTest.java
+++ b/okapi-core/src/test/java/okapi/ModuleTest.java
@@ -257,6 +257,12 @@ public class ModuleTest {
       + "      \"type\" : \"system\"" + LS
       + "    } ]" + LS
       + "  } ]," + LS
+      + "  \"permissionSets\" : [ {" + LS
+      + "    \"permissionName\" : \"everything\"," + LS
+      + "    \"displayName\" : \"every possible permission\"," + LS
+      + "    \"description\" : \"All permissions combined\"," + LS
+      + "    \"subPermissions\" : [ \"sample.needed\", \"sample.extra\" ]" + LS
+      + "  } ]," + LS
       + "  \"launchDescriptor\" : {" + LS
       + "    \"exec\" : \"java -Dport=%p -jar " + testModJar + "\"" + LS
       + "  }" + LS


### PR DESCRIPTION
Adds permission sets to the ModuleDescriptor. Those are not yet used for anything. Should be 100% backwards compatible.