### PR TITLE
Fluagen okapi 789 max conn iteration config

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/service/impl/ProcessModuleHandle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/service/impl/ProcessModuleHandle.java
@@ -5,6 +5,7 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.NetClient;
 import io.vertx.core.net.NetClientOptions;
 import io.vertx.core.net.NetSocket;
@@ -50,6 +51,11 @@ public class ProcessModuleHandle implements ModuleHandle {
     this.tcpPortWaiting = new TcpPortWaiting(vertx, "localhost", port);
     if (desc.getWaitIterations() != null) {
       tcpPortWaiting.setMaxIterations(desc.getWaitIterations());
+    }
+    JsonObject config = vertx.getOrCreateContext().config();
+    Integer maxIterations = config.getInteger("deploy.waitIterations");
+    if (maxIterations != null) {
+      tcpPortWaiting.setMaxIterations(maxIterations);
     }
   }
 

--- a/okapi-core/src/test/java/org/folio/okapi/ModuleTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ModuleTest.java
@@ -127,6 +127,7 @@ public class ModuleTest {
     conf = new JsonObject();
 
     conf.put("storage", value)
+      .put("deploy.waitIterations", 30)
       .put("port", "9230")
       .put("port_start", "9231")
       .put("port_end", "9237")


### PR DESCRIPTION
The setting is renamed to deploy.waitIterations since the property is called waitIterations in deployment descriptor.. The configuration (if set) takes precedence over everything else.