### PR TITLE
Extend /_/proxy/tenants/<t>/modules with full parameter OKAPI-588

### DIFF
--- a/okapi-core/src/main/raml/okapi.raml
+++ b/okapi-core/src/main/raml/okapi.raml
@@ -551,6 +551,11 @@ schemas:
               text/plain:
       get:
         description: Get enabled modules for tenant
+        queryParameters:
+          full:
+            description: whether full or compact MD should be returned
+            type: boolean
+            required: false
         responses:
           200:
             headers:
@@ -558,7 +563,7 @@ schemas:
                 description: Okapi trace and timing
             body:
               application/json:
-                schema: TenantModuleDescriptorList
+                schema: ModuleList
           404:
             description: Not Found
             body:

--- a/okapi-core/src/test/java/okapi/ModuleTenantsTest.java
+++ b/okapi-core/src/test/java/okapi/ModuleTenantsTest.java
@@ -180,6 +180,7 @@ public class ModuleTenantsTest {
     final String docSample_1_0_0 = "{" + LS
       + "  \"id\" : \"sample-module-1.0.0\"," + LS
       + "  \"name\" : \"this module\"," + LS
+      + "  \"requires\" : [ ]," + LS
       + "  \"provides\" : [ {" + LS
       + "    \"id\" : \"_tenant\"," + LS
       + "    \"version\" : \"1.0\"," + LS
@@ -196,7 +197,6 @@ public class ModuleTenantsTest {
       + "      \"pathPattern\" : \"/testb/foo\"" + LS
       + "    } ]" + LS
       + "  } ]," + LS
-      + "  \"requires\" : [ ]," + LS
       + "  \"launchDescriptor\" : {" + LS
       + "    \"exec\" : "
       + "\"java -Dport=%p -jar ../okapi-test-module/target/okapi-test-module-fat.jar\"" + LS
@@ -206,6 +206,7 @@ public class ModuleTenantsTest {
     r = c.given()
       .header("Content-Type", "application/json")
       .body(docSample_1_0_0).post("/_/proxy/modules").then().statusCode(201)
+      .body(equalTo(docSample_1_0_0))
       .extract().response();
     Assert.assertTrue(
       "raml: " + c.getLastReport().toString(),
@@ -262,6 +263,26 @@ public class ModuleTenantsTest {
       "raml: " + c.getLastReport().toString(),
       c.getLastReport().isEmpty());
     String locationTenantModule = r.getHeader("Location");
+
+    c = api.createRestAssured3();
+    c.given()
+      .header("Content-Type", "application/json")
+      .get("/_/proxy/tenants/" + okapiTenant + "/modules")
+      .then().statusCode(200)
+      .body(equalTo("[ " + docEnableSample + " ]"));
+    Assert.assertTrue(
+      "raml: " + c.getLastReport().toString(),
+      c.getLastReport().isEmpty());
+
+    c = api.createRestAssured3();
+    c.given()
+      .header("Content-Type", "application/json")
+      .get("/_/proxy/tenants/" + okapiTenant + "/modules?full=true")
+      .then().statusCode(200)
+      .body(equalTo("[ " + docSample_1_0_0 + " ]"));
+    Assert.assertTrue(
+      "raml: " + c.getLastReport().toString(),
+      c.getLastReport().isEmpty());
 
     // run module
     c = api.createRestAssured3();


### PR DESCRIPTION
This in fact changes the schema of that response, but since only "id"
was ever used, it is safe to change that to ModuleDescriptor list.