### PR TITLE
OKAPI-858: okapi.sh should not put credentials into -D command line

### DIFF
--- a/dist/okapi.sh
+++ b/dist/okapi.sh
@@ -27,6 +27,10 @@ parse_okapi_conf()  {
 
       if [ "$storage" == "postgres" ]; then
          OKAPI_JAVA_OPTS+=" -Dstorage=postgres"
+         OKAPI_OPTIONS+=" -conf ${PID_DIR}/okapi-postgres.conf"
+         rm -f "${PID_DIR}/okapi-postgres.conf" > /dev/null 2>&1
+         touch "${PID_DIR}/okapi-postgres.conf"
+         chmod 600 "${PID_DIR}/okapi-postgres.conf"
          # include postgres_server_pem only if defined (even if empty string)
          jq -n --arg WARNING "AUTOMATICALLY CREATED FILE, DO NOT EDIT!"  \
                --arg postgres_host       "${postgres_host:-localhost}"   \
@@ -43,9 +47,8 @@ parse_okapi_conf()  {
                  \$postgres_database
                  ${postgres_server_pem+,\$postgres_server_pem}
                }" > "${PID_DIR}/okapi-postgres.conf"
-         OKAPI_OPTIONS+=" -conf ${PID_DIR}/okapi-postgres.conf"
          echo "${PID_DIR}/okapi-postgres.conf = "
-         cat "${PID_DIR}/okapi-postgres.conf"
+         cat "${PID_DIR}/okapi-postgres.conf" | sed 's/\(\"\postgres_password":\).*[^,]/\1 .../g'
       else
          OKAPI_JAVA_OPTS+=" -Dstorage=inmemory"
       fi

--- a/dist/okapi.sh
+++ b/dist/okapi.sh
@@ -27,11 +27,25 @@ parse_okapi_conf()  {
 
       if [ "$storage" == "postgres" ]; then
          OKAPI_JAVA_OPTS+=" -Dstorage=postgres"
-         OKAPI_JAVA_OPTS+=" -Dpostgres_host=${postgres_host:-localhost}"
-         OKAPI_JAVA_OPTS+=" -Dpostgres_port=${postgres_port:-5432}"
-         OKAPI_JAVA_OPTS+=" -Dpostgres_username=${postgres_username:-okapi}"
-         OKAPI_JAVA_OPTS+=" -Dpostgres_password=${postgres_password:-okapi25}"
-         OKAPI_JAVA_OPTS+=" -Dpostgres_database=${postgres_database:-okapi}"
+         # include postgres_server_pem only if defined (even if empty string)
+         jq -n --arg WARNING "AUTOMATICALLY CREATED FILE, DO NOT EDIT!"  \
+               --arg postgres_host       "${postgres_host:-localhost}"   \
+               --arg postgres_port       "${postgres_port:-5432}"        \
+               --arg postgres_username   "${postgres_username:-okapi}"   \
+               --arg postgres_password   "${postgres_password:-okapi25}" \
+               --arg postgres_database   "${postgres_database:-okapi}"   \
+               --arg postgres_server_pem "${postgres_server_pem}"        \
+               "{\$WARNING,
+                 \$postgres_host,
+                 \$postgres_port,
+                 \$postgres_username,
+                 \$postgres_password,
+                 \$postgres_database
+                 ${postgres_server_pem+,\$postgres_server_pem}
+               }" > "${PID_DIR}/okapi-postgres.conf"
+         OKAPI_OPTIONS+=" -conf ${PID_DIR}/okapi-postgres.conf"
+         echo "${PID_DIR}/okapi-postgres.conf = "
+         cat "${PID_DIR}/okapi-postgres.conf"
       else
          OKAPI_JAVA_OPTS+=" -Dstorage=inmemory"
       fi


### PR DESCRIPTION
Collect all postgres_* variables, encode them as JSON, write them to
okapi-postgres.conf (at the writeable directory PID_DIR), and pass
the file via the -conf parameter.

Include postgres_server_pem only if defined (even if empty string).