### PR TITLE
Discovery delete with serviceId only OKAPI-577

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/web/InternalModule.java
+++ b/okapi-core/src/main/java/org/folio/okapi/web/InternalModule.java
@@ -157,6 +157,11 @@ public class InternalModule {
       + "    \"type\" : \"internal\" "
       + "   }, {"
       + "    \"methods\" :  [ \"DELETE\" ],"
+      + "    \"pathPattern\" : \"/_/discovery/modules/{serviceId}\","
+      + "    \"permissionsRequired\" : [ \"okapi.discovery.delete\" ], "
+      + "    \"type\" : \"internal\" "
+      + "   }, {"
+      + "    \"methods\" :  [ \"DELETE\" ],"
       + "    \"pathPattern\" : \"/_/discovery/modules/{serviceId}/{instanceId}\","
       + "    \"permissionsRequired\" : [ \"okapi.discovery.delete\" ], "
       + "    \"type\" : \"internal\" "
@@ -1103,6 +1108,18 @@ public class InternalModule {
     });
   }
 
+  private void discoveryUndeploy(ProxyContext pc, String srvcId,
+    Handler<ExtendedAsyncResult<String>> fut) {
+
+    discoveryManager.removeAndUndeploy(pc, srvcId, res -> {
+      if (res.failed()) {
+        fut.handle(new Failure<>(res.getType(), res.cause()));
+        return;
+      }
+      fut.handle(new Success<>(""));
+    });
+  }
+
   private void discoveryHealthAll(Handler<ExtendedAsyncResult<String>> fut) {
     discoveryManager.health(res -> {
       if (res.failed()) {
@@ -1456,6 +1473,10 @@ public class InternalModule {
       }
       if (n == 6 && segments[3].equals("modules") && m.equals(DELETE)) {
         discoveryUndeploy(pc, decodedSegs[4], decodedSegs[5], fut);
+        return;
+      }
+      if (n == 5 && segments[3].equals("modules") && m.equals(DELETE)) {
+        discoveryUndeploy(pc, decodedSegs[4], fut);
         return;
       }
       // /_/discovery/health

--- a/okapi-core/src/main/raml/okapi.raml
+++ b/okapi-core/src/main/raml/okapi.raml
@@ -166,6 +166,17 @@ schemas:
           description: Server Error
           body:
             text/plain:
+    delete:
+      description: Remove registration for a given instance
+      responses:
+        204:
+          headers:
+            X-Okapi-Trace:
+              description: Okapi trace and timing
+        404:
+          description: Not Found
+          body:
+            text/plain:
     /{instance_id}:
       get:
         description: Update registration of a specified instance

--- a/okapi-core/src/test/java/okapi/ModuleTenantsTest.java
+++ b/okapi-core/src/test/java/okapi/ModuleTenantsTest.java
@@ -404,7 +404,7 @@ public class ModuleTenantsTest {
 
     // undeploy basic is OK now
     c = api.createRestAssured3();
-    r = c.given()
+    c.given()
       .delete(locationBasicTenantModule)
       .then()
       .statusCode(204)
@@ -494,7 +494,7 @@ public class ModuleTenantsTest {
     // make sure sample-module-1.0.0 is not deployed anymore
     c = api.createRestAssured3();
     c.given()
-      .delete(locationSampleDeployment_1_0_0)
+      .delete("/_/discovery/modules/sample-module-1.0.0")
       .then()
       .statusCode(204);
     Assert.assertTrue(


### PR DESCRIPTION
Allow delete /discovery/modules/{serviceId} . This is simpler
than the full: /_/discovery/modules/{serviceId}/{instanceId}