### PR TITLE
Allow sorting and filter for module listing

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/service/TenantManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/service/TenantManager.java
@@ -820,7 +820,7 @@ public class TenantManager {
         return;
       }
       Tenant t = gres.result();
-      moduleManager.getAllModules(mres -> {
+      moduleManager.getModulesWithFilter(null, mres -> {
         if (mres.failed()) {
           fut.handle(new Failure<>(mres.getType(), mres.cause()));
           return;

--- a/okapi-core/src/main/java/org/folio/okapi/util/ModuleId.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/ModuleId.java
@@ -13,27 +13,54 @@ public class ModuleId implements Comparable<ModuleId> {
         return;
       }
     }
-    throw new IllegalArgumentException("missing semantic version: " + s);
+    product = s;
+    semVer = null;
   }
 
   public int compareTo(ModuleId other) {
     int cmp = product.compareTo(other.product);
-    if (cmp == 0) {
-      return semVer.compareTo(other.semVer);
+    if (cmp > 0) {
+      return 5; // 4, 3, 2, 1 for major, minor, patch, rest
     } else if (cmp < 0) {
+      return -5; // 4, 3, 2, 1 for major, minor, patch, rest
+    } else if (semVer != null && other.semVer != null) {
+      return semVer.compareTo(other.semVer);
+    } else if (semVer != null && other.semVer == null) {
+      return 4;
+    } else if (semVer == null && other.semVer != null) {
       return -4;
     } else {
-      return 4;
+      return 0;
     }
   }
 
+  @Override
   public String toString() {
-    return "module: " + product + " " + semVer.toString();
+    StringBuilder b = new StringBuilder();
+    b.append("module: ");
+    b.append(product);
+    if (semVer != null) {
+      b.append(" ");
+      b.append(semVer.toString());
+    }
+    return b.toString();
   }
 
   public static int compare(String i1, String i2) {
     ModuleId m1 = new ModuleId(i1);
     ModuleId m2 = new ModuleId(i2);
     return m1.compareTo(m2);
+  }
+
+  public boolean hasPrefix(ModuleId other) {
+    if (!this.product.equals(other.product)) {
+      return false;
+    } else if (this.semVer != null && other.semVer != null) {
+      return semVer.hasPrefix(other.semVer);
+    } else if (this.semVer == null && other.semVer != null) {
+      return false;
+    } else {
+      return true;
+    }
   }
 }

--- a/okapi-core/src/main/java/org/folio/okapi/util/SemVer.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/SemVer.java
@@ -77,10 +77,51 @@ public class SemVer implements Comparable<SemVer> {
     return i;
   }
 
+  public boolean hasPrefix(SemVer other) {
+    Iterator<String> i1 = this.versions.iterator();
+    Iterator<String> i2 = other.versions.iterator();
+    int level = 4; // major returns +-4, minor +-3, patch +- 2, rest +-1.
+    while (i1.hasNext() && i2.hasNext()) {
+      int v = compareComp(i1.next(), i2.next());
+      if (v != 0) {
+        return false;
+      }
+    }
+    if (!i1.hasNext() && i2.hasNext()) {
+      return false;
+    }
+    else if (i1.hasNext() && !i2.hasNext()) {
+      return true;
+    }
+    i1 = this.preRelease.iterator();
+    i2 = other.preRelease.iterator();
+    while (i1.hasNext() && i2.hasNext()) {
+      int v = compareComp(i1.next(), i2.next());
+      if (v != 0) {
+        return false;
+      }
+    }
+    if (!i1.hasNext() && i2.hasNext()) {
+      return false;
+    }
+    else if (i1.hasNext() && !i2.hasNext()) {
+      return true;
+    }
+    if (this.metadata != null && other.metadata != null) {
+      int v = this.metadata.compareTo(other.metadata);
+      if (v != 0) {
+        return false;
+      }
+    } else if (this.metadata == null && other.metadata != null) {
+      return false;
+    }
+    return true;
+  }
+
   public int compareTo(SemVer other) {
     Iterator<String> i1 = this.versions.iterator();
     Iterator<String> i2 = other.versions.iterator();
-    int level = 3; // major returns +-3, minor +-2, rest +-1.
+    int level = 4; // major returns +-4, minor +-3, patch +- 2, rest +-1.
     while (i1.hasNext() && i2.hasNext()) {
       int v = compareComp(i1.next(), i2.next());
       if (v > 0) {
@@ -88,7 +129,7 @@ public class SemVer implements Comparable<SemVer> {
       } else if (v < 0) {
         return -level;
       }
-      if (level > 1) {
+      if (level > 2) {
         level--;
       }
     }
@@ -134,6 +175,7 @@ public class SemVer implements Comparable<SemVer> {
     return 0;
   }
 
+  @Override
   public String toString() {
     StringBuilder b = new StringBuilder();
     Iterator<String> it = this.versions.iterator();

--- a/okapi-core/src/main/raml/okapi.raml
+++ b/okapi-core/src/main/raml/okapi.raml
@@ -293,6 +293,19 @@ schemas:
           text/plain:
   get:
     description: list all available modules
+    queryParameters:
+      filter:
+        description: filter by module ID
+        type: string
+        required: false
+      orderBy:
+        description: order by field
+        type: string
+        required: false
+      order:
+        description: Order
+        enum: [desc, asc]
+        required: false
     responses:
       200:
         headers:
@@ -301,7 +314,14 @@ schemas:
         body:
           application/json:
             schema: ModuleList
-
+      400:
+        description: Bad Request
+        body:
+          text/plain:
+      500:
+        description: Server Error
+        body:
+          text/plain:
   /{module_id}:
     get:
       description: retrieve descriptor for a particular module

--- a/okapi-core/src/test/java/okapi/PullTest.java
+++ b/okapi-core/src/test/java/okapi/PullTest.java
@@ -227,11 +227,111 @@ public class PullTest {
       "raml: " + c.getLastReport().toString(),
       c.getLastReport().isEmpty());
 
-    //
     c = api.createRestAssured();
     c.given().port(port2)
       .header("Content-Type", "application/json")
       .body(pullDoc).post("/_/proxy/pull/modules").then().statusCode(200)
+      .body(equalTo("[ ]"));
+    Assert.assertTrue(
+      "raml: " + c.getLastReport().toString(),
+      c.getLastReport().isEmpty());
+
+    c = api.createRestAssured();
+    c.given().port(port2)
+      .header("Content-Type", "application/json")
+      .get("/_/proxy/modules?orderBy=id&order=desc").then().statusCode(200)
+      .body(equalTo("[ {" + LS
+        + "  \"id\" : \"okapi-0.0.0\"," + LS
+        + "  \"name\" : \"okapi-0.0.0\"" + LS
+        + "}, {" + LS
+        + "  \"id\" : \"module-c-1.0.0\"," + LS
+        + "  \"name\" : \"C\"" + LS
+        + "}, {" + LS
+        + "  \"id\" : \"module-b-1.0.0\"," + LS
+        + "  \"name\" : \"B\"" + LS
+        + "}, {" + LS
+        + "  \"id\" : \"module-a-1.0.0\"," + LS
+        + "  \"name\" : \"A\"" + LS
+        + "} ]"));
+    Assert.assertTrue(
+      "raml: " + c.getLastReport().toString(),
+      c.getLastReport().isEmpty());
+
+    c = api.createRestAssured();
+    c.given().port(port2)
+      .header("Content-Type", "application/json")
+      .get("/_/proxy/modules?orderBy=id&order=asc").then().statusCode(200)
+      .body(equalTo("[ {" + LS
+        + "  \"id\" : \"module-a-1.0.0\"," + LS
+        + "  \"name\" : \"A\"" + LS
+        + "}, {" + LS
+        + "  \"id\" : \"module-b-1.0.0\"," + LS
+        + "  \"name\" : \"B\"" + LS
+        + "}, {" + LS
+        + "  \"id\" : \"module-c-1.0.0\"," + LS
+        + "  \"name\" : \"C\"" + LS
+        + "}, {" + LS
+        + "  \"id\" : \"okapi-0.0.0\"," + LS
+        + "  \"name\" : \"okapi-0.0.0\"" + LS
+        + "} ]"));
+    Assert.assertTrue(
+      "raml: " + c.getLastReport().toString(),
+      c.getLastReport().isEmpty());
+
+    c = api.createRestAssured();
+    c.given().port(port2)
+      .header("Content-Type", "application/json")
+      .get("/_/proxy/modules?orderBy=bogus").then().statusCode(400);
+    Assert.assertTrue(
+      "raml: " + c.getLastReport().toString(),
+      c.getLastReport().isEmpty());
+
+    c = api.createRestAssured();
+    c.given().port(port2)
+      .header("Content-Type", "application/json")
+      .get("/_/proxy/modules?filter=module-c&orderBy=id").then().statusCode(200)
+      .body(equalTo("[ {" + LS
+        + "  \"id\" : \"module-c-1.0.0\"," + LS
+        + "  \"name\" : \"C\"" + LS
+        + "} ]"));
+    Assert.assertTrue(
+      "raml: " + c.getLastReport().toString(),
+      c.getLastReport().isEmpty());
+
+    c = api.createRestAssured();
+    c.given().port(port2)
+      .header("Content-Type", "application/json")
+      .get("/_/proxy/modules?filter=module-c-1").then().statusCode(200)
+      .body(equalTo("[ {" + LS
+        + "  \"id\" : \"module-c-1.0.0\"," + LS
+        + "  \"name\" : \"C\"" + LS
+        + "} ]"));
+    Assert.assertTrue(
+      "raml: " + c.getLastReport().toString(),
+      c.getLastReport().isEmpty());
+
+    c = api.createRestAssured();
+    c.given().port(port2)
+      .header("Content-Type", "application/json")
+      .get("/_/proxy/modules?filter=module-2").then().statusCode(200)
+      .body(equalTo("[ ]"));
+    Assert.assertTrue(
+      "raml: " + c.getLastReport().toString(),
+      c.getLastReport().isEmpty());
+
+    c = api.createRestAssured();
+    c.given().port(port2)
+      .header("Content-Type", "application/json")
+      .get("/_/proxy/modules?filter=module").then().statusCode(200)
+      .body(equalTo("[ ]"));
+    Assert.assertTrue(
+      "raml: " + c.getLastReport().toString(),
+      c.getLastReport().isEmpty());
+
+    c = api.createRestAssured();
+    c.given().port(port2)
+      .header("Content-Type", "application/json")
+      .get("/_/proxy/modules?filter=foo").then().statusCode(200)
       .body(equalTo("[ ]"));
     Assert.assertTrue(
       "raml: " + c.getLastReport().toString(),

--- a/okapi-core/src/test/java/okapi/util/ModuleIdTest.java
+++ b/okapi-core/src/test/java/okapi/util/ModuleIdTest.java
@@ -11,25 +11,39 @@ public class ModuleIdTest {
 
   @Test
   public void test() {
-    ModuleId m1 = new ModuleId("module-1");
-    assertEquals("module: module version: 1", m1.toString());
+    ModuleId module_1 = new ModuleId("module-1");
+    assertEquals("module: module version: 1", module_1.toString());
 
-    ModuleId m2 = new ModuleId("foo-bar1-1.2");
-    assertEquals("module: foo-bar1 version: 1 2", m2.toString());
+    ModuleId foobar_1_2 = new ModuleId("foo-bar1-1.2");
+    assertEquals("module: foo-bar1 version: 1 2", foobar_1_2.toString());
 
-    ModuleId m3 = new ModuleId("module-1.9");
-    assertEquals("module: module version: 1 9", m3.toString());
+    ModuleId module_1_9 = new ModuleId("module-1.9");
+    assertEquals("module: module version: 1 9", module_1_9.toString());
 
-    assertEquals(m1.compareTo(m2), 4);
-    assertEquals(m2.compareTo(m1), -4);
+    ModuleId module = new ModuleId("module");
+    assertEquals("module: module", module.toString());
 
-    assertEquals(m1.compareTo(m3), -2);
-    assertEquals(m3.compareTo(m1), 2);
+    assertTrue(module_1.hasPrefix(module));
+    assertFalse(module.hasPrefix(module_1));
+    assertTrue(module_1_9.hasPrefix(module));
+    assertTrue(module_1_9.hasPrefix(module_1));
+    assertFalse(module_1.hasPrefix(module_1_9));
+    assertFalse(foobar_1_2.hasPrefix(module));
 
-    assertEquals(m2.compareTo(m3), -4);
-    assertEquals(m3.compareTo(m2), 4);
+    assertEquals(5, module_1.compareTo(foobar_1_2));
+    assertEquals(-5, foobar_1_2.compareTo(module_1));
 
-    assertEquals(ModuleId.compare("abc-2.9", "abc-3.5"), -3);
-    assertEquals(ModuleId.compare("abc-2", "abcd-3"), -4);
+    assertEquals(-3, module_1.compareTo(module_1_9));
+    assertEquals(3, module_1_9.compareTo(module_1));
+
+    assertEquals(-5, foobar_1_2.compareTo(module_1_9));
+    assertEquals(5, module_1_9.compareTo(foobar_1_2));
+
+    assertEquals(-4, module.compareTo(module_1));
+    assertEquals(4, module_1.compareTo(module));
+    assertEquals(0, module.compareTo(module));
+
+    assertEquals(-4, ModuleId.compare("abc-2.9", "abc-3.5"));
+    assertEquals(-5, ModuleId.compare("abc-2", "abcd-3"));
   }
 }

--- a/okapi-core/src/test/java/okapi/util/SemVerTest.java
+++ b/okapi-core/src/test/java/okapi/util/SemVerTest.java
@@ -19,24 +19,34 @@ public class SemVerTest {
     SemVer v2 = new SemVer("2");
     assertEquals("version: 2", v2.toString());
 
-    assertEquals(v1.compareTo(v2), -3);
-    assertEquals(v2.compareTo(v1), 3);
-    assertEquals(v1.compareTo(v1), 0);
-    assertEquals(v2.compareTo(v2), 0);
+    assertEquals(-4, v1.compareTo(v2));
+    assertEquals(4, v2.compareTo(v1));
+    assertEquals(0, v1.compareTo(v1));
+    assertEquals(0, v2.compareTo(v2));
+
+    assertFalse(v1.hasPrefix(v2));
+    assertFalse(v2.hasPrefix(v1));
+
+    SemVer v1_0 = new SemVer("1.0");
+    assertEquals("version: 1 0", v1_0.toString());
 
     SemVer v1_2 = new SemVer("1.2");
     assertEquals("version: 1 2", v1_2.toString());
+    assertTrue(v1_2.hasPrefix(v1));
+    assertFalse(v1_2.hasPrefix(v2));
 
-    assertEquals(v1_2.compareTo(v1), 2);
-    assertEquals(v1.compareTo(v1_2), -2);
-    assertEquals(v2.compareTo(v1_2), 3);
+    assertEquals(3, v1_2.compareTo(v1));
+    assertEquals(-3, v1.compareTo(v1_2));
+    assertEquals(4, v2.compareTo(v1_2));
 
     SemVer v1_5 = new SemVer("1.5.0");
     assertEquals("version: 1 5 0", v1_5.toString());
     SemVer v1_10 = new SemVer("1.10.0");
     assertEquals("version: 1 10 0", v1_10.toString());
-    assertEquals(v1_10.compareTo(v1_5), 2);
-    assertEquals(v1_5.compareTo(v1_10), -2);
+    assertEquals(3, v1_10.compareTo(v1_5));
+    assertEquals(-3, v1_5.compareTo(v1_10));
+    assertFalse(v1_5.hasPrefix(v1_10));
+    assertFalse(v1_10.hasPrefix(v1_5));
 
     SemVer p1 = new SemVer("1.0.0-alpha");
     assertEquals("version: 1 0 0 pre: alpha", p1.toString());
@@ -55,21 +65,34 @@ public class SemVerTest {
     SemVer p8 = new SemVer("1.0.0");
     assertEquals("version: 1 0 0", p8.toString());
 
-    assertEquals(p1.compareTo(p2), -1);
-    assertEquals(p2.compareTo(p3), -1);
-    assertEquals(p3.compareTo(p4), -1);
-    assertEquals(p4.compareTo(p5), -1);
-    assertEquals(p5.compareTo(p6), -1);
-    assertEquals(p6.compareTo(p7), -1);
-    assertEquals(p7.compareTo(p8), -1);
+    assertTrue(p1.hasPrefix(v1));
+    assertTrue(p7.hasPrefix(v1));
+    assertTrue(p8.hasPrefix(v1));
+    assertTrue(p1.hasPrefix(v1_0));
+    assertTrue(p7.hasPrefix(v1_0));
+    assertTrue(p8.hasPrefix(v1_0));
+    assertFalse(v1.hasPrefix(p8));
+    assertTrue(p1.hasPrefix(p8));
+    assertFalse(p4.hasPrefix(p5));
+    assertTrue(p5.hasPrefix(p4));
+    assertTrue(p6.hasPrefix(p4));
+    assertFalse(p6.hasPrefix(p5));
 
-    assertEquals(p2.compareTo(p1), 1);
-    assertEquals(p3.compareTo(p2), 1);
-    assertEquals(p4.compareTo(p3), 1);
-    assertEquals(p5.compareTo(p4), 1);
-    assertEquals(p6.compareTo(p5), 1);
-    assertEquals(p7.compareTo(p6), 1);
-    assertEquals(p8.compareTo(p7), 1);
+    assertEquals(-1, p1.compareTo(p2));
+    assertEquals(-1, p2.compareTo(p3));
+    assertEquals(-1, p3.compareTo(p4));
+    assertEquals(-1, p4.compareTo(p5));
+    assertEquals(-1, p5.compareTo(p6));
+    assertEquals(-1, p6.compareTo(p7));
+    assertEquals(-1, p7.compareTo(p8));
+
+    assertEquals(1, p2.compareTo(p1));
+    assertEquals(1, p3.compareTo(p2));
+    assertEquals(1, p4.compareTo(p3));
+    assertEquals(1, p5.compareTo(p4));
+    assertEquals(1, p6.compareTo(p5));
+    assertEquals(1, p7.compareTo(p6));
+    assertEquals(1, p8.compareTo(p7));
 
     SemVer snap1 = new SemVer("1.0.0-rc.1+snapshot-2017.1");
     assertEquals("version: 1 0 0 pre: rc 1 metadata: snapshot-2017.1", snap1.toString());
@@ -80,9 +103,9 @@ public class SemVerTest {
     SemVer snap3 = new SemVer("1.0.0+snapshot-2017.2");
     assertEquals("version: 1 0 0 metadata: snapshot-2017.2", snap3.toString());
 
-    assertEquals(snap1.compareTo(snap2), -1);
-    assertEquals(snap2.compareTo(snap1), 1);
-    assertEquals(snap3.compareTo(snap1), 1);
-    assertEquals(snap1.compareTo(snap3), -1);
+    assertEquals(-1, snap1.compareTo(snap2));
+    assertEquals(1, snap2.compareTo(snap1));
+    assertEquals(1, snap3.compareTo(snap1));
+    assertEquals(-1, snap1.compareTo(snap3));
   }
 }


### PR DESCRIPTION
There are three new parameters for /_/proxy/modules: filter, orderBy
and order. Filter is module ID prefix - possibly only with leading
module name with none or partial version. The orderBy can only have
single value "id" at this point (module ID). Parameter order is
"asc" or "desc". If parameter orderBy is omitted no particular
sorting takes place.