### PR TITLE
For caching, ignore X-Cache header

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -88,7 +88,8 @@ public class ProxyService {
     httpClient = new HttpClientCached(vertx.createHttpClient(opt));
     httpClient.addIgnoreHeader(XOkapiHeaders.REQUEST_TIMESTAMP)
       .addIgnoreHeader(XOkapiHeaders.REQUEST_ID)
-      .addIgnoreHeader(XOkapiHeaders.REQUEST_IP);
+      .addIgnoreHeader(XOkapiHeaders.REQUEST_IP)
+      .addIgnoreHeader("X-Cache");
     httpClient.cacheStatuses().add(202);
     Boolean cache = Config.getSysConfBoolean("httpCache", false, config);
     if (Boolean.FALSE.equals(cache)) {


### PR DESCRIPTION
This is passed in request in some cases (which it shouldn't).