### PR TITLE
Fix deleting MD from Okapi causes Vert.x warning OKAPI-750

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/util/DepResolution.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/DepResolution.java
@@ -66,11 +66,9 @@ public class DepResolution {
       moduses.append(seenVersion.getVersion());
       for (ModuleDescriptor mdi : modList) {
         for (InterfaceDescriptor reqi : mdi.getRequiresList()) {
-          if (req.getId().equals(reqi.getId())) {
-            if (seenVersion.isCompatible(reqi)) {
-              moduses.append("/");
-              moduses.append(mdi.getId());
-            }
+          if (req.getId().equals(reqi.getId()) && seenVersion.isCompatible(reqi)) {
+            moduses.append("/");
+            moduses.append(mdi.getId());
           }
         }
       }

--- a/okapi-core/src/test/java/org/folio/okapi/ModuleTenantsTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ModuleTenantsTest.java
@@ -2006,7 +2006,7 @@ public class ModuleTenantsTest {
       "raml: " + c.getLastReport().toString(),
       c.getLastReport().isEmpty());
     Assert.assertEquals("Incompatible version for module req1-1.0.0 interface i1. "
-      + "Need 1.0. Have 2.0/req2-1.0.0", r.getBody().asString());
+      + "Need 1.0. Have 2.0", r.getBody().asString());
 
     c = api.createRestAssured3();
     r = c.given()
@@ -2019,7 +2019,7 @@ public class ModuleTenantsTest {
       "raml: " + c.getLastReport().toString(),
       c.getLastReport().isEmpty());
     Assert.assertEquals("Incompatible version for module req1-1.0.0 interface i1. "
-      + "Need 1.0. Have 2.0/req2-1.0.0", r.getBody().asString());
+      + "Need 1.0. Have 2.0", r.getBody().asString());
 
     c = api.createRestAssured3();
     r = c.given()
@@ -2032,7 +2032,7 @@ public class ModuleTenantsTest {
       "raml: " + c.getLastReport().toString(),
       c.getLastReport().isEmpty());
     Assert.assertEquals("Incompatible version for module req2-1.0.0 interface i1. "
-      + "Need 2.0. Have 1.0/req1-1.0.0", r.getBody().asString());
+      + "Need 2.0. Have 1.0", r.getBody().asString());
 
     c = api.createRestAssured3();
     c.given()
@@ -2244,7 +2244,7 @@ public class ModuleTenantsTest {
       "raml: " + c.getLastReport().toString(),
       c.getLastReport().isEmpty());
     Assert.assertEquals("Incompatible version for module req1-1.0.0 interface i1. "
-      + "Need 1.0. Have 2.0/req2-1.0.0", r.getBody().asString());
+      + "Need 1.0. Have 2.0", r.getBody().asString());
   }
 
   @Test

--- a/okapi-core/src/test/java/org/folio/okapi/ModuleTenantsTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ModuleTenantsTest.java
@@ -2006,7 +2006,7 @@ public class ModuleTenantsTest {
       "raml: " + c.getLastReport().toString(),
       c.getLastReport().isEmpty());
     Assert.assertEquals("Incompatible version for module req1-1.0.0 interface i1. "
-      + "Need 1.0. Have 2.0", r.getBody().asString());
+      + "Need 1.0. Have 2.0/req2-1.0.0", r.getBody().asString());
 
     c = api.createRestAssured3();
     r = c.given()
@@ -2019,7 +2019,7 @@ public class ModuleTenantsTest {
       "raml: " + c.getLastReport().toString(),
       c.getLastReport().isEmpty());
     Assert.assertEquals("Incompatible version for module req1-1.0.0 interface i1. "
-      + "Need 1.0. Have 2.0", r.getBody().asString());
+      + "Need 1.0. Have 2.0/req2-1.0.0", r.getBody().asString());
 
     c = api.createRestAssured3();
     r = c.given()
@@ -2032,7 +2032,7 @@ public class ModuleTenantsTest {
       "raml: " + c.getLastReport().toString(),
       c.getLastReport().isEmpty());
     Assert.assertEquals("Incompatible version for module req2-1.0.0 interface i1. "
-      + "Need 2.0. Have 1.0", r.getBody().asString());
+      + "Need 2.0. Have 1.0/req1-1.0.0", r.getBody().asString());
 
     c = api.createRestAssured3();
     c.given()
@@ -2244,7 +2244,7 @@ public class ModuleTenantsTest {
       "raml: " + c.getLastReport().toString(),
       c.getLastReport().isEmpty());
     Assert.assertEquals("Incompatible version for module req1-1.0.0 interface i1. "
-      + "Need 1.0. Have 2.0", r.getBody().asString());
+      + "Need 1.0. Have 2.0/req2-1.0.0", r.getBody().asString());
   }
 
   @Test


### PR DESCRIPTION
The fix is simple: optimize interface checks - that's methods
DepResolution.checkAllDependencies and DepResolution.checkDependencies