### PR TITLE
Adjust RES log to show request parameters

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -99,10 +99,11 @@ public class ProxyService {
     ProxyContext pc) {
 
     RoutingContext ctx = pc.getCtx();
-    String url = makeUrl(mi, ctx).replaceFirst("[?#].*$", ".."); // rm params
+    String url = makeUrl(mi, ctx);
     pc.addTraceHeaderLine(ctx.request().method() + " "
       + mi.getModuleDescriptor().getId() + " "
-      + url + " : " + statusCode + pc.timeDiff());
+      + url.replaceFirst("[?#].*$", "..") // remove params
+      + " : " + statusCode + pc.timeDiff());
     pc.logResponse(mi.getModuleDescriptor().getId(), url, statusCode);
   }
 


### PR DESCRIPTION
A small log change so we can see the response time for the full request path and parameters.