### PR TITLE
Update tests to not use routingEntries in provides

### DIFF
--- a/okapi-core/src/test/java/okapi/ModuleTest.java
+++ b/okapi-core/src/test/java/okapi/ModuleTest.java
@@ -329,7 +329,7 @@ public class ModuleTest {
       + "    \"id\" : \"_tenant\"," + LS
       + "    \"version\" : \"1.0\"," + LS
       + "    \"interfaceType\" : \"system\"," + LS
-      + "    \"routingEntries\" : [ {" + LS
+      + "    \"handlers\" : [ {" + LS
       + "      \"methods\" : [ \"POST\", \"DELETE\" ]," + LS
       + "      \"path\" : \"/_/tenant\"," + LS
       + "      \"level\" : \"10\"," + LS
@@ -1548,7 +1548,8 @@ public class ModuleTest {
       + "    \"path\" : \"/testb\"," + LS
       + "    \"level\" : \"31\"," + LS
       + "    \"type\" : \"request-response\"" + LS
-      + "  } ]" + LS
+      + "  } ]," + LS
+      + "  \"tenantInterface\" : \"/tenant\"" + LS
       + "}";
     c = api.createRestAssured();
     r = c.given()

--- a/okapi-core/src/test/java/okapi/bean/BeanTest.java
+++ b/okapi-core/src/test/java/okapi/bean/BeanTest.java
@@ -128,7 +128,7 @@ public class BeanTest {
       + "  \"provides\" : [ {" + LS
       + "    \"id\" : \"sample\"," + LS
       + "    \"version\" : \"1.0.0\"," + LS
-      + "    \"routingEntries\" : [ {" + LS
+      + "    \"handlers\" : [ {" + LS
       + "      \"methods\" : [ \"GET\", \"POST\" ]," + LS
       + "      \"pathPattern\" : \"/users/{id}\"," + LS
       + "      \"level\" : \"30\"," + LS
@@ -141,7 +141,7 @@ public class BeanTest {
       + "    \"id\" : \"_tenant\"," + LS
       + "    \"version\" : \"1.0.0\"," + LS
       + "    \"interfaceType\" : \"system\"," + LS
-      + "    \"routingEntries\" : [ {" + LS
+      + "    \"handlers\" : [ {" + LS
       + "      \"methods\" : [ \"POST\", \"DELETE\" ]," + LS
       + "      \"path\" : \"/_/tenant\"," + LS
       + "      \"level\" : \"10\"," + LS


### PR DESCRIPTION
Property handlers should be used instead. Part of OKAPI-289 work