### PR TITLE
Make one log message debug rather than info

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/service/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/service/ProxyService.java
@@ -257,7 +257,7 @@ public class ProxyService {
     }
 
     if (tenantId == null) {
-      logger.info("No tenantId, defaulting to " + XOkapiHeaders.SUPERTENANT_ID);
+      logger.debug("No tenantId, defaulting to " + XOkapiHeaders.SUPERTENANT_ID);
       return XOkapiHeaders.SUPERTENANT_ID; // without setting it in pc
     }
     pc.setTenant(tenantId);


### PR DESCRIPTION
The message "No tenantId, defaulting to okapi.supertenant" occurs a lot
in normal operation so it is hereby changed to debug level.