### PR TITLE
Allow content-length header

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
@@ -432,6 +432,7 @@ public class MainVerticle extends AbstractVerticle {
             .allowedMethod(HttpMethod.POST)
             //allow request headers
             .allowedHeader(HttpHeaders.CONTENT_TYPE.toString())
+            .allowedHeader(HttpHeaders.CONTENT_LENGTH.toString())
             .allowedHeader(XOkapiHeaders.TENANT)
             .allowedHeader(XOkapiHeaders.TOKEN)
             .allowedHeader(XOkapiHeaders.AUTHORIZATION)


### PR DESCRIPTION
We were having trouble receiving params in [`mod-kb-ebsco`](https://github.com/thefrontside/mod-kb-ebsco) when it's installed as part of an Okapi cluster.

@sadatay diagnosed the problem in `mod-kb-ebsco`'s Ruby stack: Rack uses `Content-Length` to determine whether or not it should attempt to parse the request body into params. Since `Content-Length` never makes it past Okapi, Rack and ActionDispatch behave as if they've seen a zero-length request body.

Passing through the `Content-Length` header to modules should fix the issue.