### PR TITLE
OKAPI-569: Security update PostgreSQL 9.6.8, postgresql-embedded 2.9

### DIFF
--- a/okapi-core/pom.xml
+++ b/okapi-core/pom.xml
@@ -129,7 +129,7 @@
     <dependency>
       <groupId>ru.yandex.qatools.embed</groupId>
       <artifactId>postgresql-embedded</artifactId>
-      <version>2.4</version>
+      <version>2.9</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Update postgresql-embedded from 2.4 to 2.9. This updates PostgreSQL from 9.6.3 to 9.6.8 fixing these security vulnerabilities:

    CVE-2017-7546 empty password accepted
    CVE-2017-7547 pg_user_mappings view discloses passwords
    CVE-2017-7548 lo_put() function ignores ACLs
    CVE-2017-12172 Start scripts permit to modify root-owned files
    CVE-2017-15098 Memory disclosure in JSON functions
    CVE-2017-15099 INSERT ... ON CONFLICT DO UPDATE fails to enforce SELECT privileges
    CVE-2018-1053 pg_upgrade creates file of sensitive metadata under prevailing umask
    CVE-2018-1058 Uncontrolled search path element

See list with details: https://www.postgresql.org/support/security/
