### PR TITLE
Fix strange logformat OKAPI-453

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/MainCluster.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainCluster.java
@@ -10,11 +10,11 @@ public class MainCluster {
   }
 
   public static void main(String[] args) {
-    final Logger logger = LoggerFactory.getLogger("okapi");
     MainDeploy d = new MainDeploy();
-
     d.init(args, res -> {
       if (res.failed()) {
+        // use logger after vert.x logger is configured in d.init
+        Logger logger = LoggerFactory.getLogger("okapi");
         logger.error(res.cause());
         exit(1);
       }


### PR DESCRIPTION
Ensure that property vertx.logger-delegate-factory-class-name is
set before we get a logger from LoggerFactory first time.