### PR TITLE
Fix X-Okapi-Module-ID is passed to callee OKAPI-474

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/service/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/service/ProxyService.java
@@ -461,6 +461,7 @@ public class ProxyService {
         pc.logRequest(ctx, tenantId);
 
         ctx.request().headers().add(XOkapiHeaders.URL, okapiUrl);
+        ctx.request().headers().remove(XOkapiHeaders.MODULE_ID);
         authHeaders(l, ctx.request().headers(), authToken, pc);
 
         resolveUrls(l.iterator(), res -> {

--- a/okapi-core/src/test/java/okapi/ModuleTest.java
+++ b/okapi-core/src/test/java/okapi/ModuleTest.java
@@ -3089,11 +3089,14 @@ public class ModuleTest {
       .get("/testb")
       .then().statusCode(404);
 
-    given()
+    r = given()
       .header("X-Okapi-Module-Id", "sample-module-3")
+      .header("X-all-headers", "H") // makes module echo headers
       .header("X-Okapi-Tenant", okapiTenant)
       .get("/testb")
-      .then().statusCode(200);
+      .then().statusCode(200).extract().response();
+    // check that X-Okapi-Module-Id was not passed to it
+    Assert.assertNull(r.headers().get("X-Okapi-Module-Id"));
 
     given()
       .header("X-Okapi-Module-Id", "sample-module-4")


### PR DESCRIPTION
Just clear it after routing entries are resolved.