### PR TITLE
OKAPI-635: Return Auth filter error to caller without relying on pre/post filter

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/service/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/service/ProxyService.java
@@ -707,6 +707,10 @@ public class ProxyService {
       Iterator<ModuleInstance> newIt;
       if (res.statusCode() < 200 || res.statusCode() >= 300) {
         newIt = getNewIterator(it, mi);
+        if (!newIt.hasNext() && XOkapiHeaders.FILTER_AUTH.equalsIgnoreCase(mi.getRoutingEntry().getPhase())) {
+          proxyResponseImmediate(pc, res, mi);
+          return;
+        }
       } else {
         newIt = it;
       }


### PR DESCRIPTION
Fix in okapi-634 was not enough. Noticed a few API test errors in our environment. Heads-up, I will merge this once build is green to unblock API test failures in our env. Thanks. 