### PR TITLE
Prevent Vertx thread block warnings OKAPI-759

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/util/AsyncLock.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/AsyncLock.java
@@ -10,18 +10,34 @@ public class AsyncLock {
 
   private final boolean isCluster;
   private final SharedData shared;
+  // A good margin below thread lock warnings (60 seconds)
+  private static final long LONG_TIME = 5000; // in ms
 
   public AsyncLock(Vertx vertx) {
     shared = vertx.sharedData();
     isCluster = vertx.isClustered();
   }
 
+  private void getLockR(String name, AsyncResult<Lock> x, Handler<AsyncResult<Lock>> resultHandler) {
+    // when timeout is received we repeat again..
+    if (x.failed() && x.cause().getMessage().startsWith("Timed out")) {
+      getLock(name, resultHandler);
+      return;
+    }
+    resultHandler.handle(x);
+  }
+
+  /**
+   * Lock with no timeout. The built-in getLock has a timeout which is way
+   * too short.
+   * @param name of lock
+   * @param resultHandler to be called when lock is obtained or error
+   */
   public void getLock(String name, Handler<AsyncResult<Lock>> resultHandler) {
-    long longTime = 2000000000;
     if (isCluster) {
-      shared.getLockWithTimeout(name, longTime, resultHandler);
+      shared.getLockWithTimeout(name, LONG_TIME, x -> getLockR(name, x, resultHandler));
     } else {
-      shared.getLocalLockWithTimeout(name, longTime, resultHandler);
+      shared.getLocalLockWithTimeout(name, LONG_TIME, x -> getLockR(name, x, resultHandler));
     }
   }
 }


### PR DESCRIPTION
Supply a timeout less than 60 seconds for getLockWithTimeout to
avoid the warnings to be shown. The call is just repeated instead.