### PR TITLE
Remove locale dependency

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/service/impl/DockerModuleHandle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/service/impl/DockerModuleHandle.java
@@ -216,9 +216,11 @@ public class DockerModuleHandle implements ModuleHandle {
         }
       });
     });
-    req.exceptionHandler(d -> {
-      logger.warn("{}: {}", url, d.getMessage());
-      future.handle(Future.failedFuture(url + ": " + d.getMessage()));
+    req.exceptionHandler(e -> {
+      Throwable cause = e.getCause() == null ? e : e.getCause();
+      String msg = url + ": " + e.getMessage() + " - " + cause.getClass().getName();
+      logger.warn(msg);
+      future.handle(Future.failedFuture(msg));
     });
     req.end();
   }

--- a/okapi-core/src/test/java/org/folio/okapi/service/impl/DockerModuleHandleTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/service/impl/DockerModuleHandleTest.java
@@ -64,7 +64,7 @@ public class DockerModuleHandleTest {
       "mod-users-5.0.0-SNAPSHOT", ports, "localhost", 9232, conf);
 
     dh.start(context.asyncAssertFailure(cause ->
-      context.assertTrue(cause.getMessage().contains("Connection refused"),
+      context.assertTrue(cause.getMessage().contains("java.net.ConnectException"),
         cause.getMessage())
     ));
   }


### PR DESCRIPTION
LANG=de_DE.UTF-8 mvn clean install
fails in DockerModuleHandleTest#testNoDockerAtPort()
because netty translates "Connection refused" to
"Verbindungsaufbau abgelehnt".

This fix changes the exception message and the test
to be more locale independent.