### PR TITLE
OKAPI-342: Replace /login with /authn/login

### DIFF
--- a/doc/guide.md
+++ b/doc/guide.md
@@ -485,9 +485,9 @@ Most of this work has been delegated to modules, so Okapi itself will not have
 to do so much work. But it still needs to orchestrate the whole operation.
 
 Ignoring all the messy details, this how it works: The client (often on a web
-browser, but can really be anything) calls the `/login` service to identify
+browser, but can really be anything) calls the `/authn/login` service to identify
 itself. Depending on the tenant, we may have different authorization modules
-serving the `/login` request, and they may take different parameters (username
+serving the `/authn/login` request, and they may take different parameters (username
 and password are the most likely, but we can have anything from simple IP
 authentication to complex interactions with LDAP, OAuth, or other systems).
 
@@ -833,7 +833,7 @@ but we have a dummy module that can be used to demonstrate how it
 works. Also this one is mostly used for testing the auth mechanisms in
 Okapi itself.
 
-The dummy module supports two functions: `/login` is, as its name implies,
+The dummy module supports two functions: `/authn/login` is, as its name implies,
 a login function that takes a username and password, and if acceptable,
 returns a token in a HTTP header. Any other path goes through the check
 function that checks that we have a valid token in the HTTP request
@@ -1172,7 +1172,7 @@ cat > /tmp/okapi-module-auth.json <<END
       "handlers": [
         {
           "methods": [ "POST" ],
-          "pathPattern": "/login"
+          "pathPattern": "/authn/login"
         }
       ]
     }
@@ -1188,7 +1188,7 @@ cat > /tmp/okapi-module-auth.json <<END
 }
 END
 ```
-The module has one handler, for the `/login` path. It also has a filter that
+The module has one handler, for the `/authn/login` path. It also has a filter that
 connects with every incoming request. That is where it decides if the user will
 be allowed to make the request. This one has a type "headers", which means that
 Okapi does not pass the whole request to it, just the headers.
@@ -1228,7 +1228,7 @@ Content-Length: 345
     "version" : "3.4",
     "handlers" : [ {
       "methods" : [ "POST" ],
-      "pathPattern" : "/login"
+      "pathPattern" : "/authn/login"
     } ]
   } ],
   "filters" : [ {
@@ -1337,12 +1337,12 @@ curl -w '\n' -X POST -D - \
   -H "Content-type: application/json" \
   -H "X-Okapi-Tenant: testlib" \
   -d @/tmp/okapi-login.json \
-  http://localhost:9130/login
+  http://localhost:9130/authn/login
 
 HTTP/1.1 200 OK
 Content-Type: application/json
 X-Okapi-Token: dummyJwt.eyJzdWIiOiJwZXRlciIsInRlbmFudCI6InRlc3RsaWIifQ==.sig
-X-Okapi-Trace: POST - Okapi test auth module http://localhost:9132/login : 200 159251us
+X-Okapi-Trace: POST - Okapi test auth module http://localhost:9132/authn/login : 200 159251us
 Transfer-Encoding: chunked
 
 {  "tenant": "testlib",  "username": "peter",  "password": "peter-password"}

--- a/doc/security.md
+++ b/doc/security.md
@@ -64,7 +64,7 @@ even some pseudo-authentication that just says that this is an unidentified
 member of the general public.
 
 There should usually be (at least) one authentication module enabled for each
-tenant. The user's first request should be to /login, which gets routed to the
+tenant. The user's first request should be to /authn/login, which gets routed to the
 right authentication module. It will get some parameters, for example tenant,
 username, and password. It will verify these, talking to
 what ever backend is proper. When it is satisfied, it will get a JWT token
@@ -84,7 +84,7 @@ module will verify it every time.
 ## Authorization
 This is where Okapi gets a bit more involved, and where things get technical.
 
-When a request comes in to Okapi (excluding the /login and other requests that
+When a request comes in to Okapi (excluding the /authn/login and other requests that
 are open for anyone), Okapi looks at the tenant, and figures out the pipeline
 of modules it is going to call. This should include the authorization module at
 (or near) the beginning.
@@ -499,7 +499,7 @@ modules can check against LDAP servers, OAuth, or any other authentication metho
  * Clicks on a submit button.
 
 3.2: The UI sends a request to Okapi:
- * POST `http://folio.org/okapi/login`
+ * POST `http://folio.org/okapi/authn/login`
  * X-Okapi-Tenant: ourlib
  * Of course we do not have any JWT yet.
 
