### PR TITLE
FOLIO-1027 enable lint-raml jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,7 @@ buildMvn {
   publishModDescriptor = 'no'
   publishAPI = 'yes'
   mvnDeploy = 'yes'
+  runLintRamlCop = 'yes'
 
   doDocker = {
     buildJavaDocker {


### PR DESCRIPTION
Enable lint-raml with CI.

Developers can run the same script locally at `../folio-tools/lint-raml/lint_raml_cop.py`

See the [guides/raml-cop](https://dev.folio.org/guides/raml-cop/).
