### PR TITLE
Optimize shared map usage OKAPI-664

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/util/AsyncLocalmap.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/AsyncLocalmap.java
@@ -103,8 +103,8 @@ class AsyncLocalmap<K, V> implements AsyncMap<K, V> {
   }
 
   @Override
-  public void keys(Handler<AsyncResult<Set<K>>> hndlr) {
-    throw new UnsupportedOperationException("Not supported yet.");
+  public void keys(Handler<AsyncResult<Set<K>>> resultHandler) {
+    resultHandler.handle(Future.succeededFuture(map.keySet()));
   }
 
   @Override

--- a/okapi-core/src/main/java/org/folio/okapi/util/LockedStringMap.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/LockedStringMap.java
@@ -5,17 +5,16 @@ import org.folio.okapi.common.Failure;
 import org.folio.okapi.common.Success;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.Json;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.shareddata.AsyncMap;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
 import static org.folio.okapi.common.ErrorType.*;
 import org.folio.okapi.common.Messages;
 import org.folio.okapi.common.OkapiLogger;
@@ -28,16 +27,9 @@ public class LockedStringMap {
     Map<String, String> strings = new LinkedHashMap<>();
   }
 
-  static class KeyList {
-
-    @JsonProperty
-    Set<String> keys = new TreeSet<>();
-  }
-
   private AsyncMap<String, String> list = null;
   private Vertx vertx = null;
   private static final int DELAY = 10; // ms in recursing for retry of map
-  private static final String ALL_KEYS = "_keys"; // keeps a list of all known keys
   protected final Logger logger = OkapiLogger.get();
   private Messages messages = Messages.getInstance();
 
@@ -105,89 +97,15 @@ public class LockedStringMap {
   }
 
   public void getKeys(Handler<ExtendedAsyncResult<Collection<String>>> fut) {
-    list.get(ALL_KEYS, resGet -> {
-      if (resGet.failed()) {
-        fut.handle(new Failure<>(INTERNAL, resGet.cause()));
+    list.keys(res -> {
+      if (res.failed()) {
+        fut.handle(new Failure<>(INTERNAL, res.cause()));
       } else {
-        getKeys2(resGet.result(), fut);
+        List<String> s2 = new ArrayList<>(res.result());
+        java.util.Collections.sort(s2);
+        fut.handle(new Success<>(s2));
       }
     });
-  }
-
-  private void getKeys2(String val, Handler<ExtendedAsyncResult<Collection<String>>> fut) {
-    Collection<String> result = new TreeSet<>();
-    if (val == null || val.isEmpty()) {
-      fut.handle(new Success<>(result));
-    } else {
-      KeyList keys = Json.decodeValue(val, KeyList.class);
-
-      CompList<Collection<String>> futures = new CompList<>(INTERNAL);
-      for (String k : keys.keys) {
-        Future<String> f = Future.future();
-        list.get(k, res -> {
-          if (res.succeeded()) {
-            String v = res.result();
-            if (v != null) {
-              result.add(k);
-            }
-          }
-          f.handle(res);
-        });
-        futures.add(f);
-      }
-      futures.all(result, fut);
-    }
-  }
-
-  private void addKey(String k, Handler<ExtendedAsyncResult<Void>> fut) {
-    KeyList klist = new KeyList();
-    list.get(ALL_KEYS, resGet -> {
-      if (resGet.failed()) {
-        fut.handle(new Failure<>(INTERNAL, resGet.cause()));
-      } else {
-        String oldVal = resGet.result();
-        if (oldVal != null) {
-          KeyList oldlist = Json.decodeValue(oldVal, KeyList.class);
-          klist.keys.addAll(oldlist.keys);
-        }
-        if (klist.keys.contains(k)) {
-          fut.handle(new Success<>());
-        } else {
-          klist.keys.add(k);
-          addKey2(k, oldVal, Json.encodePrettily(klist), fut);
-        }
-      }
-    });
-  }
-
-  private void addKey2(String k, String oldVal, String newVal,
-    Handler<ExtendedAsyncResult<Void>> fut) {
-
-    if (oldVal == null) { // new entry
-      list.putIfAbsent(ALL_KEYS, newVal, resPut -> {
-        if (resPut.succeeded()) {
-          if (resPut.result() == null) {
-            fut.handle(new Success<>());
-          } else { // Someone messed with it, try again
-            vertx.setTimer(DELAY, res -> addKey(k, fut));
-          }
-        } else {
-          fut.handle(new Failure<>(INTERNAL, resPut.cause()));
-        }
-      });
-    } else { // existing entry, put and retry if someone else messed with it
-      list.replaceIfPresent(ALL_KEYS, oldVal, newVal, resRepl -> {
-        if (resRepl.succeeded()) {
-          if (resRepl.result()) {
-            fut.handle(new Success<>());
-          } else {
-            vertx.setTimer(DELAY, res -> addKey(k, fut));
-          }
-        } else {
-          fut.handle(new Failure<>(INTERNAL, resRepl.cause()));
-        }
-      });
-    }
   }
 
   public void addOrReplace(boolean allowReplace, String k, String k2, String value,
@@ -225,7 +143,7 @@ public class LockedStringMap {
       list.putIfAbsent(k, newVal, resPut -> {
         if (resPut.succeeded()) {
           if (resPut.result() == null) {
-            addKey(k, fut);
+            fut.handle(new Success<>());
           } else { // Someone messed with it, try again
             vertx.setTimer(DELAY, res
               -> addOrReplace(allowReplace, k, k2, value, fut));
@@ -238,7 +156,7 @@ public class LockedStringMap {
       list.replaceIfPresent(k, oldVal, newVal, resRepl -> {
         if (resRepl.succeeded()) {
           if (resRepl.result()) {
-            addKey(k, fut);
+            fut.handle(new Success<>());
           } else {
             vertx.setTimer(DELAY, res
               -> addOrReplace(allowReplace, k, k2, value, fut));
@@ -288,9 +206,6 @@ public class LockedStringMap {
         if (resDel.succeeded()) {
           if (resDel.result()) {
             fut.handle(new Success<>(true));
-            // Note that we don't remove from the allkeys list.
-            // That could lead to race conditions, better to have
-            // unused entries in the allkeys list.
           } else {
             vertx.setTimer(DELAY, res -> remove(k, k2, fut));
           }

--- a/okapi-core/src/test/java/okapi/util/LockedStringMapTest.java
+++ b/okapi-core/src/test/java/okapi/util/LockedStringMapTest.java
@@ -135,7 +135,7 @@ public class LockedStringMapTest {
   public void listKeys(TestContext context) {
     map.getKeys(res -> {
       assertTrue(res.succeeded());
-      assertTrue("[k1, k1.1]".equals(res.result().toString()));
+      assertEquals("[k1, k1.1]", res.result().toString());
       deleteKey1(context);
     });
   }


### PR DESCRIPTION
This is achived by using the built-in AsyncMap.keys whith appeared in
Vert.x 3.5.0 rather than emulating it as. The problem with emulating the
keys-method was that we could often have collisions when modifying it.