### PR TITLE
OKAPI-786 Use new base docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Okapi — a multitenant API Gateway
 =================================
 
-Copyright (C) 2015-2019 The Open Library Foundation
+Copyright (C) 2015-2020 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.

--- a/okapi-core/Dockerfile
+++ b/okapi-core/Dockerfile
@@ -1,4 +1,4 @@
-FROM folioci/openjdk8-jre-alpine:latest
+FROM folioci/alpine-jre-openjdk8:latest
 
 ENV VERTICLE_FILE okapi-core-fat.jar
 


### PR DESCRIPTION
Uses the updated base docker image folioci/alpine-jre-openjdk8:latest
This has more recent Alpine Linux and more recent Java 8. See some notes at OKAPI-786 and FOLIO-2367.

Regarding testing of this change:
Since the merge of pull/865 ("OKAPI-321 domain sockets for docker") the default 'mvn clean install' does not build on macOS. So to test, i have done the following:

git checkout aac952e # which is just prior to that merge
edit okapi-core/Dockerfile
mvn clean install
cd okapi-core
docker build -f Dockerfile  -t test-okapi-docker .
docker run -d test-okapi-docker dev
docker exec -it `<CONTAINER ID>` bash
`# do some basic curl actions`
exit
docker logs `<CONTAINER ID>`