### PR TITLE
OKAPI-568 md2toc allow underscore

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## 2.12.0 (IN PROGRESS)
 
  * OKAPI-565 Review and catalog Okapi docs
+ * OKAPI-568 Allow underscore in md2toc generated ToC links
 
 ## 2.11.0 2018-03-23
 

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -24,7 +24,7 @@ managing and running microservices.
     * [Running Okapi itself](#running-okapi-itself)
     * [Example 1: Deploying and using a simple module](#example-1-deploying-and-using-a-simple-module)
     * [Example 2: Adding the Auth module](#example-2-adding-the-auth-module)
-    * [Example 3: Upgrading, versions, environment, and the `_tenant` interface](#example-3-upgrading-versions-environment-and-the-tenant-interface)
+    * [Example 3: Upgrading, versions, environment, and the `_tenant` interface](#example-3-upgrading-versions-environment-and-the-_tenant-interface)
     * [Example 4: Complete ModuleDescriptor](#example-4-complete-moduledescriptor)
     * [Multiple interfaces](#multiple-interfaces)
     * [Cleaning up](#cleaning-up)

--- a/doc/md2toc
+++ b/doc/md2toc
@@ -52,7 +52,7 @@ while (my $line = <>) {
         next if $level < $lowest || $level > $highest;
         my $link = lc($line);
         $link =~ s/ /-/g;
-        $link =~ s/[^a-z0-9-]//g;
+        $link =~ s/[^a-z0-9-_]//g;
         if ($skip > 0) {
             $skip--;
         } else {


### PR DESCRIPTION
Allow underscore in generated ToC links

Match behaviour of GitHub and Jekyll rendering.

See notes at [OKAPI-568](https://issues.folio.org/browse/OKAPI-568)