### PR TITLE
Fix install module results in huge number of headers OKAPI-466

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/service/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/service/ProxyService.java
@@ -217,7 +217,7 @@ public class ProxyService {
    * tenant against what it has in the token, so even if a client puts up a bad
    * tenant, we should be safe.
    *
-   * @param ctx
+   * @param pc
    * @return null in case of errors, with the response already set in ctx. If
    * all went well, returns the tenantId for further processing.
    */
@@ -846,7 +846,7 @@ public class ProxyService {
         }
         // Pass response headers - needed for unit test, if nothing else
         pc.debug("Request for " + module + " " + path + " ok");
-        pc.passOkapiClientRespHeaders(cli);
+        pc.passOkapiTraceHeaders(cli);
         fut.handle(new Success<>(cli.getResponsebody()));
       });
     });

--- a/okapi-core/src/main/java/org/folio/okapi/util/ProxyContext.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/ProxyContext.java
@@ -74,10 +74,11 @@ public class ProxyContext {
    *
    * @param ok OkapiClient to take resp headers from
    */
-  public void passOkapiClientRespHeaders(OkapiClient ok) {
+  public void passOkapiTraceHeaders(OkapiClient ok) {
     MultiMap respH = ok.getRespHeaders();
     for (Map.Entry<String, String> e : respH.entries()) {
-      if (e.getKey().startsWith("X-") || e.getKey().startsWith("x-")) {
+      if (XOkapiHeaders.TRACE.equals(e.getKey())
+        || "X-Tenant-Perms-Result".equals(e.getKey())) {
         ctx.response().headers().add(e.getKey(), e.getValue());
       }
     }

--- a/okapi-core/src/test/java/okapi/ModuleTest.java
+++ b/okapi-core/src/test/java/okapi/ModuleTest.java
@@ -3200,7 +3200,7 @@ public class ModuleTest {
     Response r;
 
     int i;
-    for (i = 0; i < 1000; i++) {
+    for (i = 0; i < 10; i++) {
       String docSampleModule = "{" + LS
         + "  \"id\" : \"sample-1.2." + Integer.toString(i) + "\"," + LS
         + "  \"name\" : \"sample module " + Integer.toString(i) + "\"," + LS


### PR DESCRIPTION
Only X-Okapi-Trace and -Tenant-Perms-Result saved when enabling
module for tenant (including install).