### PR TITLE
Sanitize response headers OKAPI-764

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -390,6 +390,7 @@ public class ProxyService {
         hres.headers().addAll(res.headers());
       }
     }
+    sanitizeAuthHeaders(hres.headers());
     hres.headers().remove("Content-Length");
     hres.headers().remove("Transfer-Encoding");
     if (hres.getStatusCode() != 204) {


### PR DESCRIPTION
It happened always betwen modules, but just not for the last
response.