### PR TITLE
Allow delegate CORS to module

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
@@ -5,14 +5,11 @@ import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
-import io.vertx.core.http.HttpHeaders;
-import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.ext.web.Router;
-import io.vertx.ext.web.handler.CorsHandler;
 import java.lang.management.ManagementFactory;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -41,15 +38,13 @@ import org.folio.okapi.service.TenantStore;
 import org.folio.okapi.service.impl.Storage;
 import org.folio.okapi.service.impl.Storage.InitMode;
 import org.folio.okapi.service.impl.TenantStoreNull;
+import org.folio.okapi.util.CorsHelper;
 import org.folio.okapi.util.LogHelper;
 
 @java.lang.SuppressWarnings({"squid:S1192"})
 public class MainVerticle extends AbstractVerticle {
 
   private final Logger logger = OkapiLogger.get();
-
-  public static final String CHECK_DELEGATE_CORS = "check-delegate-CORS";
-  public static final String DELEGATE_CORS = "delegate-CORS";
 
   private ModuleManager moduleManager;
   private TenantManager tenantManager;
@@ -356,37 +351,8 @@ public class MainVerticle extends AbstractVerticle {
     Router router = Router.router(vertx);
     logger.debug("Setting up routes");
 
-    // handle delegate CORS
-    router.routeWithRegex("^/_/invoke/tenant/[^/ ]+/.*").handler(ctx -> {
-      ctx.data().put(CHECK_DELEGATE_CORS, true);
-      ctx.next();
-    });
-
     //handle CORS
-    router.route().handler(ctx -> {
-      if (ctx.data().containsKey(DELEGATE_CORS)) {
-        ctx.next();
-      } else {
-        CorsHandler.create("*")
-          .allowedMethod(HttpMethod.PUT)
-          .allowedMethod(HttpMethod.DELETE)
-          .allowedMethod(HttpMethod.GET)
-          .allowedMethod(HttpMethod.POST)
-          //allow request headers
-          .allowedHeader(HttpHeaders.CONTENT_TYPE.toString())
-          .allowedHeader(XOkapiHeaders.TENANT)
-          .allowedHeader(XOkapiHeaders.TOKEN)
-          .allowedHeader(XOkapiHeaders.AUTHORIZATION)
-          .allowedHeader(XOkapiHeaders.REQUEST_ID) //expose response headers
-          .allowedHeader(XOkapiHeaders.MODULE_ID)
-          .exposedHeader(HttpHeaders.LOCATION.toString())
-          .exposedHeader(XOkapiHeaders.TRACE)
-          .exposedHeader(XOkapiHeaders.TOKEN)
-          .exposedHeader(XOkapiHeaders.AUTHORIZATION)
-          .exposedHeader(XOkapiHeaders.REQUEST_ID)
-          .exposedHeader(XOkapiHeaders.MODULE_ID).handle(ctx);
-      }
-    });
+    CorsHelper.addCorsHanlder(router);
 
     if (proxyService != null) {
       router.routeWithRegex("^/_/invoke/tenant/[^/ ]+/.*")

--- a/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
@@ -352,7 +352,7 @@ public class MainVerticle extends AbstractVerticle {
     logger.debug("Setting up routes");
 
     //handle CORS
-    CorsHelper.addCorsHanlder(router);
+    CorsHelper.addCorsHandler(router);
 
     if (proxyService != null) {
       router.routeWithRegex("^/_/invoke/tenant/[^/ ]+/.*")

--- a/okapi-core/src/main/java/org/folio/okapi/bean/RoutingEntry.java
+++ b/okapi-core/src/main/java/org/folio/okapi/bean/RoutingEntry.java
@@ -2,6 +2,7 @@ package org.folio.okapi.bean;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.Json;
@@ -31,6 +32,8 @@ public class RoutingEntry {
   private String[] permissionsRequired;
   private String[] permissionsDesired;
   private String[] modulePermissions;
+  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+  private boolean delegateCors;
   private static final String INVALID_PATH_CHARS = "\\%+{}()[].;:=?@#^$\"' ";
   @JsonIgnore
   private String phaseLevel = "50"; // default for regular handler
@@ -404,6 +407,15 @@ public class RoutingEntry {
       }
     }
     this.phase = phase;
+  }
+
+  @JsonProperty("delegateCORS")
+  public boolean isDelegateCors() {
+    return delegateCors;
+  }
+
+  public void setDelegateCors(boolean delegateCors) {
+    this.delegateCors = delegateCors;
   }
 
   /**

--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -540,8 +540,12 @@ public class ProxyService {
           return; // ctx already set up
         }
 
-        // handle delegate CORS
-        CorsHelper.checkCorsDelegate(ctx, l);
+        // check delegate CORS and reroute if necessary
+        if (CorsHelper.checkCorsDelegate(ctx, l)) {
+          stream.resume();
+          ctx.reroute(ctx.request().path());
+          return;
+        }
 
         pc.setModList(l);
 

--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import org.apache.logging.log4j.Logger;
+import org.folio.okapi.MainVerticle;
 import org.folio.okapi.bean.DeploymentDescriptor;
 import org.folio.okapi.bean.ModuleDescriptor;
 import org.folio.okapi.bean.ModuleInstance;
@@ -538,6 +539,18 @@ public class ProxyService {
           stream.resume();
           return; // ctx already set up
         }
+
+        // handle delegate CORS
+        if (ctx.data().containsKey(MainVerticle.CHECK_DELEGATE_CORS)) {
+          ctx.data().remove(MainVerticle.CHECK_DELEGATE_CORS);
+          if (l.stream().anyMatch(mi -> mi.isHandler() && mi.getRoutingEntry().isDelegateCors())) {
+            ctx.data().put(MainVerticle.DELEGATE_CORS, true);
+            stream.resume();
+            ctx.reroute(ctx.request().path());
+            return;
+          }
+        }
+
         pc.setModList(l);
 
         pc.logRequest(ctx, tenantId);

--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import org.apache.logging.log4j.Logger;
-import org.folio.okapi.MainVerticle;
 import org.folio.okapi.bean.DeploymentDescriptor;
 import org.folio.okapi.bean.ModuleDescriptor;
 import org.folio.okapi.bean.ModuleInstance;
@@ -45,6 +44,7 @@ import org.folio.okapi.common.OkapiLogger;
 import org.folio.okapi.common.OkapiToken;
 import org.folio.okapi.common.Success;
 import org.folio.okapi.common.XOkapiHeaders;
+import org.folio.okapi.util.CorsHelper;
 import org.folio.okapi.util.DropwizardHelper;
 import org.folio.okapi.util.ProxyContext;
 
@@ -541,15 +541,7 @@ public class ProxyService {
         }
 
         // handle delegate CORS
-        if (ctx.data().containsKey(MainVerticle.CHECK_DELEGATE_CORS)) {
-          ctx.data().remove(MainVerticle.CHECK_DELEGATE_CORS);
-          if (l.stream().anyMatch(mi -> mi.isHandler() && mi.getRoutingEntry().isDelegateCors())) {
-            ctx.data().put(MainVerticle.DELEGATE_CORS, true);
-            stream.resume();
-            ctx.reroute(ctx.request().path());
-            return;
-          }
-        }
+        CorsHelper.checkCorsDelegate(ctx, l);
 
         pc.setModList(l);
 

--- a/okapi-core/src/main/java/org/folio/okapi/util/CorsHelper.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/CorsHelper.java
@@ -68,7 +68,8 @@ public class CorsHelper {
    * @param moduleInstances a list of {@link ModuleInstance}
    * @return true if reroute if needed, false otherwise
    */
-  public static boolean checkCorsDelegate(RoutingContext ctx, List<ModuleInstance> moduleInstances) {
+  public static boolean checkCorsDelegate(
+      RoutingContext ctx, List<ModuleInstance> moduleInstances) {
     if (ctx.data().containsKey(CHECK_DELEGATE_CORS)) {
       ctx.data().remove(CHECK_DELEGATE_CORS);
       if (moduleInstances.stream().anyMatch(mi ->

--- a/okapi-core/src/main/java/org/folio/okapi/util/CorsHelper.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/CorsHelper.java
@@ -1,0 +1,84 @@
+package org.folio.okapi.util;
+
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.CorsHandler;
+import java.util.List;
+import org.folio.okapi.bean.ModuleInstance;
+import org.folio.okapi.common.XOkapiHeaders;
+
+/**
+ * Customized CORS handling.
+ *
+ * <p>If a module API specifies <b>delegateCORS</b> to true in RAML, Okapi will
+ * delegate CORS handling to the module if and only if the API is invoked
+ * through {@code /_/invoke/tenant/<tenantId>/moduleAPI}
+ */
+public class CorsHelper {
+
+  private static final String CHECK_DELEGATE_CORS = "check-delegate-CORS";
+  private static final String DELEGATE_CORS = "delegate-CORS";
+
+  private CorsHelper() {
+  }
+
+  /**
+   * Add CORS handler to {@link Router}.
+   *
+   * @param router - {@link Router}
+   */
+  public static void addCorsHanlder(Router router) {
+
+    router.routeWithRegex("^/_/invoke/tenant/[^/ ]+/.*").handler(ctx -> {
+      ctx.data().put(CHECK_DELEGATE_CORS, true);
+      ctx.next();
+    });
+
+    router.route().handler(ctx -> {
+      if (ctx.data().containsKey(DELEGATE_CORS)) {
+        ctx.next();
+      } else {
+        CorsHandler.create("*")
+          .allowedMethod(HttpMethod.PUT)
+          .allowedMethod(HttpMethod.DELETE)
+          .allowedMethod(HttpMethod.GET)
+          .allowedMethod(HttpMethod.POST)
+          .allowedHeader(HttpHeaders.CONTENT_TYPE.toString())
+          .allowedHeader(XOkapiHeaders.TENANT)
+          .allowedHeader(XOkapiHeaders.TOKEN)
+          .allowedHeader(XOkapiHeaders.AUTHORIZATION)
+          .allowedHeader(XOkapiHeaders.REQUEST_ID) //expose response headers
+          .allowedHeader(XOkapiHeaders.MODULE_ID)
+          .exposedHeader(HttpHeaders.LOCATION.toString())
+          .exposedHeader(XOkapiHeaders.TRACE)
+          .exposedHeader(XOkapiHeaders.TOKEN)
+          .exposedHeader(XOkapiHeaders.AUTHORIZATION)
+          .exposedHeader(XOkapiHeaders.REQUEST_ID)
+          .exposedHeader(XOkapiHeaders.MODULE_ID).handle(ctx);
+      }
+    });
+  }
+
+  /**
+   * Check CORS delegate and reroute if necessary.
+   *
+   * @param ctx             - {@link RoutingContext}
+   * @param moduleInstances a list of {@link ModuleInstance}
+   */
+  public static void checkCorsDelegate(RoutingContext ctx, List<ModuleInstance> moduleInstances) {
+    if (ctx.data().containsKey(CHECK_DELEGATE_CORS)) {
+      ctx.data().remove(CHECK_DELEGATE_CORS);
+      if (moduleInstances.stream().anyMatch(mi ->
+          mi.isHandler() && mi.getRoutingEntry().isDelegateCors())) {
+        ctx.data().put(DELEGATE_CORS, true);
+        ctx.request().resume();
+        ctx.reroute(ctx.request().path());
+        return;
+      }
+    }
+
+  }
+
+}

--- a/okapi-core/src/main/java/org/folio/okapi/util/CorsHelper.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/CorsHelper.java
@@ -62,23 +62,22 @@ public class CorsHelper {
   }
 
   /**
-   * Check CORS delegate and reroute if necessary.
+   * Check CORS delegate to decide if reroute if necessary.
    *
    * @param ctx             - {@link RoutingContext}
    * @param moduleInstances a list of {@link ModuleInstance}
+   * @return true if reroute if needed, false otherwise
    */
-  public static void checkCorsDelegate(RoutingContext ctx, List<ModuleInstance> moduleInstances) {
+  public static boolean checkCorsDelegate(RoutingContext ctx, List<ModuleInstance> moduleInstances) {
     if (ctx.data().containsKey(CHECK_DELEGATE_CORS)) {
       ctx.data().remove(CHECK_DELEGATE_CORS);
       if (moduleInstances.stream().anyMatch(mi ->
           mi.isHandler() && mi.getRoutingEntry().isDelegateCors())) {
         ctx.data().put(DELEGATE_CORS, true);
-        ctx.request().resume();
-        ctx.reroute(ctx.request().path());
-        return;
+        return true;
       }
     }
-
+    return false;
   }
 
 }

--- a/okapi-core/src/main/java/org/folio/okapi/util/CorsHelper.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/CorsHelper.java
@@ -29,7 +29,7 @@ public class CorsHelper {
    *
    * @param router - {@link Router}
    */
-  public static void addCorsHanlder(Router router) {
+  public static void addCorsHandler(Router router) {
 
     router.routeWithRegex("^/_/invoke/tenant/[^/ ]+/.*").handler(ctx -> {
       ctx.data().put(CHECK_DELEGATE_CORS, true);

--- a/okapi-core/src/main/raml/RoutingEntry.json
+++ b/okapi-core/src/main/raml/RoutingEntry.json
@@ -68,6 +68,10 @@
       "items": {
         "type": "string"
       }
+    },
+    "delegateCORS": {
+      "description": "Okapi handles CORS by default. Set to true to delegate CORS handling to the module",
+      "type": "boolean"
     }
   }
 }

--- a/okapi-core/src/main/raml/RoutingEntry.json
+++ b/okapi-core/src/main/raml/RoutingEntry.json
@@ -70,7 +70,7 @@
       }
     },
     "delegateCORS": {
-      "description": "Okapi handles CORS by default. Set to true to delegate CORS handling to the module",
+      "description": "Okapi handles CORS by default. Set to true to delegate CORS handling to the module. This only applies to calls made via /_/invoke/tenant/<tid>/<path>",
       "type": "boolean"
     }
   }

--- a/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
@@ -3498,7 +3498,7 @@ public class ProxyTest {
       .statusCode(200)
       .log().ifValidationFails();
 
-    // with CORS delegate and query parameer
+    // with CORS delegate and query parameter
     c.given()
       .header("Content-Type", "application/json")
       .header("X-Okapi-Token", getOkapiToken(tenant))

--- a/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
@@ -1,10 +1,12 @@
 package org.folio.okapi;
 
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
 import guru.nidi.ramltester.RamlDefinition;
 import guru.nidi.ramltester.RamlLoaders;
 import guru.nidi.ramltester.restassured3.RestAssuredClient;
 import io.restassured.RestAssured;
-import static io.restassured.RestAssured.given;
 import io.restassured.response.Response;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Future;
@@ -14,6 +16,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.json.JsonArray;
@@ -27,7 +30,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
-
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Map.Entry;
@@ -36,8 +38,6 @@ import org.apache.logging.log4j.Logger;
 import org.folio.okapi.common.HttpClientLegacy;
 import org.folio.okapi.common.HttpResponse;
 import org.folio.okapi.common.XOkapiHeaders;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -49,6 +49,7 @@ public class ProxyTest {
   private Vertx vertx;
   private HttpClient httpClient;
   private static final String LS = System.lineSeparator();
+  private static final String CORS_TEST_HEADER = "CORS_TEST_HEADER";
   private final int portTimer = 9235;
   private final int portPre = 9236;
   private final int portPost = 9237;
@@ -187,6 +188,9 @@ public class ProxyTest {
             });
           } else if (p.startsWith("/regularcall")) {
             ctx.response().end(extractSubFromToken(ctx));
+          } else if (p.startsWith("/corscall")) {
+            ctx.response().putHeader(CORS_TEST_HEADER, ctx.request().query());
+            ctx.response().end("Response from CORS test");
           } else {
             ctx.response().setStatusCode(404);
             ctx.response().end(p);
@@ -3457,6 +3461,62 @@ public class ProxyTest {
     given().delete("/_/proxy/tenants/" + tenant).then().statusCode(204);
   }
 
+  @Test
+  public void testDelegateCORS() {
+    String tenant = "test-tenant-delegate-cors";
+    String moduleId = "test-tenant-delegate-cors-module-1.0.0";
+    String authModuleId = "test-tenant-delegate-cors-auth-module-1.0.0";
+    String body = new JsonObject().put("id", "test").encode();
+
+    setupBasicTenant(tenant);
+    setupBasicModule(tenant, moduleId, "1.1");
+    setupBasicAuth(tenant, authModuleId);
+
+    RestAssuredClient c = api.createRestAssured3();
+
+    // no CORS delegate
+    c.given()
+      .header("Content-Type", "application/json")
+      .header("X-Okapi-Token", getOkapiToken(tenant))
+      .header("origin", "localhost")
+      .body(body)
+      .post("/_/invoke/tenant/" + tenant + "/regularcall")
+      .then()
+      .header(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS.toString(), notNullValue())
+      .statusCode(200)
+      .log().ifValidationFails();
+
+    // with CORS delegate
+    c.given()
+      .header("Content-Type", "application/json")
+      .header("X-Okapi-Token", getOkapiToken(tenant))
+      .header("origin", "localhost")
+      .body(body)
+      .post("/_/invoke/tenant/" + tenant + "/corscall")
+      .then()
+      .header(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS.toString(), nullValue())
+      .statusCode(200)
+      .log().ifValidationFails();
+
+    // with CORS delegate and query parameer
+    c.given()
+      .header("Content-Type", "application/json")
+      .header("X-Okapi-Token", getOkapiToken(tenant))
+      .header("origin", "localhost")
+      .body(body)
+      .post("/_/invoke/tenant/" + tenant + "/corscall?x=y")
+      .then()
+      .header(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS.toString(), nullValue())
+      .header(CORS_TEST_HEADER, "x=y")
+      .statusCode(200)
+      .log().ifValidationFails();
+
+    given().delete("/_/proxy/tenants/" + tenant + "/modules").then().statusCode(204);
+    given().delete("/_/discovery/modules").then().statusCode(204);
+    given().delete("/_/proxy/modules/" + moduleId).then().statusCode(204);
+    given().delete("/_/proxy/tenants/" + tenant).then().statusCode(204);
+  }
+
   // add basic tenant
   private void setupBasicTenant(String tenant) {
     String tenantJson = new JsonObject().put("id", tenant).encode();
@@ -3610,7 +3670,16 @@ public class ProxyTest {
               .put("methods", new JsonArray().add("POST"))
               .put("pathPattern", "/regularcall")
               .put("permissionsRequired", new JsonArray())
-              .put("modulePermissions", new JsonArray().add("regularcall.test.post"))))))
+              .put("modulePermissions", new JsonArray().add("regularcall.test.post")))))
+        .add(new JsonObject()
+            .put("id", "CORS-TEST")
+            .put("version", "1.0")
+            .put("handlers", new JsonArray()
+              .add(new JsonObject()
+                .put("methods", new JsonArray().add("POST"))
+                .put("pathPattern", "/corscall")
+                .put("permissionsRequired", new JsonArray())
+                .put("delegateCORS", "true")))))
       .put("requires", new JsonArray())
       .put("permissionSets", new JsonArray()
         .add(new JsonObject()


### PR DESCRIPTION
See [OKAPI-847](https://issues.folio.org/browse/OKAPI-847): Conditionally defer CORS handling to module when invoked via passthrough API