### PR TITLE
Okapi 773 switch discovery only if all succeeds

### DIFF
--- a/okapi-common/src/main/java/org/folio/okapi/common/OkapiClient.java
+++ b/okapi-common/src/main/java/org/folio/okapi/common/OkapiClient.java
@@ -214,15 +214,17 @@ public class OkapiClient {
         if (statusCode >= 200 && statusCode <= 299) {
           fut.handle(new Success<>(responsebody));
         } else {
-          if (statusCode== 404) {
-            fut.handle(new Failure<>(NOT_FOUND, "404 " + responsebody + ": " + url));
+          ErrorType errorType;
+          if (statusCode == 404) {
+            errorType = ErrorType.NOT_FOUND;
           } else if (statusCode == 403) {
-            fut.handle(new Failure<>(FORBIDDEN, "403 " + responsebody + ": " + url));
-          } else if (statusCode == 400) {
-            fut.handle(new Failure<>(USER, responsebody));
+            errorType = ErrorType.FORBIDDEN;
+          } else if (statusCode >= 500) {
+            errorType = ErrorType.INTERNAL;
           } else {
-            fut.handle(new Failure<>(INTERNAL, responsebody));
+            errorType = ErrorType.USER;
           }
+          fut.handle(new Failure<>(errorType, Integer.toString(statusCode) + ": " + responsebody));
         }
       });
       reqres.exceptionHandler(e -> {

--- a/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
@@ -1,6 +1,9 @@
 package org.folio.okapi;
 
-import org.folio.okapi.managers.ModuleManager;
+import java.lang.management.ManagementFactory;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
@@ -14,11 +17,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.CorsHandler;
-import static java.lang.System.getenv;
-import java.lang.management.ManagementFactory;
-import java.util.Set;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.Logger;
 import org.folio.okapi.bean.ModuleDescriptor;
 import org.folio.okapi.bean.Tenant;
@@ -28,9 +26,10 @@ import org.folio.okapi.common.Messages;
 import org.folio.okapi.common.ModuleVersionReporter;
 import org.folio.okapi.common.OkapiLogger;
 import org.folio.okapi.managers.DeploymentManager;
-import org.folio.okapi.service.ModuleStore;
+import org.folio.okapi.managers.ModuleManager;
 import org.folio.okapi.managers.ProxyService;
 import org.folio.okapi.managers.TenantManager;
+import org.folio.okapi.service.ModuleStore;
 import org.folio.okapi.service.TenantStore;
 import org.folio.okapi.util.LogHelper;
 import org.folio.okapi.common.XOkapiHeaders;
@@ -99,7 +98,7 @@ public class MainVerticle extends AbstractVerticle {
     if (loglevel != null) {
       LogHelper.setRootLogLevel(loglevel);
     } else {
-      String lev = getenv("OKAPI_LOGLEVEL");
+      String lev = System.getenv("OKAPI_LOGLEVEL");
       if (lev != null && !lev.isEmpty()) {
         LogHelper.setRootLogLevel(loglevel);
       }

--- a/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
@@ -434,6 +434,7 @@ public class MainVerticle extends AbstractVerticle {
       if (res.succeeded()) {
         logger.info("Deploy completed succesfully");
       } else {
+        // not reporting failure if re-deploy fails
         logger.info("Deploy failed", res.cause());
       }
       if (enableProxy) {

--- a/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
@@ -342,11 +342,7 @@ public class MainVerticle extends AbstractVerticle {
         + "}";
       final Tenant ten = Json.decodeValue(docTenant, Tenant.class);
       tenantManager.insert(ten, res -> {
-        if (res.failed()) {
-          promise.fail(res.cause()); // something went badly wrong
-          return;
-        }
-        promise.complete();
+        promise.handle(res.mapEmpty());
       });
     });
   }

--- a/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
@@ -228,9 +228,6 @@ public class MainVerticle extends AbstractVerticle {
   }
 
   private Future<Void> startDatabases() {
-    if (storage == null) {
-      return Future.succeededFuture();
-    }
     return storage.prepareDatabases(initMode);
   }
 
@@ -263,8 +260,6 @@ public class MainVerticle extends AbstractVerticle {
         return;
       }
       if (gres.getType() != ErrorType.NOT_FOUND) {
-        logger.warn("checkInternalModules: Could not get {}: {}",
-          okapiModule, gres.cause());
         promise.fail(gres.cause()); // something went badly wrong
         return;
       }

--- a/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
@@ -341,9 +341,7 @@ public class MainVerticle extends AbstractVerticle {
         + "}"
         + "}";
       final Tenant ten = Json.decodeValue(docTenant, Tenant.class);
-      tenantManager.insert(ten, res -> {
-        promise.handle(res.mapEmpty());
-      });
+      tenantManager.insert(ten, res -> promise.handle(res.mapEmpty()));
     });
   }
 

--- a/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
@@ -314,8 +314,7 @@ public class MainVerticle extends AbstractVerticle {
           // Use the commit, easier interface.
           // the internal module can not have dependencies
           // See Okapi-359 about version checks across the cluster
-          tenantManager.updateModuleCommit(XOkapiHeaders.SUPERTENANT_ID,
-            ev, okapiModule, ures -> {
+          tenantManager.updateModuleCommit(st, ev, okapiModule, ures -> {
               if (ures.failed()) {
                 promise.fail(ures.cause());
                 return;

--- a/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
@@ -296,7 +296,7 @@ public class MainVerticle extends AbstractVerticle {
         Tenant st = gres.result();
         Set<String> enabledMods = st.getEnabled().keySet();
         if (enabledMods.contains(okapiModule)) {
-          logger.info("checkSuperTenant: enabled version is OK");
+          logger.info("checkSuperTenant: enabled version is {}", okapiModule);
           promise.complete();
           return;
         }
@@ -316,7 +316,8 @@ public class MainVerticle extends AbstractVerticle {
             + "{} we already have {} in the database. Use that!",
             okapiVersion, ev);
         } else {
-          logger.info("checkSuperTenant: Need to upgrade the stored version");
+          logger.info("checkSuperTenant: Need to upgrade the stored version from {} to {}",
+            ev, okapiModule);
           // Use the commit, easier interface.
           // the internal module can not have dependencies
           // See Okapi-359 about version checks across the cluster

--- a/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
@@ -426,7 +426,7 @@ public class MainVerticle extends AbstractVerticle {
             logger.info("API Gateway started PID {}. Listening on port {}",
               ManagementFactory.getRuntimeMXBean().getName(), port);
           } else {
-            logger.fatal("createHttpServer failed for port {}: {}", port, result.cause());
+            logger.fatal("createHttpServer failed for port {}", port, result.cause());
           }
           promise.handle(result.mapEmpty());
         }
@@ -440,7 +440,7 @@ public class MainVerticle extends AbstractVerticle {
       if (res.succeeded()) {
         logger.info("Deploy completed succesfully");
       } else {
-        logger.info("Deploy failed: {}", res.cause());
+        logger.info("Deploy failed", res.cause());
       }
       if (enableProxy) {
         tenantManager.startTimers(promise);

--- a/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
@@ -258,24 +258,22 @@ public class MainVerticle extends AbstractVerticle {
     final String interfaceVersion = md.getProvides()[0].getVersion();
     moduleManager.get(okapiModule, gres -> {
       if (gres.succeeded()) { // we already have one, go on
-        logger.debug("checkInternalModules: Already have " + okapiModule
-          + " with interface version " + interfaceVersion);
+        logger.debug("checkInternalModules: Already have {} "
+          + " with interface version {}", okapiModule, interfaceVersion);
         // See Okapi-359 about version checks across the cluster
         checkSuperTenant(okapiModule, promise);
         return;
       }
       if (gres.getType() != ErrorType.NOT_FOUND) {
-        logger.warn("checkInternalModules: Could not get "
-          + okapiModule + ": " + gres.cause());
+        logger.warn("checkInternalModules: Could not get {}: {}",
+          okapiModule, gres.cause());
         promise.fail(gres.cause()); // something went badly wrong
         return;
       }
-      logger.debug("Creating the internal Okapi module " + okapiModule
-        + " with interface version " + interfaceVersion);
+      logger.debug("Creating the internal Okapi module {} with interface version {}",
+        okapiModule, interfaceVersion);
       moduleManager.create(md, true, true, true, ires -> {
         if (ires.failed()) {
-          logger.warn("Failed to create the internal Okapi module"
-            + okapiModule + " " + ires.cause());
           promise.fail(ires.cause()); // something went badly wrong
           return;
         }
@@ -310,13 +308,13 @@ public class MainVerticle extends AbstractVerticle {
           }
         }
         final String ev = enver;
-        logger.debug("checkSuperTenant: Enabled version is '" + ev
-          + "', not '" + okapiModule + "'");
+        logger.debug("checkSuperTenant: Enabled version is '{}', not '{}'",
+          ev, okapiModule);
         // See Okapi-359 about version checks across the cluster
         if (ModuleId.compare(ev, okapiModule) >= 4) {
-          logger.warn("checkSuperTenant: This Okapi is too old, "
-            + okapiVersion + " we already have " + ev + " in the database. "
-            + " Use that!");
+          logger.warn("checkSuperTenant: This Okapi is too old,"
+            + "{} we already have {} in the database. Use that!",
+            okapiVersion, ev);
         } else {
           logger.info("checkSuperTenant: Need to upgrade the stored version");
           // Use the commit, easier interface.
@@ -325,22 +323,21 @@ public class MainVerticle extends AbstractVerticle {
           tenantManager.updateModuleCommit(XOkapiHeaders.SUPERTENANT_ID,
             ev, okapiModule, ures -> {
               if (ures.failed()) {
-                logger.debug("checkSuperTenant: "
-                  + "Updating enabled internalModule failed: " + ures.cause());
+                logger.warn("checkSuperTenant: "
+                  + "Updating enabled internalModule failed: {}", ures.cause());
                 promise.fail(ures.cause());
                 return;
               }
-            logger.info("Upgraded the InternalModule version"
-              + " from '" + ev + "' to '" + okapiModule + "'"
-              + " for " + XOkapiHeaders.SUPERTENANT_ID);
+            logger.info("Upgraded the InternalModule version from '{}' to '{}' for {}",
+              ev, okapiModule, XOkapiHeaders.SUPERTENANT_ID);
             });
         }
         promise.complete();
         return;
       }
       if (gres.getType() != ErrorType.NOT_FOUND) {
-        logger.warn("checkSuperTenant: Could not get "
-          + XOkapiHeaders.SUPERTENANT_ID + ": " + gres.cause());
+        logger.warn("checkSuperTenant: Could not get {}: {}",
+          XOkapiHeaders.SUPERTENANT_ID, gres.cause());
         promise.fail(gres.cause()); // something went badly wrong
         return;
       }
@@ -358,8 +355,8 @@ public class MainVerticle extends AbstractVerticle {
       final Tenant ten = Json.decodeValue(docTenant, Tenant.class);
       tenantManager.insert(ten, ires -> {
         if (ires.failed()) {
-          logger.warn("Failed to create the superTenant "
-            + XOkapiHeaders.SUPERTENANT_ID + " " + ires.cause());
+          logger.warn("Failed to create the superTenant {}: {}",
+            XOkapiHeaders.SUPERTENANT_ID, ires.cause());
           promise.fail(ires.cause()); // something went badly wrong
           return;
         }

--- a/okapi-core/src/main/java/org/folio/okapi/bean/ModuleDescriptor.java
+++ b/okapi-core/src/main/java/org/folio/okapi/bean/ModuleDescriptor.java
@@ -82,7 +82,7 @@ public class ModuleDescriptor implements Comparable<ModuleDescriptor> {
 
   @JsonIgnore
   public List<InterfaceDescriptor> getRequiresOptionalList() {
-    List<InterfaceDescriptor> l = new ArrayList();
+    List<InterfaceDescriptor> l = new ArrayList<>();
     Collections.addAll(l, getRequiresList());
     Collections.addAll(l, getOptionalList());
     return l;

--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -1098,7 +1098,7 @@ public class ProxyService {
       OkapiClient cli = res.result();
       String deftok = cli.getRespHeaders().get(XOkapiHeaders.TOKEN);
       logger.debug("authForSystemInterface: {}",
-        Json.encode(cli.getRespHeaders().entries()));
+        () -> Json.encode(cli.getRespHeaders().entries()));
       String modTok = cli.getRespHeaders().get(XOkapiHeaders.MODULE_TOKENS);
       JsonObject jo = new JsonObject(modTok);
       String token = jo.getString(inst.getModuleDescriptor().getId(), deftok);

--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -996,7 +996,7 @@ public class ProxyService {
     }
   }
 
-  private DeploymentDescriptor pickInstance(List<DeploymentDescriptor> instances) {
+  private static DeploymentDescriptor pickInstance(List<DeploymentDescriptor> instances) {
     int sz = instances.size();
     return sz > 0 ? instances.get(random.nextInt(sz)) : null;
   }
@@ -1159,7 +1159,7 @@ public class ProxyService {
    * Helper to make request headers for the system requests we make. Copies all
    * X- headers over. Adds a tenant, and a token, if we have one.
    */
-  private Map<String, String> sysReqHeaders(MultiMap headersIn,
+  private static Map<String, String> sysReqHeaders(MultiMap headersIn,
     String tenantId, String authToken, ModuleInstance inst, String modPerms) {
 
     Map<String, String> headersOut = new HashMap<>();
@@ -1234,7 +1234,7 @@ public class ProxyService {
   }
 
   // store Auth/Handler response, and pass header as needed
-  private void storeResponseInfo(ProxyContext pc, ModuleInstance mi, HttpClientResponse res) {
+  private static void storeResponseInfo(ProxyContext pc, ModuleInstance mi, HttpClientResponse res) {
     String phase = mi.getRoutingEntry().getPhase();
     // It was a real handler, remember the response code and headers
     if (mi.isHandler()) {
@@ -1249,7 +1249,7 @@ public class ProxyService {
   }
 
   // skip handler, but not if at pre/post filter phase
-  private Iterator<ModuleInstance> getNewIterator(Iterator<ModuleInstance> it, ModuleInstance mi,
+  private static Iterator<ModuleInstance> getNewIterator(Iterator<ModuleInstance> it, ModuleInstance mi,
     int statusCode) {
 
     if (statusCode >= 200 && statusCode <= 299) {

--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -1092,7 +1092,6 @@ public class ProxyService {
     ModuleInstance authInst = new ModuleInstance(authMod, filt, inst.getPath(), HttpMethod.HEAD, inst.isHandler());
     doCallSystemInterface(headers, tenantId, null, authInst, modPerms, "", res -> {
       if (res.failed()) {
-        logger.warn("Auth check for systemInterface failed!");
         fut.handle(res);
         return;
       }

--- a/okapi-core/src/main/java/org/folio/okapi/managers/PullManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/PullManager.java
@@ -52,8 +52,8 @@ public class PullManager {
     final Buffer body = Buffer.buffer();
     HttpClientRequest req = httpClient.getAbs(url, res1 -> {
       if (res1.failed()) {
-        logger.info("pull for " + baseUrl + " failed with status "
-          + res1.cause().getMessage());
+        logger.warn("pull for {} failed with status {}", baseUrl,
+          res1.cause().getMessage());
         getRemoteUrl(it, fut);
         return;
       }
@@ -61,8 +61,8 @@ public class PullManager {
       res.handler(body::appendBuffer);
       res.endHandler(x -> {
         if (res.statusCode() != 200) {
-          logger.info("pull for " + baseUrl + " failed with status "
-            + res.statusCode());
+          logger.warn("pull for {} failed with status {}",
+            baseUrl, res.statusCode());
           fut.handle(new Failure<>(ErrorType.USER,
             "pull for " + baseUrl + " returned status " + res.statusCode() + "\n" + body.toString()));
         } else {

--- a/okapi-core/src/main/java/org/folio/okapi/managers/PullManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/PullManager.java
@@ -53,7 +53,7 @@ public class PullManager {
     HttpClientRequest req = httpClient.getAbs(url, res1 -> {
       if (res1.failed()) {
         logger.warn("pull for {} failed with status {}", baseUrl,
-          res1.cause().getMessage());
+          res1.cause().getMessage(), res1);
         getRemoteUrl(it, fut);
         return;
       }

--- a/okapi-core/src/main/java/org/folio/okapi/managers/PullManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/PullManager.java
@@ -52,8 +52,8 @@ public class PullManager {
     final Buffer body = Buffer.buffer();
     HttpClientRequest req = httpClient.getAbs(url, res1 -> {
       if (res1.failed()) {
-        logger.warn("pull for {} failed with status {}", baseUrl,
-          res1.cause().getMessage(), res1);
+        logger.warn("pull for {} failed: {}", baseUrl,
+          res1.cause().getMessage(), res1.cause());
         getRemoteUrl(it, fut);
         return;
       }

--- a/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
@@ -366,9 +366,8 @@ public class TenantManager {
     getTenantInterface(mdFrom, mdTo, jo, tenantParameters, purge, ires -> {
       if (ires.failed()) {
         if (ires.getType() == ErrorType.NOT_FOUND) {
-          logger.debug("eadTenantInterface: "
-            + (mdTo != null ? mdTo.getId() : mdFrom.getId())
-            + " has no support for tenant init");
+          logger.debug("eadTenantInterface: {} has no support for tenant init",
+            (mdTo != null ? mdTo.getId() : mdFrom.getId()));
           ead2TenantInterface(tenant, mdFrom, mdTo, pc, fut);
         } else {
           fut.handle(new Failure<>(ires.getType(), ires.cause()));

--- a/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
@@ -340,7 +340,7 @@ public class TenantManager {
           }
           ead5commit(tenant, mdFrom, mdTo, pc, res1 -> {
             if (res1.failed()) {
-              fut.handle(new Failure<>(res.getType(), res.cause()));
+              fut.handle(new Failure<>(ErrorType.USER, res.cause()));
               return;
             }
             fut.handle(new Success<>(mdTo != null ? mdTo.getId() : ""));
@@ -383,7 +383,7 @@ public class TenantManager {
         final String req = purge ? "" : jo.encodePrettily();
         proxyService.callSystemInterface(tenant, tenInst, req, pc, cres -> {
           if (cres.failed()) {
-            fut.handle(new Failure<>(cres.getType(), cres.cause()));
+            fut.handle(new Failure<>(ErrorType.USER, cres.cause()));
           } else {
             pc.passOkapiTraceHeaders(cres.result());
             // We can ignore the result, the call went well.
@@ -721,7 +721,7 @@ public class TenantManager {
     proxyService.callSystemInterface(tenant, permInst,
       pljson, pc, cres -> {
         if (cres.failed()) {
-          fut.handle(new Failure<>(cres.getType(), cres.cause()));
+          fut.handle(new Failure<>(ErrorType.USER, cres.cause()));
         } else {
           pc.passOkapiTraceHeaders(cres.result());
           pc.debug("tenantPerms request to " + permsModule.getName()

--- a/okapi-core/src/main/java/org/folio/okapi/service/impl/Storage.java
+++ b/okapi-core/src/main/java/org/folio/okapi/service/impl/Storage.java
@@ -1,8 +1,6 @@
 package org.folio.okapi.service.impl;
 
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;

--- a/okapi-core/src/main/java/org/folio/okapi/service/impl/Storage.java
+++ b/okapi-core/src/main/java/org/folio/okapi/service/impl/Storage.java
@@ -60,7 +60,7 @@ public class Storage {
     }
   }
 
-  public void prepareDatabases(InitMode initModeP, Handler<AsyncResult<Void>> fut) {
+  public Future<Void> prepareDatabases(InitMode initModeP) {
     String dbInit = Config.getSysConf("mongo_db_init", "0", config);
     if (mongo != null && "1".equals(dbInit)) {
       initModeP = InitMode.INIT;
@@ -77,8 +77,7 @@ public class Storage {
 
     boolean reset = initMode != InitMode.NORMAL;
 
-    Future<Void> future = Future.succeededFuture();
-    future.compose(res -> {
+    return Future.succeededFuture().compose(res -> {
       Promise<Void> promise = Promise.promise();
       envStore.init(reset, promise::handle);
       return promise.future();
@@ -97,7 +96,7 @@ public class Storage {
       Promise<Void> promise = Promise.promise();
       moduleStore.init(reset, promise::handle);
       return promise.future();
-    }).setHandler(fut::handle);
+    });
   }
 
   public ModuleStore getModuleStore() {

--- a/okapi-core/src/main/java/org/folio/okapi/service/impl/TenantStoreMongo.java
+++ b/okapi-core/src/main/java/org/folio/okapi/service/impl/TenantStoreMongo.java
@@ -78,8 +78,8 @@ public class TenantStoreMongo implements TenantStore {
             if (ures.succeeded()) {
               fut.handle(new Success<>());
             } else {
-              logger.warn("Failed to update descriptor for " + id
-                      + ": " + ures.cause().getMessage());
+              logger.warn("Failed to update descriptor for {}: {}",
+                id, ures.cause().getMessage());
               fut.handle(new Failure<>(ErrorType.INTERNAL, ures.cause()));
             }
           });

--- a/okapi-core/src/main/java/org/folio/okapi/service/impl/TenantStorePostgres.java
+++ b/okapi-core/src/main/java/org/folio/okapi/service/impl/TenantStorePostgres.java
@@ -14,7 +14,6 @@ import org.folio.okapi.bean.TenantDescriptor;
 import org.folio.okapi.common.ErrorType;
 import org.folio.okapi.common.ExtendedAsyncResult;
 import org.folio.okapi.common.Failure;
-import org.folio.okapi.common.Messages;
 import org.folio.okapi.common.Success;
 
 /**
@@ -29,7 +28,6 @@ public class TenantStorePostgres implements TenantStore {
   private static final String ID_SELECT = JSON_COLUMN + "->'descriptor'->>'id' = $1";
   private static final String ID_INDEX = JSON_COLUMN + "->'descriptor'->'id'";
   private final PostgresTable<Tenant> pgTable;
-  private Messages messages = Messages.getInstance();
 
   public TenantStorePostgres(PostgresHandle pg) {
     this.pg = pg;

--- a/okapi-core/src/main/java/org/folio/okapi/util/DepResolution.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/DepResolution.java
@@ -39,9 +39,9 @@ public class DepResolution {
     List<InterfaceDescriptor> pIntsList = pInts.get(req.getId());
     if (pIntsList != null) {
       for (InterfaceDescriptor pi : pIntsList) {
-        logger.debug("Checking dependency of " + md.getId() + ": "
-          + req.getId() + " " + req.getVersion()
-          + " against " + pi.getId() + " " + pi.getVersion());
+        logger.debug("Checking dependency of {}: {} {} against {} {}",
+          md.getId(), req.getId(), req.getVersion(),
+          pi.getId(), pi.getVersion());
         if (req.getId().equals(pi.getId())) {
           if (pi.isCompatible(req)) {
             logger.debug("Dependency OK");

--- a/okapi-core/src/main/java/org/folio/okapi/util/LockedTypedMap2.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/LockedTypedMap2.java
@@ -43,7 +43,7 @@ public class LockedTypedMap2<T> extends LockedStringMap {
       } else {
         LinkedList<T> t = new LinkedList<>();
         for (String s : res.result()) {
-          t.add((T) Json.decodeValue(s, clazz));
+          t.add(Json.decodeValue(s, clazz));
         }
         fut.handle(new Success<>(t));
       }

--- a/okapi-core/src/main/java/org/folio/okapi/util/ProxyContext.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/ProxyContext.java
@@ -85,10 +85,9 @@ public class ProxyContext {
     timer = DropwizardHelper.getTimerContext(key);
     if (waitMs > 0) {
       timerId = ctx.vertx().setPeriodic(waitMs, res
-        -> logger.warn(reqId + " WAIT "
-          + ctx.request().remoteAddress()
-          + " " + tenant + " " + ctx.request().method()
-          + " " + ctx.request().path())
+        -> logger.warn(reqId + " WAIT {} {} {} {}",
+          ctx.request().remoteAddress(), tenant,
+          ctx.request().method(), ctx.request().path())
       );
     }
   }

--- a/okapi-core/src/test/java/org/folio/okapi/ModuleTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ModuleTest.java
@@ -2722,6 +2722,22 @@ public class ModuleTest {
   }
 
   @Test
+  public void testPurgedatabase(TestContext context) {
+    conf.remove("mongo_db_init");
+    conf.remove("postgres_db_init");
+    conf.put("mode", "purgedatabase");
+    async = context.async();
+    undeployFirst(x -> {
+      DeploymentOptions opt = new DeploymentOptions().setConfig(conf);
+      vertx.deployVerticle(MainVerticle.class.getName(), opt, res -> {
+        context.assertTrue(res.succeeded());
+        async.complete();
+      });
+    });
+    async.await(1000);
+  }
+
+  @Test
   public void testInternalModule(TestContext context) {
     conf.remove("mongo_db_init");
     conf.remove("postgres_db_init");

--- a/okapi-core/src/test/java/org/folio/okapi/ModuleTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ModuleTest.java
@@ -2700,7 +2700,7 @@ public class ModuleTest {
 
   @Test
   public void testInitdatabaseBadCredentials(TestContext context) {
-    if (!postgres.equals(conf.getString("storage"))) {
+    if (!"postgres".equals(conf.getString("storage"))) {
       return;
     }
     conf.remove("mongo_db_init");
@@ -2713,7 +2713,8 @@ public class ModuleTest {
       vertx.deployVerticle(MainVerticle.class.getName(), opt, res -> {
         context.assertTrue(res.failed());
         context.assertTrue(res.cause().getMessage().contains(
-          "failed password authentication for user \"okapi\""));
+          "password authentication failed for user \"okapi\""),
+          res.cause().getMessage());
         async.complete();
       });
     });

--- a/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
@@ -53,6 +53,7 @@ public class ProxyTest {
   private MultiMap postHandlerHeaders;
   private static RamlDefinition api;
   private int timerDelaySum = 0;
+  private int timerTenantInitStatus = 200;
 
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {
@@ -160,7 +161,7 @@ public class ProxyTest {
       ctx.request().endHandler(res -> {
         try {
           if (p.startsWith("/_/tenant")) {
-            ctx.response().setStatusCode(200);
+            ctx.response().setStatusCode(timerTenantInitStatus);
             ctx.response().end();
             return;
           }
@@ -248,6 +249,7 @@ public class ProxyTest {
     httpClient = vertx.createHttpClient();
     Async async = context.async();
 
+    timerTenantInitStatus = 200;
     RestAssured.port = port;
     DeploymentOptions opt = new DeploymentOptions()
       .setConfig(new JsonObject()
@@ -2596,4 +2598,196 @@ public class ProxyTest {
     }
 
   }
+
+  @Test
+  public void testTenantInit(TestContext context) {
+    RestAssuredClient c;
+    Response r;
+
+    final String docTimer_1_0_0 = "{" + LS
+      + "  \"id\" : \"timer-module-1.0.0\"," + LS
+      + "  \"name\" : \"timer module\"," + LS
+      + "  \"provides\" : [ {" + LS
+      + "    \"id\" : \"_tenant\"," + LS
+      + "    \"version\" : \"1.1\"," + LS
+      + "    \"interfaceType\" : \"system\"," + LS
+      + "    \"handlers\" : [ {" + LS
+      + "      \"methods\" : [ \"POST\" ]," + LS
+      + "      \"pathPattern\" : \"/_/tenant/disable\"" + LS
+      + "    }, {" + LS
+      + "      \"methods\" : [ \"POST\", \"DELETE\" ]," + LS
+      + "      \"pathPattern\" : \"/_/tenant\"" + LS
+      + "    } ]" + LS
+      + "  }, {" + LS
+      + "    \"id\" : \"myint\"," + LS
+      + "    \"version\" : \"1.0\"," + LS
+      + "    \"handlers\" : [ {" + LS
+      + "      \"methods\" : [ \"POST\" ]," + LS
+      + "      \"pathPattern\" : \"/{id}\"" + LS
+      + "    } ]" + LS
+      + "  } ]," + LS
+      + "  \"requires\" : [ ]" + LS
+      + "}";
+
+    c = api.createRestAssured3();
+    r = c.given()
+      .header("Content-Type", "application/json")
+      .body(docTimer_1_0_0).post("/_/proxy/modules").then().statusCode(201)
+      .extract().response();
+    Assert.assertTrue("raml: " + c.getLastReport().toString(),
+      c.getLastReport().isEmpty());
+
+    final String nodeDoc1 = "{" + LS
+      + "  \"instId\" : \"localhost-" + Integer.toString(portTimer) + "\"," + LS
+      + "  \"srvcId\" : \"timer-module-1.0.0\"," + LS
+      + "  \"url\" : \"http://localhost:" + Integer.toString(portTimer) + "\"" + LS
+      + "}";
+
+    c = api.createRestAssured3();
+    c.given().header("Content-Type", "application/json")
+      .body(nodeDoc1).post("/_/discovery/modules")
+      .then().statusCode(201);
+    Assert.assertTrue("raml: " + c.getLastReport().toString(),
+      c.getLastReport().isEmpty());
+
+    final String okapiTenant = "roskilde";
+    // add tenant
+    final String docTenantRoskilde = "{" + LS
+      + "  \"id\" : \"" + okapiTenant + "\"," + LS
+      + "  \"name\" : \"" + okapiTenant + "\"," + LS
+      + "  \"description\" : \"Roskilde bibliotek\"" + LS
+      + "}";
+    c = api.createRestAssured3();
+    given()
+      .header("Content-Type", "application/json")
+      .body(docTenantRoskilde).post("/_/proxy/tenants")
+      .then().statusCode(201)
+      .body(equalTo(docTenantRoskilde));
+
+    c = api.createRestAssured3();
+    c.given()
+      .header("Content-Type", "application/json")
+      .body("["
+        + " {\"id\" : \"timer-module-1.0.0\", \"action\" : \"enable\"}"
+        + "]")
+      .post("/_/proxy/tenants/" + okapiTenant + "/install")
+      .then().statusCode(200).log().ifValidationFails();
+    Assert.assertTrue("raml: " + c.getLastReport().toString(),
+      c.getLastReport().isEmpty());
+
+    given()
+      .header("X-Okapi-Tenant", okapiTenant)
+      .header("Content-Type", "text/plain")
+      .header("Accept", "text/plain")
+      .body("Okapi").post("/1")
+      .then().statusCode(200).log().ifValidationFails();
+
+    final String docTimer_1_0_1 = "{" + LS
+      + "  \"id\" : \"timer-module-1.0.1\"," + LS
+      + "  \"name\" : \"timer module\"," + LS
+      + "  \"provides\" : [ {" + LS
+      + "    \"id\" : \"_tenant\"," + LS
+      + "    \"version\" : \"1.1\"," + LS
+      + "    \"interfaceType\" : \"system\"," + LS
+      + "    \"handlers\" : [ {" + LS
+      + "      \"methods\" : [ \"POST\" ]," + LS
+      + "      \"pathPattern\" : \"/_/tenant/disable\"" + LS
+      + "    }, {" + LS
+      + "      \"methods\" : [ \"POST\", \"DELETE\" ]," + LS
+      + "      \"pathPattern\" : \"/_/tenant\"" + LS
+      + "    } ]" + LS
+      + "  }, {" + LS
+      + "    \"id\" : \"myint\"," + LS
+      + "    \"version\" : \"1.0\"," + LS
+      + "    \"handlers\" : [ {" + LS
+      + "      \"methods\" : [ \"POST\" ]," + LS
+      + "      \"pathPattern\" : \"/{id}\"" + LS
+      + "    } ]" + LS
+      + "  } ]," + LS
+      + "  \"requires\" : [ ]" + LS
+      + "}";
+
+    c = api.createRestAssured3();
+    r = c.given()
+      .header("Content-Type", "application/json")
+      .body(docTimer_1_0_1).post("/_/proxy/modules").then().statusCode(201)
+      .extract().response();
+    Assert.assertTrue("raml: " + c.getLastReport().toString(),
+      c.getLastReport().isEmpty());
+
+    final String nodeDoc2 = "{" + LS
+      + "  \"instId\" : \"localhost1-" + Integer.toString(portTimer) + "\"," + LS
+      + "  \"srvcId\" : \"timer-module-1.0.1\"," + LS
+      + "  \"url\" : \"http://localhost:" + Integer.toString(portTimer) + "\"" + LS
+      + "}";
+    c = api.createRestAssured3();
+    c.given().header("Content-Type", "application/json")
+      .body(nodeDoc2).post("/_/discovery/modules")
+      .then().statusCode(201);
+    Assert.assertTrue("raml: " + c.getLastReport().toString(),
+      c.getLastReport().isEmpty());
+
+    final String docEdge_1_0_0 = "{" + LS
+      + "  \"id\" : \"edge-module-1.0.0\"," + LS
+      + "  \"name\" : \"edge module\"," + LS
+      + "  \"provides\" : [ {" + LS
+      + "    \"id\" : \"edge\"," + LS
+      + "    \"version\" : \"1.0\"," + LS
+      + "    \"handlers\" : [ {" + LS
+      + "      \"methods\" : [ \"GET\", \"POST\" ]," + LS
+      + "      \"pathPattern\" : \"/edge/{id}\"" + LS
+      + "    } ]" + LS
+      + "  } ]," + LS
+      + "  \"requires\" : [ ]" + LS
+      + "}";
+    c = api.createRestAssured3();
+    r = c.given()
+      .header("Content-Type", "application/json")
+      .body(docEdge_1_0_0).post("/_/proxy/modules").then().statusCode(201)
+      .extract().response();
+    Assert.assertTrue(
+      "raml: " + c.getLastReport().toString(),
+      c.getLastReport().isEmpty());
+
+    final String nodeDiscoverEdge = "{" + LS
+      + "  \"instId\" : \"localhost-" + Integer.toString(portEdge) + "\"," + LS
+      + "  \"srvcId\" : \"edge-module-1.0.0\"," + LS
+      + "  \"url\" : \"http://localhost:" + Integer.toString(portEdge) + "\"" + LS
+      + "}";
+
+    c = api.createRestAssured3();
+    c.given().header("Content-Type", "application/json")
+      .body(nodeDiscoverEdge).post("/_/discovery/modules")
+      .then().statusCode(201);
+    Assert.assertTrue("raml: " + c.getLastReport().toString(),
+      c.getLastReport().isEmpty());
+
+    c = api.createRestAssured3();
+    c.given().header("Content-Type", "application/json")
+      .get("/_/proxy/tenants/" + okapiTenant + "/modules")
+      .then().statusCode(200).body(containsString("timer-module-1.0.0"));
+    Assert.assertTrue("raml: " + c.getLastReport().toString(),
+      c.getLastReport().isEmpty());
+
+    timerTenantInitStatus = 400;
+    c = api.createRestAssured3();
+    c.given()
+      .header("Content-Type", "application/json")
+      .body("["
+        + " {\"id\" : \"edge-module-1.0.0\", \"action\" : \"enable\"},"
+        + " {\"id\" : \"timer-module-1.0.1\", \"action\" : \"enable\"}"
+        + "]")
+      .post("/_/proxy/tenants/" + okapiTenant + "/install")
+      .then().statusCode(500).log().ifValidationFails();
+    Assert.assertTrue("raml: " + c.getLastReport().toString(),
+      c.getLastReport().isEmpty());
+
+    c = api.createRestAssured3();
+    c.given().header("Content-Type", "application/json")
+      .get("/_/proxy/tenants/" + okapiTenant + "/modules")
+      .then().statusCode(200).body(containsString("timer-module-1.0.0"));
+    Assert.assertTrue("raml: " + c.getLastReport().toString(),
+      c.getLastReport().isEmpty());
+  }
+
 }

--- a/okapi-test-auth-module/src/test/java/AuthModuleTest.java
+++ b/okapi-test-auth-module/src/test/java/AuthModuleTest.java
@@ -72,7 +72,7 @@ public class AuthModuleTest {
     cli.get("/notokentenant", res -> {
       cli.close();
       context.assertTrue(res.failed());
-      context.assertEquals("Permissions required: foo,bar", res.cause().getMessage());
+      context.assertEquals("401: Permissions required: foo,bar", res.cause().getMessage());
       async.complete();
     });
   }
@@ -169,7 +169,7 @@ public class AuthModuleTest {
     cli.post("/authn/login", body, res -> {
       cli.close();
       context.assertTrue(res.failed());
-      context.assertEquals(ErrorType.INTERNAL, res.getType());
+      context.assertEquals(ErrorType.USER, res.getType());
       async.complete();
     });
   }


### PR DESCRIPTION
This PR improves coverage in general for install. It ensures that the tenant module association is not happening until all modules have been completing tenant init and tenant permissions interface. Of course, if the modules do not implement these interfaces, they will not be considered. Also if a module is not running at all, of course, also that stops upgrading. There's no switch for this. This changes behavior for the better, so a desired breaking change = bug fix.

Out of scope of this issue:

We should extend the tenant interface with a rollback mechanism so that module can be notified to rollback if they have succeeded but another module has failed. 

Finally, we could do a pre-check tenant init which has no side effects but just let the module ack that it can do upgrade (without actually doing anything). https://issues.folio.org/browse/OKAPI-814
