### PR TITLE
OKAPI-877: Update log4j to 2.13.3 in okapi 2.40 (CVE-2020-9488)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,8 +207,8 @@
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
         <version>2.13.3</version>
-	<type>pom</type>
-	<scope>import</scope>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -205,24 +205,12 @@
 
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-api</artifactId>
-        <version>2.12.1</version>
+        <artifactId>log4j-bom</artifactId>
+        <version>2.13.3</version>
+	<type>pom</type>
+	<scope>import</scope>
       </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-core</artifactId>
-        <version>2.12.1</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-1.2-api</artifactId>
-        <version>2.12.1</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-slf4j-impl</artifactId>
-        <version>2.12.1</version>
-      </dependency>
+
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>


### PR DESCRIPTION
Goldenrod runs Okapi 2.40.

Okapi 3.* has been upgraded to use log4j 2.13.2:
https://issues.folio.org/browse/OKAPI-873
This is the backport of this upgrade to Okapi 2.40
to get these issues fixed in Goldenrod:

* https://issues.apache.org/jira/browse/LOG4J2-2809
  see https://issues.folio.org/browse/OKAPI-873 for details
* https://nvd.nist.gov/vuln/detail/CVE-2020-9488
  "Improper validation of certificate with host mismatch in
  Apache Log4j SMTP appender." This may affect an implementer
  if the sysop uses encrypted SMTP for logging.