### PR TITLE
Install: report 400 for modules not found OKAPI-614

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/util/DepResolution.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/DepResolution.java
@@ -176,11 +176,11 @@ public class DepResolution {
     for (TenantModuleDescriptor tm : tml) {
       String id = tm.getId();
       ModuleId moduleId = new ModuleId(id);
-      if (!moduleId.hasSemVer()) {
-        id = moduleId.getLatest(modsAvailable.keySet());
-        tm.setId(id);
-      }
       if (tm.getAction() == TenantModuleDescriptor.Action.enable) {
+        if (!moduleId.hasSemVer()) {
+          id = moduleId.getLatest(modsAvailable.keySet());
+          tm.setId(id);
+        }
         if (!modsAvailable.containsKey(id)) {
           errors.add(messages.getMessage("10801", id));
         }
@@ -188,8 +188,14 @@ public class DepResolution {
           tm.setAction(TenantModuleDescriptor.Action.uptodate);
         }
       }
-      if (tm.getAction() == TenantModuleDescriptor.Action.disable && !modsEnabled.containsKey(id)) {
-        errors.add(messages.getMessage("10801", id));
+      if (tm.getAction() == TenantModuleDescriptor.Action.disable) {
+        if (!moduleId.hasSemVer()) {
+          id = moduleId.getLatest(modsEnabled.keySet());
+          tm.setId(id);
+        }
+        if (!modsEnabled.containsKey(id)) {
+          errors.add(messages.getMessage("10801", id));
+        }
       }
     }
     if (!errors.isEmpty()) {

--- a/okapi-core/src/main/java/org/folio/okapi/util/DepResolution.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/DepResolution.java
@@ -172,6 +172,7 @@ public class DepResolution {
     List<TenantModuleDescriptor> tml,
     Handler<ExtendedAsyncResult<Boolean>> fut) {
 
+    List<String> errors = new LinkedList<>();
     for (TenantModuleDescriptor tm : tml) {
       String id = tm.getId();
       ModuleId moduleId = new ModuleId(id);
@@ -181,17 +182,19 @@ public class DepResolution {
       }
       if (tm.getAction() == TenantModuleDescriptor.Action.enable) {
         if (!modsAvailable.containsKey(id)) {
-          fut.handle(new Failure<>(NOT_FOUND, id));
-          return;
+          errors.add(messages.getMessage("10801", id));
         }
         if (modsEnabled.containsKey(id)) {
           tm.setAction(TenantModuleDescriptor.Action.uptodate);
         }
       }
       if (tm.getAction() == TenantModuleDescriptor.Action.disable && !modsEnabled.containsKey(id)) {
-        fut.handle(new Failure<>(NOT_FOUND, id));
-        return;
+        errors.add(messages.getMessage("10801", id));
       }
+    }
+    if (!errors.isEmpty()) {
+      fut.handle(new Failure<>(USER, String.join(". ", errors)));
+      return;
     }
     final int lim = tml.size();
     for (int i = 0; i <= lim; i++) {

--- a/okapi-core/src/test/java/okapi/ModuleTenantsTest.java
+++ b/okapi-core/src/test/java/okapi/ModuleTenantsTest.java
@@ -482,7 +482,7 @@ public class ModuleTenantsTest {
       .header("Content-Type", "application/json")
       .body("[ {\"id\" : \"sample-foo-1.2.3\", \"action\" : \"enable\"} ]")
       .post("/_/proxy/tenants/" + okapiTenant + "/install?simulate=true")
-      .then().statusCode(404);
+      .then().statusCode(400);
     Assert.assertTrue(
       "raml: " + c.getLastReport().toString(),
       c.getLastReport().isEmpty());
@@ -493,7 +493,7 @@ public class ModuleTenantsTest {
       .header("Content-Type", "application/json")
       .body("[ {\"id\" : \"sample-foo\", \"action\" : \"enable\"} ]")
       .post("/_/proxy/tenants/" + okapiTenant + "/install?simulate=true")
-      .then().statusCode(404);
+      .then().statusCode(400);
     Assert.assertTrue(
       "raml: " + c.getLastReport().toString(),
       c.getLastReport().isEmpty());
@@ -838,7 +838,7 @@ public class ModuleTenantsTest {
       .header("Content-Type", "application/json")
       .body("[ {\"id\" : \"sample-module-1.2.0\", \"action\" : \"disable\"} ]")
       .post("/_/proxy/tenants/" + okapiTenant + "/install?simulate=true")
-      .then().statusCode(404);
+      .then().statusCode(400);
     Assert.assertTrue(
       "raml: " + c.getLastReport().toString(),
       c.getLastReport().isEmpty());
@@ -1673,7 +1673,7 @@ public class ModuleTenantsTest {
       .body("[ {\"id\" : \"level1\", \"action\" : \"enable\"},"
         + " {\"id\" : \"level2\", \"action\" : \"disable\"} ]")
       .post("/_/proxy/tenants/" + okapiTenant + "/install?simulate=true")
-      .then().statusCode(404);
+      .then().statusCode(400);
     Assert.assertTrue(
       "raml: " + c.getLastReport().toString(),
       c.getLastReport().isEmpty());
@@ -1684,7 +1684,7 @@ public class ModuleTenantsTest {
       .body("[ {\"id\" : \"level1-1.0.1\", \"action\" : \"enable\"},"
         + " {\"id\" : \"level2-1.0.1\", \"action\" : \"disable\"} ]")
       .post("/_/proxy/tenants/" + okapiTenant + "/install?simulate=true")
-      .then().statusCode(404);
+      .then().statusCode(400);
     Assert.assertTrue(
       "raml: " + c.getLastReport().toString(),
       c.getLastReport().isEmpty());
@@ -1695,7 +1695,7 @@ public class ModuleTenantsTest {
       .body("[ {\"id\" : \"level2-1.0.1\", \"action\" : \"enable\"},"
         + " {\"id\" : \"level1-1.0.1\", \"action\" : \"disable\"} ]")
       .post("/_/proxy/tenants/" + okapiTenant + "/install?simulate=true")
-      .then().statusCode(404);
+      .then().statusCode(400);
     Assert.assertTrue(
       "raml: " + c.getLastReport().toString(),
       c.getLastReport().isEmpty());

--- a/okapi-core/src/test/java/okapi/ModuleTenantsTest.java
+++ b/okapi-core/src/test/java/okapi/ModuleTenantsTest.java
@@ -843,6 +843,21 @@ public class ModuleTenantsTest {
       "raml: " + c.getLastReport().toString(),
       c.getLastReport().isEmpty());
 
+    // delete without version (takes the already installed one)
+    c = api.createRestAssured3();
+    c.given()
+      .header("Content-Type", "application/json")
+      .body("[ {\"id\" : \"sample-module\", \"action\" : \"disable\"} ]")
+      .post("/_/proxy/tenants/" + okapiTenant + "/install?simulate=true")
+      .then().statusCode(200)
+      .body(equalTo("[ {" + LS
+        + "  \"id\" : \"sample-module-2.0.0\"," + LS
+        + "  \"action\" : \"disable\"" + LS
+        + "} ]"));
+    Assert.assertTrue(
+      "raml: " + c.getLastReport().toString(),
+      c.getLastReport().isEmpty());
+
     // simulate removal of sample
     c = api.createRestAssured3();
     c.given()


### PR DESCRIPTION
Since the problem with unknmown modules IDs is with POSTed
content rather than the URL 400 instead of 404 is returned.
Also all missing modules are reported (not just the first one).