### PR TITLE
using "0.0.0.0" as -cluster-host default value in cluster mode

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/MainDeploy.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainDeploy.java
@@ -176,14 +176,14 @@ public class MainDeploy {
 
   private void deployClustered(final Logger logger, Handler<AsyncResult<Vertx>> fut) {
     if (hConfig == null) {
-      hConfig = new Config();
-      if (clusterHost == null){
-        clusterHost = "0.0.0.0";
-      }      
-      else (clusterHost != null) {
+      hConfig = new Config();  
+      if (clusterHost != null) {
         NetworkConfig network = hConfig.getNetworkConfig();
         InterfacesConfig iFace = network.getInterfaces();
         iFace.setEnabled(true).addInterface(clusterHost);
+      }
+      else {
+        clusterHost = "0.0.0.0"
       }
     }
     hConfig.setProperty("hazelcast.logging.type", "slf4j");

--- a/okapi-core/src/main/java/org/folio/okapi/MainDeploy.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainDeploy.java
@@ -171,11 +171,15 @@ public class MainDeploy {
   private void deployClustered(final Logger logger, Handler<AsyncResult<Vertx>> fut) {
     if (hConfig == null) {
       hConfig = new Config();
-      if (clusterHost != null) {
+      if(clusterHost == null){
+        clusterHost = "0.0.0.0";
+      }      
+      //
+      /*if (clusterHost != null) {
         NetworkConfig network = hConfig.getNetworkConfig();
         InterfacesConfig iFace = network.getInterfaces();
         iFace.setEnabled(true).addInterface(clusterHost);
-      }
+      }*/
     }
     hConfig.setProperty("hazelcast.logging.type", "slf4j");
 

--- a/okapi-core/src/main/java/org/folio/okapi/MainDeploy.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainDeploy.java
@@ -183,7 +183,7 @@ public class MainDeploy {
         iFace.setEnabled(true).addInterface(clusterHost);
       }
       else {
-        clusterHost = "0.0.0.0"
+        clusterHost = "0.0.0.0";
       }
     }
     hConfig.setProperty("hazelcast.logging.type", "slf4j");

--- a/okapi-core/src/main/java/org/folio/okapi/MainDeploy.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainDeploy.java
@@ -177,9 +177,14 @@ public class MainDeploy {
   private void deployClustered(final Logger logger, Handler<AsyncResult<Vertx>> fut) {
     if (hConfig == null) {
       hConfig = new Config();
-      if(clusterHost == null){
+      if (clusterHost == null){
         clusterHost = "0.0.0.0";
       }      
+      else (clusterHost != null) {
+        NetworkConfig network = hConfig.getNetworkConfig();
+        InterfacesConfig iFace = network.getInterfaces();
+        iFace.setEnabled(true).addInterface(clusterHost);
+      }
     }
     hConfig.setProperty("hazelcast.logging.type", "slf4j");
 


### PR DESCRIPTION
run okapi in cluster mode, we need a paramter -clust-host to tell hazelcast which network is using.
so if we using ip "0.0.0.0" as a default value, it will be use the local ip address.
this will be more smarter, the user no need to care param -cluster-host.