### PR TITLE
For IntelliJ IDEA use continuation indent of 4

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,3 +16,6 @@ indent_style = tab
 
 [md2toc]
 indent_size = 4
+
+[**.java]
+continuation_indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,7 @@ root = true
 charset = utf-8
 end_of_line = lf
 indent_size = 2
+continuation_indent_size = 4
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
@@ -16,6 +17,3 @@ indent_style = tab
 
 [md2toc]
 indent_size = 4
-
-[**.java]
-continuation_indent_size = 4


### PR DESCRIPTION
If IDEA uses editorconfig it uses a contination indent to be same as
indent_size (2).. We want it to be 4. This setting is probably only
recognoized by IDEA.