### PR TITLE
add -Dnodename as configurable option. Set a default in cluster mode

### DIFF
--- a/dist/okapi.conf
+++ b/dist/okapi.conf
@@ -49,6 +49,10 @@ port_end="9141"
 # Defaults to 'localhost'
 host="localhost"
 
+# Set '-Dnodename'.  Required for deployment persistence when
+# running Okapi in cluster mode.  Defaults to `/bin/hostname`
+#nodename=
+
 # Define the storage back end - 'postgres' or 'inmemory'
 # ('postgres' only valid when 'role' is set to 'cluster' or 'dev')
 # (valid only when 'role' is set to 'dev' or 'cluster')

--- a/dist/okapi.sh
+++ b/dist/okapi.sh
@@ -38,6 +38,12 @@ parse_okapi_conf()  {
 
    # if role is not set to 'dev', get cluster options
    if [ "$role" != "dev" ]; then
+      if [ "$nodename" ]; then
+         OKAPI_JAVA_OPTS+=" -Dnodename=${nodename}"
+      else 
+         NODENAME=`hostname`
+         OKAPI_JAVA_OPTS+=" -Dnodename=${NODENAME}"
+      fi
 
       if [ "$cluster_interface" ]; then
          CLUSTER_IP=`ip addr show dev $cluster_interface | grep ' inet ' \


### PR DESCRIPTION
In order for okapi deployment persistence to work, -Dnodename must be set when running in cluster mode.   Add configurable 'nodename' option to okapi.conf OR set as `hostname` when cluster mode is specified. 