### PR TITLE
OKAPI-671 - only add headers if not exists for filter chain requests

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/service/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/service/ProxyService.java
@@ -654,7 +654,16 @@ public class ProxyService {
   }
 
   private void copyHeaders(HttpClientRequest cReq, RoutingContext ctx, ModuleInstance mi) {
-    cReq.headers().setAll(ctx.request().headers());
+    // NOTE: this breaks post filters
+    // cReq.headers().setAll(ctx.request().headers());
+    // only add headers that do not already exists
+    for(Map.Entry<String,String> entry : ctx.request().headers().entries()) {
+        String key = entry.getKey();
+        String value = entry.getValue();
+        if(!cReq.headers().contains(key, value, true)) {
+          cReq.headers().set(key, value);
+        }
+    }
     cReq.headers().remove("Content-Length");
     final String phase = mi.getRoutingEntry().getPhase();
     if (!XOkapiHeaders.FILTER_AUTH.equals(phase)) {


### PR DESCRIPTION
https://issues.folio.org/projects/OKAPI/issues/OKAPI-671?filter=allopenissues

Not sure if this is the best strategy. Also, three tests fail due to incorrect body response that seems to be caused by content-type mismatches.


expected `It works (XML) ` with actual `It works`