### PR TITLE
Pass X-Okapi-User-Id around

### DIFF
--- a/okapi-common/src/main/java/org/folio/okapi/common/XOkapiHeaders.java
+++ b/okapi-common/src/main/java/org/folio/okapi/common/XOkapiHeaders.java
@@ -49,6 +49,14 @@ public class XOkapiHeaders {
    */
   public static final String TENANT = "X-Okapi-Tenant";
 
+  /**
+   * X-Okapi-User-Id. Tells the user id of the logged-in user. Modules can pass
+   * this around, but that is not necessary if we have a good token,
+   * mod-authtoken extracts the userId from the token and returns it to Okapi,
+   * and Okapi passes it to all modules it invokes.
+   */
+  public static final String USER_ID = "X-Okapi-User-Id";
+
   /** X-Okapi-Trace. Will be added to the responses from Okapi, to help
    * debugging where the request actually went, and how long did it take.
    */

--- a/okapi-core/src/test/java/okapi/ModuleTest.java
+++ b/okapi-core/src/test/java/okapi/ModuleTest.java
@@ -1299,6 +1299,7 @@ public class ModuleTest {
       .header("X-Okapi-Permissions-Required", "sample.needed")
       .header("X-Okapi-Module-Permissions", "{\"sample-module\":[\"sample.modperm\"]}")
       .header("X-Okapi-Url", "http://localhost:9130") // no trailing slash!
+      .header("X-Okapi-User-Id", "peter")
       .header("X-Url-Params", "query=foo&limit=10")
       .body(containsString("It works"));
     // Check only the required permission bit, since there is only one.

--- a/okapi-test-auth-module/src/main/java/org/folio/okapi/auth/Auth.java
+++ b/okapi-test-auth-module/src/main/java/org/folio/okapi/auth/Auth.java
@@ -161,6 +161,8 @@ public class Auth {
 
     String decodedJson = new String(Base64.getDecoder().decode(payload));
     logger.debug("test-auth: check payload: " + decodedJson);
+    JsonObject jtok = new JsonObject(decodedJson);
+    String userId = jtok.getString("sub", "");
 
     // Fake some desired permissions
     String des = ctx.request().getHeader(XOkapiHeaders.PERMISSIONS_DESIRED);
@@ -172,7 +174,8 @@ public class Auth {
     String modTok = moduleTokens(ctx);
     ctx.response().headers()
       .add(XOkapiHeaders.TOKEN, tok)
-      .add(XOkapiHeaders.MODULE_TOKENS, modTok);
+      .add(XOkapiHeaders.MODULE_TOKENS, modTok)
+      .add(XOkapiHeaders.USER_ID, userId);
     responseText(ctx, 202); // Abusing 202 to say check OK
     echo(ctx);
   }


### PR DESCRIPTION
No changes needed in Okapi itself, only in test auth module, ModuleTest, and XOkapiHeaders.