### PR TITLE
OKAPI-854: Deprecate postgres_user, switch to postgres_username

### DIFF
--- a/dist/okapi.conf
+++ b/dist/okapi.conf
@@ -66,7 +66,7 @@ storage="inmemory"
 # Set Postgres parameters.  Ignored unless 'storage="postgres"'
 postgres_host="localhost"   # default 'localhost'
 postgres_port="5432"        # default postgres port
-postgres_user="okapi"       # default
+postgres_username="okapi"   # default
 postgres_password="okapi25" # default
 postgres_database="okapi"   # default
 

--- a/dist/okapi.sh
+++ b/dist/okapi.sh
@@ -17,6 +17,8 @@ fi
 DATA_DIR="${DATA_DIR:-/var/lib/okapi}"
 LIB_DIR="${LIB_DIR:-/usr/share/folio/okapi/lib}"
 OKAPI_JAR="${LIB_DIR}/okapi-core-fat.jar"
+# Copy from deprecated postgres_user into postgres_username
+postgres_username="${postgres_username:-${postgres_user:-okapi}}"
 
 parse_okapi_conf()  {
 
@@ -27,7 +29,7 @@ parse_okapi_conf()  {
          OKAPI_JAVA_OPTS+=" -Dstorage=postgres"
          OKAPI_JAVA_OPTS+=" -Dpostgres_host=${postgres_host:-localhost}"
          OKAPI_JAVA_OPTS+=" -Dpostgres_port=${postgres_port:-5432}"
-         OKAPI_JAVA_OPTS+=" -Dpostgres_user=${postgres_user:-okapi}"
+         OKAPI_JAVA_OPTS+=" -Dpostgres_username=${postgres_username:-okapi}"
          OKAPI_JAVA_OPTS+=" -Dpostgres_password=${postgres_password:-okapi25}"
          OKAPI_JAVA_OPTS+=" -Dpostgres_database=${postgres_database:-okapi}"
       else
@@ -133,7 +135,7 @@ java_check() {
 init_db() {
    # Postgres instance check
    if command -v psql >/dev/null; then
-      psql postgresql://${postgres_user}:${postgres_password}@${postgres_host}:${postgres_port}/${postgres_database}?connect_timeout=5 > /dev/null 2>&1 << EOF
+      psql postgresql://${postgres_username}:${postgres_password}@${postgres_host}:${postgres_port}/${postgres_database}?connect_timeout=5 > /dev/null 2>&1 << EOF
 \q
 EOF
       POSTGRES_RETVAL=$?
@@ -145,7 +147,7 @@ EOF
          exit 2
       else
          echo -n "Initializing okapi database..."
-         $JAVA -Dport=8600 -Dstorage=postgres -Dpostgres_host=${postgres_host} -Dpostgres_port=${postgres_port} -Dpostgres_user=${postgres_user} -Dpostgres_password=${postgres_password} -Dpostgres_database=${postgres_database} -jar ${OKAPI_JAR} initdatabase >/dev/null 2>&1
+         $JAVA -Dport=8600 -Dstorage=postgres -Dpostgres_host=${postgres_host} -Dpostgres_port=${postgres_port} -Dpostgres_username=${postgres_username} -Dpostgres_password=${postgres_password} -Dpostgres_database=${postgres_database} -jar ${OKAPI_JAR} initdatabase >/dev/null 2>&1
          INIT_RETVAL=$?
          if [ "$INIT_RETVAL" != 0 ]; then
             echo "Failed"

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -2679,6 +2679,7 @@ Defaults to `localhost`.
 * `postgres_host` : PostgreSQL host. Defaults to `localhost`.
 * `postgres_port` : PostgreSQL port. Defaults to 5432.
 * `postgres_username` : PostgreSQL username. Defaults to `okapi`.
+  (Don't use deprecated `postgres_user` that is implemented for `-D` only.)
 * `postgres_password`: PostgreSQL password. Defaults to `okapi25`.
 * `postgres_database`: PostgreSQL database. Defaults to `okapi`.
 * `postgres_db_init`: For a value of `1`, Okapi will drop existing

--- a/okapi-core/src/main/java/org/folio/okapi/service/impl/PostgresHandle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/service/impl/PostgresHandle.java
@@ -57,6 +57,8 @@ class PostgresHandle {
         logger.warn("Bad postgres_port value: {}: {}", val, e.getMessage());
       }
     }
+
+    // postgres_user is supported for system configuration (-D option) only and is deprecated
     connectOptions.setUser(Config.getSysConf("postgres_username",
         Config.getSysConf("postgres_user", "okapi", new JsonObject()), conf));
     connectOptions.setPassword(Config.getSysConf("postgres_password", "okapi25", conf));


### PR DESCRIPTION
Add deprecation comments to doc/guide.md, PostgresHandle.java and dist/okapi.sh.
Change environment variable postgres_user to postgres_username in dist/okapi.sh
while supporting the deprecated form used by
https://github.com/folio-org/folio-ansible/blob/q4-2019/roles/okapi/templates/okapi.conf.j2
https://github.com/folio-org/okapi-debian/tree/debian-debian/dist