### PR TITLE
Stop timer for two cases OKAPI-508

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/service/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/service/ProxyService.java
@@ -661,6 +661,7 @@ public class ProxyService {
               + data.toString() + "'");
           });
           res.endHandler(v -> {
+            pc.closeTimer();
             ctx.response().end();
             pc.trace("ProxyHeaders response end");
           });
@@ -749,6 +750,7 @@ public class ProxyService {
     internalModule.internalService(req, pc, res -> {
       if (res.failed()) {
         pc.responseError(res.getType(), res.cause());
+        pc.closeTimer();
         return;
       }
       String resp = res.result();


### PR DESCRIPTION
Case 1: Internal requests that fails. Case 2: type headers that
returns failure (<200 or >=300).