### PR TITLE
Update okapi.sh

### DIFF
--- a/dist/okapi.sh
+++ b/dist/okapi.sh
@@ -95,7 +95,7 @@ parse_okapi_conf()  {
 
    # configure dockerURL
    if [ "$dockerurl" ] ; then
-      OKAPI_JAVA_OPTS+=" -DdockerURL=${dockerurl}"
+      OKAPI_JAVA_OPTS+=" -DdockerUrl=${dockerurl}"
    fi
 
    # configure okapi URL


### PR DESCRIPTION
Typo ... always use http://localhost:4243 independently the config file.