### PR TITLE
OKAPI-866 OOM bulk upload

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -745,19 +745,38 @@ public class ProxyService {
                                    WriteStream<Buffer> mainWriteStream,
                                    List<HttpClientRequest> logWriteStreams) {
     readStream.handler(data -> {
-      readStream.pause();
-      AtomicInteger pend = new AtomicInteger(1 + logWriteStreams.size());
-      mainWriteStream.write(data, x -> {
-        if (pend.decrementAndGet() == 0) {
-          readStream.resume();
-        }
-      });
+      AtomicInteger pend = new AtomicInteger();
+      // two passes.. to avoid drainHandler being fired off too early.
+      // first pass: see if any of writing streams are full?
+      mainWriteStream.write(data);
+      if (mainWriteStream.writeQueueFull()) {
+        pend.incrementAndGet();
+      }
       for (WriteStream<Buffer> w : logWriteStreams) {
-        w.write(data, x -> {
-          if (pend.decrementAndGet() == 0) {
-            readStream.resume();
+        w.write(data);
+        if (w.writeQueueFull()) {
+          pend.incrementAndGet();
+        }
+      }
+      if (pend.get() > 0) {
+        // second pass: at least one was full. pause and set up drainHandlers for full ones.
+        readStream.pause();
+        if (mainWriteStream.writeQueueFull()) {
+          mainWriteStream.drainHandler(x -> {
+            if (pend.decrementAndGet() == 0) {
+              readStream.resume();
+            }
+          });
+        }
+        for (WriteStream<Buffer> w : logWriteStreams) {
+          if (w.writeQueueFull()) {
+            w.drainHandler(x -> {
+              if (pend.decrementAndGet() == 0) {
+                readStream.resume();
+              }
+            });
           }
-        });
+        }
       }
     });
     readStream.endHandler(v -> {

--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -592,7 +592,8 @@ public class ProxyService {
         for (HttpClientRequest r : clientRequestList) {
           r.write(data);
         }
-        ctx.response().write(data);
+        res.pause();
+        ctx.response().write(data, end -> res.resume());
       });
       res.endHandler(v -> {
         pc.closeTimer();
@@ -798,7 +799,8 @@ public class ProxyService {
       stream.handler(data -> {
         pc.trace("proxyRequestResponse request chunk '"
             + data.toString() + "'");
-        clientRequest.write(data);
+        stream.pause();
+        clientRequest.write(data, comp -> stream.resume());
         for (HttpClientRequest r : clientRequestList) {
           r.write(data);
         }

--- a/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
@@ -493,7 +493,7 @@ public class ProxyTest {
       buffer.appendString("X");
     }
     endRequest(request, buffer, 0, bufCnt);
-    async.await(20000);
+    async.await(30000);
 
     given().delete("/_/proxy/tenants/" + okapiTenant + "/modules").then().statusCode(204);
     given().delete("/_/discovery/modules").then().statusCode(204);

--- a/okapi-core/src/test/java/org/folio/okapi/managers/ProxyServiceTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/managers/ProxyServiceTest.java
@@ -1,0 +1,176 @@
+package org.folio.okapi.managers;
+
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.streams.ReadStream;
+import io.vertx.core.streams.WriteStream;
+import java.util.Arrays;
+import org.assertj.core.api.WithAssertions;
+import org.junit.Test;
+
+public class ProxyServiceTest implements WithAssertions {
+
+  class MyReadStream implements ReadStream<Buffer> {
+    boolean pause = false;
+    Handler<Buffer> handler;
+    Handler<Void> endHandler;
+
+    public ReadStream<Buffer> exceptionHandler(Handler<Throwable> handler) {
+      return this;
+    }
+
+    public ReadStream<Buffer> handler(@Nullable Handler<Buffer> handler) {
+      this.handler = handler;
+      return this;
+    }
+
+    public void handle(int n) {
+      for (int i=1; i<=n; i++) {
+        if (pause) {
+          throw new AssertionError("Unexpected pause with " + i);
+        }
+        handler.handle(Buffer.buffer(Integer.toString(i)));
+      }
+    }
+
+    public ReadStream<Buffer> pause() {
+      pause = true;
+      return this;
+    }
+
+    public ReadStream<Buffer> resume() {
+      pause = false;
+      return this;
+    }
+
+    public ReadStream<Buffer> fetch(long amount) {
+      return this;
+    }
+
+    public ReadStream<Buffer> endHandler(@Nullable Handler<Void> endHandler) {
+      this.endHandler = endHandler;
+      return this;
+    }
+  }
+
+  class MyWriteStream implements WriteStream<Buffer> {
+    int maxSize = 4;
+    int queue;
+    int processed;
+    boolean overflow = false;
+    boolean processImmediately = false;
+    boolean end = false;
+    Handler<Void> drainHandler;
+
+    public MyWriteStream() {
+    }
+
+    public WriteStream<Buffer> exceptionHandler(Handler<Throwable> handler) {
+      return this;
+    }
+
+    public Future<Void> write(Buffer data) {
+      write(data, null);
+      return null;
+    }
+
+    public void write(Buffer data, Handler<AsyncResult<Void>> handler) {
+      queue++;
+      if (writeQueueFull()) {
+        overflow = true;
+      }
+      if (processImmediately) {
+        processQueue(1);
+      }
+      if (handler != null) {
+        handler.handle(null);
+      }
+    }
+
+    public void processQueue(int i) {
+      int n = i > queue ? queue: i;
+      queue -= n;
+      processed += n;
+      if (overflow && queue <= maxSize/2) {
+        overflow = false;
+        if (drainHandler != null) {
+          drainHandler.handle(null);
+        }
+      }
+    }
+
+    public void end(Handler<AsyncResult<Void>> handler) {
+      end = true;
+      handler.handle(Future.succeededFuture());
+    }
+
+    public WriteStream<Buffer> setWriteQueueMaxSize(int maxSize) {
+      this.maxSize = maxSize;
+      return this;
+    }
+
+    public boolean writeQueueFull() {
+      return queue >= maxSize;
+    }
+
+    public WriteStream<Buffer> drainHandler(@Nullable Handler<Void> handler) {
+      drainHandler = handler;
+      return this;
+    }
+  }
+
+  @Test
+  public void pumpOneToManySimple() {
+    MyReadStream readStream = new MyReadStream();
+    MyWriteStream writeStream1 = new MyWriteStream();
+    MyWriteStream writeStream2 = new MyWriteStream();
+    ProxyService.pumpOneToMany(readStream, Arrays.asList(writeStream1, writeStream2));
+
+    readStream.handle(4);
+    assertThat(writeStream1.overflow).isTrue();
+    assertThat(writeStream2.overflow).isTrue();
+    assertThat(readStream.pause).isTrue();
+
+    writeStream1.processQueue(4);
+    assertThat(writeStream1.overflow).isFalse();
+    assertThat(writeStream2.overflow).isTrue();
+    assertThat(readStream.pause).isTrue();
+
+    writeStream2.processQueue(4);
+    assertThat(writeStream1.overflow).isFalse();
+    assertThat(writeStream2.overflow).isFalse();
+    assertThat(readStream.pause).isFalse();
+
+    readStream.handle(1);
+    assertThat(writeStream1.end).isFalse();
+    assertThat(writeStream2.end).isFalse();
+
+    readStream.endHandler.handle(null);
+    assertThat(writeStream1.end).isTrue();
+    assertThat(writeStream2.end).isTrue();
+  }
+
+  @Test
+  public void pumpOneToManyPiledUp() {
+    MyReadStream readStream = new MyReadStream();
+    MyWriteStream writeStream1 = new MyWriteStream();
+    MyWriteStream writeStream2 = new MyWriteStream();
+    ProxyService.pumpOneToMany(readStream, Arrays.asList(writeStream1, writeStream2));
+
+    readStream.handle(4);
+    writeStream1.processQueue(4);
+
+    // async requests may have piled up
+    writeStream1.write(null);
+    writeStream1.write(null);
+    writeStream1.write(null);
+    writeStream1.write(null);      // this reaches maxSize
+    writeStream1.processQueue(4);  // below maxSize/2 causing a second drainHandler call
+    assertThat(writeStream2.writeQueueFull()).isTrue();
+    assertThat(writeStream2.overflow).isTrue();
+    assertThat(readStream.pause).isTrue();
+  }
+}

--- a/okapi-test-module/src/test/java/SampleModuleTest.java
+++ b/okapi-test-module/src/test/java/SampleModuleTest.java
@@ -218,7 +218,7 @@ public class SampleModuleTest {
     long bufCnt = 10000;
     long total = bufSz * bufCnt;
     HttpClient client = vertx.createHttpClient();
-    for (int loop = 0; loop < 10; loop++) {
+    for (int loop = 0; loop < 2; loop++) {
       Async async = context.async();
       logger.info("Sending {} GB", total / 1e9);
       HttpClientRequest request = HttpClientLegacy.post(client, PORT, "localhost", "/testb", res -> {

--- a/okapi-test-module/src/test/java/SampleModuleTest.java
+++ b/okapi-test-module/src/test/java/SampleModuleTest.java
@@ -1,6 +1,8 @@
-
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientRequest;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -8,8 +10,10 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.logging.log4j.Logger;
 import org.folio.okapi.common.ErrorType;
+import org.folio.okapi.common.HttpClientLegacy;
 import org.folio.okapi.common.OkapiClient;
 import org.folio.okapi.common.OkapiLogger;
 import org.folio.okapi.common.XOkapiHeaders;
@@ -206,5 +210,46 @@ public class SampleModuleTest {
 
       async.complete();
     });
+  }
+
+  @Test
+  public void testUpload(TestContext context) {
+    int bufSz = 100000;
+    long bufCnt = 10000;
+    long total = bufSz * bufCnt;
+    HttpClient client = vertx.createHttpClient();
+    for (int loop = 0; loop < 10; loop++) {
+      Async async = context.async();
+      logger.info("Sending {} GB", total / 1e9);
+      HttpClientRequest request = HttpClientLegacy.post(client, PORT, "localhost", "/testb", res -> {
+        context.assertEquals(200, res.statusCode());
+        AtomicLong cnt = new AtomicLong();
+        res.handler(h -> cnt.addAndGet(h.length()));
+        res.exceptionHandler(ex -> {
+          context.fail(ex);
+          async.complete();
+        });
+        res.endHandler(end -> {
+          context.assertEquals(total + 6, cnt.get());
+          async.complete();
+        });
+      });
+      request.exceptionHandler(ex -> {
+        context.fail(ex.getCause());
+        async.complete();
+      });
+      request.putHeader("Content-Type", "text/plain");
+      request.putHeader("Accept", "text/plain");
+      request.setChunked(true);
+      Buffer buffer = Buffer.buffer();
+      for (int j = 0; j < bufSz; j++) {
+        buffer.appendString("X");
+      }
+      for (int i = 0; i < bufCnt; i++) {
+        request.write(buffer);
+      }
+      request.end();
+      async.await(50000);
+    }
   }
 }

--- a/okapi-test-module/src/test/java/SampleModuleTest.java
+++ b/okapi-test-module/src/test/java/SampleModuleTest.java
@@ -214,7 +214,7 @@ public class SampleModuleTest {
 
   @Test
   public void testUpload(TestContext context) {
-    int bufSz = 100000;
+    int bufSz = 200000;
     long bufCnt = 10000;
     long total = bufSz * bufCnt;
     HttpClient client = vertx.createHttpClient();
@@ -245,11 +245,16 @@ public class SampleModuleTest {
       for (int j = 0; j < bufSz; j++) {
         buffer.appendString("X");
       }
-      for (int i = 0; i < bufCnt; i++) {
-        request.write(buffer);
-      }
-      request.end();
+      endRequest(request, buffer, 0, bufCnt);
       async.await(50000);
+    }
+  }
+
+  void endRequest(HttpClientRequest req, Buffer buffer, long i, long cnt) {
+    if (i == cnt) {
+      req.end();
+    } else {
+      req.write(buffer, res -> endRequest(req, buffer, i + 1, cnt));
     }
   }
 }


### PR DESCRIPTION
This should decrease the memory usage for upload and download for Okapi. The problem is fixed by switching from
https://vertx.io/docs/apidocs/io/vertx/core/http/HttpClientRequest.html#write-io.vertx.core.buffer.Buffer-
to
https://vertx.io/docs/apidocs/io/vertx/core/http/HttpClientRequest.html#write-io.vertx.core.buffer.Buffer-io.vertx.core.Handler-

The problem with the former is that, since it will not block it will pile up the request or response in memory.. Using the latter and pause the source from data until complete minimizes memory.

This PR has a test-case for okapi-test-module.. That is an end-to-end client + server to analyze the problem, which turned out to be useful.

2nd part is "just" the fix for Okapi and a similar test case .

