### PR TITLE
Fix unit test ProcessModuleHandleTest fails on Java9 OKAPI-539

### DIFF
--- a/okapi-core/src/test/java/okapi/ProcessModuleHandleTest.java
+++ b/okapi-core/src/test/java/okapi/ProcessModuleHandleTest.java
@@ -37,7 +37,7 @@ public class ProcessModuleHandleTest {
 
   private ModuleHandle createModuleHandle(LaunchDescriptor desc, int port) {
     ProcessModuleHandle pmh = new ProcessModuleHandle(vertx, desc, ports, port);
-    pmh.setConnectIterMax(5);
+    pmh.setConnectIterMax(10);
     return pmh;
   }
 


### PR DESCRIPTION
Just wait longer time for the spawned process to start listening
on the port.