### PR TITLE
Ignore _keys from map from older Okapi OKAPI-667

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/util/LockedStringMap.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/LockedStringMap.java
@@ -102,6 +102,7 @@ public class LockedStringMap {
         fut.handle(new Failure<>(INTERNAL, res.cause()));
       } else {
         List<String> s2 = new ArrayList<>(res.result());
+        s2.remove("_keys"); // older OKAPI to implement getKeys
         java.util.Collections.sort(s2);
         fut.handle(new Success<>(s2));
       }


### PR DESCRIPTION
In releases before 2.18 _keys was used to book keep all keys
for a map... Now in 2.18 and later, this should be ignored.