@@ -507,7 +507,7 @@ Note that the URL and the tenantId must be already known to the UI somehow.
 
 3.3: Okapi receives the request:
  * It checks that we know about tenant "ourlib".
- * It builds a list of modules that serve /login, and that are enabled for "ourlib".
+ * It builds a list of modules that serve /authn/login, and that are enabled for "ourlib".
  * This list will typically consist of two modules: first "auth", and then the
 actual "login" module.
  * Okapi notes that the request contains no X-Okapi-Token header.

--- a/okapi-core/src/test/java/okapi/ModuleTest.java
+++ b/okapi-core/src/test/java/okapi/ModuleTest.java
@@ -1,6 +1,23 @@
 package okapi;
 
+import static com.jayway.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
 import org.folio.okapi.MainVerticle;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.jayway.restassured.RestAssured;
+import com.jayway.restassured.response.Response;
+import com.jayway.restassured.response.ValidatableResponse;
+
+import guru.nidi.ramltester.RamlDefinition;
+import guru.nidi.ramltester.RamlLoaders;
+import guru.nidi.ramltester.restassured.RestAssuredClient;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
@@ -10,19 +27,6 @@ import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import com.jayway.restassured.RestAssured;
-import static com.jayway.restassured.RestAssured.*;
-import static org.hamcrest.Matchers.*;
-import com.jayway.restassured.response.Response;
-import com.jayway.restassured.response.ValidatableResponse;
-import guru.nidi.ramltester.RamlDefinition;
-import guru.nidi.ramltester.RamlLoaders;
-import guru.nidi.ramltester.restassured.RestAssuredClient;
 
 @RunWith(VertxUnitRunner.class)
 public class ModuleTest {
@@ -814,7 +818,7 @@ public class ModuleTest {
       + "    \"permissionsDesired\" : [ \"auth.extra\" ]" + LS
       + "  }, {"
       + "    \"methods\" : [ \"POST\" ]," + LS
-      + "    \"path\" : \"/login\"," + LS
+      + "    \"path\" : \"/authn/login\"," + LS
       + "    \"level\" : \"20\"," + LS
       + "    \"type\" : \"request-response\"" + LS
       + "  } ]," + LS
@@ -862,7 +866,7 @@ public class ModuleTest {
       + "    \"permissionsDesired\" : [ \"auth.extra\" ]" + LS
       + "  }, {"
       + "    \"methods\" : [ \"POST\" ]," + LS
-      + "    \"path\" : \"/login\"," + LS
+      + "    \"path\" : \"/authn/login\"," + LS
       + "    \"level\" : \"20\"," + LS
       + "    \"type\" : \"request-response\"" + LS
       + "  } ]," + LS
@@ -1200,7 +1204,7 @@ public class ModuleTest {
       + "  \"password\" : \"peter-wrong-password\"" + LS
       + "}";
     given().header("Content-Type", "application/json").body(docWrongLogin)
-      .header("X-Okapi-Tenant", okapiTenant).post("/login")
+      .header("X-Okapi-Tenant", okapiTenant).post("/authn/login")
       .then().statusCode(401);
 
     // Ok login, get token
@@ -1210,7 +1214,7 @@ public class ModuleTest {
       + "  \"password\" : \"peter-password\"" + LS
       + "}";
     okapiToken = given().header("Content-Type", "application/json").body(docLogin)
-      .header("X-Okapi-Tenant", okapiTenant).post("/login")
+      .header("X-Okapi-Tenant", okapiTenant).post("/authn/login")
       .then().statusCode(200).extract().header("X-Okapi-Token");
 
     // Actual requests to the module

--- a/okapi-test-auth-module/src/main/java/org/folio/okapi/auth/Auth.java
+++ b/okapi-test-auth-module/src/main/java/org/folio/okapi/auth/Auth.java
@@ -1,5 +1,14 @@
 package org.folio.okapi.auth;
 
+import static org.folio.okapi.common.HttpResponse.responseError;
+import static org.folio.okapi.common.HttpResponse.responseJson;
+import static org.folio.okapi.common.HttpResponse.responseText;
+
+import java.util.Base64;
+import java.util.HashMap;
+
+import org.folio.okapi.common.XOkapiHeaders;
+
 import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
@@ -7,10 +16,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.web.RoutingContext;
-import java.util.Base64;
-import static org.folio.okapi.common.HttpResponse.*;
-import java.util.HashMap;
-import org.folio.okapi.common.XOkapiHeaders;
 
 /**
  * A dummy auth module. Provides a minimal authentication mechanism.
@@ -62,7 +67,7 @@ public class Auth {
     final String json = ctx.getBodyAsString();
     if (json.length() == 0) {
       logger.debug("test-auth: accept OK in login");
-      responseText(ctx, 202).end("Auth accept in /login");
+      responseText(ctx, 202).end("Auth accept in /authn/login");
       return;
     }
     LoginParameters p;
@@ -184,7 +189,7 @@ public class Auth {
   }
 
   /**
-   * Accept a request. Gets called with anything else than a POST to "/login".
+   * Accept a request. Gets called with anything else than a POST to "/authn/login".
    * These need to be accepted, so we can do a pre-check before the proper POST.
    *
    * @param ctx

--- a/okapi-test-auth-module/src/main/java/org/folio/okapi/auth/MainVerticle.java
+++ b/okapi-test-auth-module/src/main/java/org/folio/okapi/auth/MainVerticle.java
@@ -1,16 +1,17 @@
 package org.folio.okapi.auth;
 
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Future;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.BodyHandler;
-import java.io.IOException;
-import java.lang.management.ManagementFactory;
 
 /**
- * The auth module provides two services: login and check. URI "/login" takes
+ * The auth module provides two services: login and check. URI "/authn/login" takes
  * username, password, and other parameters, and returns a token. URI "/check"
  * takes the token, and verifies that everything is all right. This is a very
  * trivial dummy module, that provides simple hard-coded authentication for any
@@ -33,9 +34,9 @@ public class MainVerticle extends AbstractVerticle {
 
     logger.info("Starting auth " + ManagementFactory.getRuntimeMXBean().getName() + " on port " + port);
 
-    router.post("/login").handler(BodyHandler.create());
-    router.post("/login").handler(auth::login);
-    router.route("/login").handler(auth::accept);
+    router.post("/authn/login").handler(BodyHandler.create());
+    router.post("/authn/login").handler(auth::login);
+    router.route("/authn/login").handler(auth::accept);
     router.route("/*").handler(auth::check);
 
     vertx.createHttpServer()

--- a/okapi-test-auth-module/testdata/login.sh
+++ b/okapi-test-auth-module/testdata/login.sh
@@ -1,7 +1,7 @@
 echo The following login should fail
-curl -D -  -H X-Okapi-Token:t1:peter:10058b75cb0b719d5a9efb39e97416bc -w'\n'  -X POST  -d @login-bad.json http://localhost:9020/login
+curl -D -  -H X-Okapi-Token:t1:peter:10058b75cb0b719d5a9efb39e97416bc -w'\n'  -X POST  -d @login-bad.json http://localhost:9020/authn/login
 echo
 
 echo The following login should succeed
-curl -D -  -H X-Okapi-Token:t1:peter:10058b75cb0b719d5a9efb39e97416bc -w'\n'  -X POST  -d @login1.json http://localhost:9020/login
+curl -D -  -H X-Okapi-Token:t1:peter:10058b75cb0b719d5a9efb39e97416bc -w'\n'  -X POST  -d @login1.json http://localhost:9020/authn/login
 echo


### PR DESCRIPTION
Stripes expects logins to happen on the `/authn/login` interface, but the test/demo module in Okapi uses `/login`.  With this change, it is possible to use _Okapi-test-auth-module_ as an *authentication* source (but not an *authorization* source) for Stripes.  (Note that authorization can be bypassed in Stripes by using the `hasAllPerms: true` in the `config` dictionary of _stripes.config.js_.