### PR TITLE
Okapi 860 metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ nbproject/
 .classpath
 .idea
 okapi.log
+*/bin/
 x

--- a/dist/okapi.sh
+++ b/dist/okapi.sh
@@ -84,6 +84,11 @@ parse_okapi_conf()  {
 
    fi
 
+   # Set performance metric options
+   if [ "$enable_metrics" == 1 ]; then
+      OKAPI_OPTIONS+=" -enable-metrics"
+   fi
+
    # configure log file if specified
    if [ "$log4j_config" ]; then
       OKAPI_JAVA_OPTS+=" -Dhazelcast.logging.type=log4j"

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -44,6 +44,7 @@ managing and running microservices.
     * [Deployment](#deployment)
     * [Docker](#docker)
     * [System Interfaces](#system-interfaces)
+    * [Instrumentation](#instrumentation)
 * [Module Reference](#module-reference)
     * [Life cycle of a module](#life-cycle-of-a-module)
     * [Tenant Interface](#tenant-interface)
@@ -601,7 +602,7 @@ before and after each step of execution of the request processing
 pipeline. Besides monitoring, instrumentation is crucial for the
 ability to quickly diagnose issues in the running system ("hot"
 debugging) and discovering performance bottlenecks (profiling). We are
-looking at established solutions in this regard: e.g. JMX, Dropwizard
+looking at established solutions in this regard: e.g. JMX, Micrometer
 Metrics, Graphite, etc.
 
 A multi-module system may provide a wide variety of metrics and an
@@ -2711,6 +2712,7 @@ These options are at the end of the command line:
 * `-hazelcast-config-cp` _file_ -- Read Hazelcast config from class path
 * `-hazelcast-config-file` _file_ -- Read Hazelcast config from local file
 * `-hazelcast-config-url` _url_ -- Read Hazelcast config from URL
+* `-enable-metrics` -- Enables the sending of various metrics to InfluxDB
 * `-cluster-host` _ip_ -- Vertx cluster host
 * `-cluster-port` _port_ -- Vertx cluster port
 
@@ -2938,6 +2940,26 @@ every 5 minutes and `POST /testb/2` every half hour.
 Note that the call made by Okapi will call auth-token to get a token
 for the tenant this module is enabled for. No user is involved in this.
 Use `modulePermissions` to grant permissions for the token.
+
+### Instrumentation
+
+Okapi pushes instrumentation data to an InfluxDB backend, from which
+they can be shown with something like Grafana. Vert.x pushes some numbers
+automatically, but various parts of Okapi push their own numbers explicitly,
+so we can classify by tenant or module. Individual
+modules may push their own numbers as well, as needed. It is hoped that they
+will use a key naming scheme that is close to what we do in Okapi.
+
+Enabling the metrics via `-enable-metrics` will start sending metrics to `localhost:8086`
+
+Follwing Java parameters can be used to config InfluxDB connection.
+* `influxUrl` - default to `http://localhost:8086`
+* `influxDbName` - default to `okapi`
+* `influxUser` - default to null
+* `influxPassword` - default to null
+
+For example: `java -DinfluxUrl=http://influx.yourdomain.io:8086 -jar okapi-core/target/okapi-core-fat.jar dev -enable-metrics` then metrics
+will be sent to `http://influx.yourdomain.io:8086`
 
 ## Module Reference
 

--- a/okapi-core/pom.xml
+++ b/okapi-core/pom.xml
@@ -47,6 +47,14 @@
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
+      <artifactId>vertx-micrometer-metrics</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-influx</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
       <artifactId>vertx-mongo-client</artifactId>
     </dependency>
     <dependency>
@@ -146,8 +154,8 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>3.3.3</version>
+      <artifactId>mockito-inline</artifactId>
+      <version>3.4.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/okapi-core/src/main/java/org/folio/okapi/MainDeploy.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainDeploy.java
@@ -25,6 +25,7 @@ import java.nio.file.Paths;
 import org.apache.logging.log4j.Logger;
 import org.folio.okapi.common.Messages;
 import org.folio.okapi.common.OkapiLogger;
+import org.folio.okapi.util.MetricsHelper;
 
 @java.lang.SuppressWarnings({"squid:S3776"})
 public class MainDeploy {
@@ -100,6 +101,14 @@ public class MainDeploy {
     return false;
   }
 
+  private void enableMetrics() {
+    String influxUrl = System.getProperty("influxUrl");
+    String influxDbName = System.getProperty("influxDbName");
+    String influxUserName = System.getProperty("influxUserName");
+    String influxPassword = System.getProperty("influxPassword");
+    MetricsHelper.config(vopt, influxUrl, influxDbName, influxUserName, influxPassword);
+  }
+
   private boolean parseOptions(String[] args, Handler<AsyncResult<Vertx>> fut) {
     int i = 0;
     String mode = null;
@@ -139,6 +148,8 @@ public class MainDeploy {
         clusterHost = args[++i];
       } else if ("-cluster-port".equals(args[i]) && i < args.length - 1) {
         clusterPort = Integer.parseInt(args[++i]);
+      } else if ("-enable-metrics".equals(args[i])) {
+        enableMetrics();
       } else if ("-conf".equals(args[i]) && i < args.length - 1) {
         if (readConf(args[++i], fut)) {
           return true;
@@ -172,7 +183,7 @@ public class MainDeploy {
         + "  -hazelcast-config-url url     Read Hazelcast config from URL\n"
         + "  -cluster-host ip              Vertx cluster host\n"
         + "  -cluster-port port            Vertx cluster port\n"
-    );
+        + "  -enable-metrics\n");
   }
 
   private void deployClustered(final Logger logger, Handler<AsyncResult<Vertx>> fut) {

--- a/okapi-core/src/main/java/org/folio/okapi/util/MetricsHelper.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/MetricsHelper.java
@@ -73,7 +73,7 @@ public class MetricsHelper {
     if (influxUserName != null) {
       influxDbOptions.setUserName(influxUserName);
     }
-    logger.log(Level.INFO, influxDbOptions.toJson().encodePrettily());
+    logger.info("Influx config: {}", influxDbOptions.toJson().encodePrettily());
     if (influxPassword != null) {
       influxDbOptions.setPassword(influxPassword);
     }

--- a/okapi-core/src/main/java/org/folio/okapi/util/MetricsHelper.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/MetricsHelper.java
@@ -15,6 +15,7 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
 import org.folio.okapi.bean.ModuleInstance;
 import org.folio.okapi.common.OkapiLogger;
@@ -72,7 +73,7 @@ public class MetricsHelper {
     if (influxUserName != null) {
       influxDbOptions.setUserName(influxUserName);
     }
-    logger.info(influxDbOptions.toJson().encodePrettily());
+    logger.log(Level.INFO, influxDbOptions.toJson().encodePrettily());
     if (influxPassword != null) {
       influxDbOptions.setPassword(influxPassword);
     }
@@ -151,9 +152,8 @@ public class MetricsHelper {
       return null;
     }
     String name = server ? METRICS_HTTP_SERVER_PROCESSING_TIME : METRICS_HTTP_CLIENT_RESPONSE_TIME;
-    boolean createPhaseTag = server ? false : true;
     Timer timer = Timer.builder(name)
-        .tags(createHttpTags(tenant, httpStatusCode, httpMethod, moduleInstance, createPhaseTag))
+        .tags(createHttpTags(tenant, httpStatusCode, httpMethod, moduleInstance, !server))
         .register(getRegistry());
     sample.stop(timer);
     return timer;

--- a/okapi-core/src/main/java/org/folio/okapi/util/MetricsHelper.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/MetricsHelper.java
@@ -1,0 +1,217 @@
+package org.folio.okapi.util;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.Timer.Sample;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.vertx.core.VertxOptions;
+import io.vertx.micrometer.MicrometerMetricsOptions;
+import io.vertx.micrometer.VertxInfluxDbOptions;
+import io.vertx.micrometer.backends.BackendRegistries;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.apache.logging.log4j.Logger;
+import org.folio.okapi.bean.ModuleInstance;
+import org.folio.okapi.common.OkapiLogger;
+
+/**
+ * Metrics handling.
+ */
+public class MetricsHelper {
+
+  private static final Logger logger = OkapiLogger.get();
+
+  private static final String METRICS_PREFIX = "org.folio.okapi";
+  private static final String METRICS_HTTP = METRICS_PREFIX + ".http";
+  private static final String METRICS_HTTP_SERVER = METRICS_HTTP + ".server";
+  private static final String METRICS_HTTP_CLIENT = METRICS_HTTP + ".client";
+  private static final String METRICS_HTTP_SERVER_PROCESSING_TIME = METRICS_HTTP_SERVER
+      + ".processingTime";
+  private static final String METRICS_HTTP_CLIENT_RESPONSE_TIME = METRICS_HTTP_CLIENT
+      + ".responseTime";
+  private static final String METRICS_HTTP_CLIENT_ERRORS = METRICS_HTTP_CLIENT
+      + ".errors";
+
+  private static final String TAG_HOST = "host";
+  private static final String TAG_TENANT = "tenant";
+  private static final String TAG_CODE = "code";
+  private static final String TAG_METHOD = "method";
+  private static final String TAG_MODULE = "module";
+  private static final String TAG_URL = "url";
+  private static final String TAG_PHASE = "phase";
+  private static final String TAG_EMPTY = "null";
+
+  static final String HOST_UNKNOWN = "unknown";
+
+  private static boolean enabled = false;
+  private static MeterRegistry registry;
+
+  private MetricsHelper() {
+  }
+
+  /**
+   * Config metrics options - specifically use InfluxDb micrometer options.
+   *
+   * @param vertxOptions   - {@link VertxOptions}
+   * @param influxUrl      - default to http://localhost:8086
+   * @param influxDbName   - default to okapi
+   * @param influxUserName - default to null
+   * @param influxPassword - default to null
+   */
+  public static void config(VertxOptions vertxOptions, String influxUrl,
+      String influxDbName, String influxUserName, String influxPassword) {
+    VertxInfluxDbOptions influxDbOptions = new VertxInfluxDbOptions()
+        .setEnabled(true)
+        .setUri(Optional.ofNullable(influxUrl).orElse("http://localhost:8086"))
+        .setDb(Optional.ofNullable(influxDbName).orElse("okapi"));
+    if (influxUserName != null) {
+      influxDbOptions.setUserName(influxUserName);
+    }
+    logger.info(influxDbOptions.toJson().encodePrettily());
+    if (influxPassword != null) {
+      influxDbOptions.setPassword(influxPassword);
+    }
+    vertxOptions.setMetricsOptions(new MicrometerMetricsOptions()
+        .setEnabled(true)
+        .setInfluxDbOptions(influxDbOptions));
+    enabled = true;
+  }
+
+  /**
+   * Return a {@link Sample} to help start timing a {@link Timer}.
+   *
+   * @return {@link Sample} or null if metrics is not enabled
+   */
+  public static Sample getTimerSample() {
+    return enabled ? Timer.start(getRegistry()) : null;
+  }
+
+  /**
+   * Record HTTP server processing time if metrics is enabled.
+   *
+   * @param sample         - {@link Sample} that tells the starting time
+   * @param tenant         - FOLIO tenant id
+   * @param httpStatusCode - HTTP response code to record
+   * @param httpMethod     - HTTP method to record
+   * @param moduleInstance - {@link ModuleInstance} provides some tag info
+   *
+   * @return {@link Timer} or null if metrics is not enabled
+   */
+  public static Timer recordHttpServerProcessingTime(Sample sample, String tenant,
+      int httpStatusCode, String httpMethod, ModuleInstance moduleInstance) {
+    return recordHttpTime(sample, tenant, httpStatusCode, httpMethod, moduleInstance, true);
+  }
+
+  /**
+   * Record HTTP client response time if metrics is enabled.
+   *
+   * @param sample         - {@link Sample} that tells the starting time
+   * @param tenant         - FOLIO tenant id
+   * @param httpStatusCode - HTTP response code to record
+   * @param httpMethod     - HTTP method to record
+   * @param moduleInstance - {@link ModuleInstance} provides some tag info
+   *
+   * @return {@link Timer} or null if metrics is not enabled
+   */
+  public static Timer recordHttpClientResponse(Sample sample, String tenant, int httpStatusCode,
+      String httpMethod, ModuleInstance moduleInstance) {
+    return recordHttpTime(sample, tenant, httpStatusCode, httpMethod, moduleInstance, false);
+  }
+
+  /**
+   * Record HTTP client error if metrics is enabled.
+   *
+   * @param tenant     - FOLIO tenant id
+   * @param httpMethod - HTTP method
+   * @param urlPath    - HTTP URL path
+   *
+   * @return {@link Counter} or null if metrics is not enabled
+   */
+  public static Counter recordHttpClientError(String tenant, String httpMethod, String urlPath) {
+    if (!enabled) {
+      return null;
+    }
+    Counter counter = Counter.builder(METRICS_HTTP_CLIENT_ERRORS)
+        .tag(TAG_TENANT, tenant)
+        .tag(TAG_METHOD, httpMethod)
+        .tag(TAG_URL, urlPath)
+        .register(getRegistry());
+    counter.increment();
+    return counter;
+  }
+
+  private static Timer recordHttpTime(Sample sample, String tenant, int httpStatusCode,
+      String httpMethod, ModuleInstance moduleInstance, boolean server) {
+    if (!enabled) {
+      return null;
+    }
+    String name = server ? METRICS_HTTP_SERVER_PROCESSING_TIME : METRICS_HTTP_CLIENT_RESPONSE_TIME;
+    boolean createPhaseTag = server ? false : true;
+    Timer timer = Timer.builder(name)
+        .tags(createHttpTags(tenant, httpStatusCode, httpMethod, moduleInstance, createPhaseTag))
+        .register(getRegistry());
+    sample.stop(timer);
+    return timer;
+  }
+
+  private static List<Tag> createHttpTags(String tenant, int httpStatusCode, String httpMethod,
+      ModuleInstance moduleInstance, boolean createPhaseTag) {
+    List<Tag> tags = new ArrayList<>();
+    tags.add(Tag.of(TAG_TENANT, Optional.of(tenant).orElse(TAG_EMPTY)));
+    tags.add(Tag.of(TAG_CODE, "" + httpStatusCode));
+    tags.add(Tag.of(TAG_METHOD, Optional.of(httpMethod).orElse(TAG_EMPTY)));
+    if (moduleInstance != null) {
+      tags.add(Tag.of(TAG_MODULE, moduleInstance.getModuleDescriptor().getId()));
+      // legacy case where module instance has no routing entry
+      if (moduleInstance.getRoutingEntry() != null) {
+        tags.add(Tag.of(TAG_URL, moduleInstance.getRoutingEntry().getStaticPath()));
+        if (createPhaseTag) {
+          tags.add(Tag.of(TAG_PHASE, moduleInstance.isHandler() ? "handler"
+              : moduleInstance.getRoutingEntry().getPhase()));
+        }
+      } else {
+        tags.add(Tag.of(TAG_URL, moduleInstance.getPath()));
+        tags.add(Tag.of(TAG_PHASE, moduleInstance.isHandler() ? "handler" : ""));
+      }
+    } else {
+      tags.add(Tag.of(TAG_MODULE, TAG_EMPTY));
+      tags.add(Tag.of(TAG_URL, TAG_EMPTY));
+      if (createPhaseTag) {
+        tags.add(Tag.of(TAG_PHASE, TAG_EMPTY));
+      }
+    }
+    return tags;
+  }
+
+  private static MeterRegistry getRegistry() {
+    if (registry == null) {
+      registry = Optional.ofNullable(BackendRegistries.getDefaultNow())
+          .orElse(new SimpleMeterRegistry());
+      registry.config().commonTags(TAG_HOST, getHost());
+    }
+    return registry;
+  }
+
+  static String getHost() {
+    try {
+      return InetAddress.getLocalHost().toString();
+    } catch (UnknownHostException e) {
+      logger.warn(e);
+    }
+    return HOST_UNKNOWN;
+  }
+
+  public static boolean isEnabled() {
+    return enabled;
+  }
+
+  public static void setEnabled(boolean enabled) {
+    MetricsHelper.enabled = enabled;
+  }
+
+}

--- a/okapi-core/src/main/java/org/folio/okapi/util/MetricsHelper.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/MetricsHelper.java
@@ -67,8 +67,8 @@ public class MetricsHelper {
       String influxDbName, String influxUserName, String influxPassword) {
     VertxInfluxDbOptions influxDbOptions = new VertxInfluxDbOptions()
         .setEnabled(true)
-        .setUri(Optional.ofNullable(influxUrl).orElse("http://localhost:8086"))
-        .setDb(Optional.ofNullable(influxDbName).orElse("okapi"));
+        .setUri(influxUrl == null ? "http://localhost:8086" : influxUrl)
+        .setDb(influxDbName == null ? "okapi" : influxDbName);
     if (influxUserName != null) {
       influxDbOptions.setUserName(influxUserName);
     }
@@ -161,9 +161,9 @@ public class MetricsHelper {
   private static List<Tag> createHttpTags(String tenant, int httpStatusCode, String httpMethod,
       ModuleInstance moduleInstance, boolean createPhaseTag) {
     List<Tag> tags = new ArrayList<>();
-    tags.add(Tag.of(TAG_TENANT, Optional.of(tenant).orElse(TAG_EMPTY)));
+    tags.add(Tag.of(TAG_TENANT, tenant == null ? TAG_EMPTY : tenant));
     tags.add(Tag.of(TAG_CODE, "" + httpStatusCode));
-    tags.add(Tag.of(TAG_METHOD, Optional.of(httpMethod).orElse(TAG_EMPTY)));
+    tags.add(Tag.of(TAG_METHOD, httpMethod == null ? TAG_EMPTY : httpMethod));
     if (moduleInstance != null) {
       tags.add(Tag.of(TAG_MODULE, moduleInstance.getModuleDescriptor().getId()));
       // legacy case where module instance has no routing entry
@@ -175,7 +175,7 @@ public class MetricsHelper {
         }
       } else {
         tags.add(Tag.of(TAG_URL, moduleInstance.getPath()));
-        tags.add(Tag.of(TAG_PHASE, moduleInstance.isHandler() ? "handler" : ""));
+        tags.add(Tag.of(TAG_PHASE, moduleInstance.isHandler() ? "handler" : TAG_EMPTY));
       }
     } else {
       tags.add(Tag.of(TAG_MODULE, TAG_EMPTY));

--- a/okapi-core/src/main/java/org/folio/okapi/util/MetricsHelper.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/MetricsHelper.java
@@ -15,7 +15,6 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
 import org.folio.okapi.bean.ModuleInstance;
 import org.folio.okapi.common.OkapiLogger;
@@ -73,7 +72,7 @@ public class MetricsHelper {
     if (influxUserName != null) {
       influxDbOptions.setUserName(influxUserName);
     }
-    logger.info("Influx config: {}", influxDbOptions.toJson().encodePrettily());
+    logger.info("Influx config: {}", () -> influxDbOptions.toJson().encodePrettily());
     if (influxPassword != null) {
       influxDbOptions.setPassword(influxPassword);
     }

--- a/okapi-core/src/main/java/org/folio/okapi/util/ProxyContext.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/ProxyContext.java
@@ -1,5 +1,6 @@
 package org.folio.okapi.util;
 
+import io.micrometer.core.instrument.Timer;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.web.RoutingContext;
@@ -42,6 +43,17 @@ public class ProxyContext {
 
   private final Messages messages = Messages.getInstance();
 
+  private Timer.Sample sample;
+  private ModuleInstance handlerModuleInstance;
+
+  public ModuleInstance getHandlerModuleInstance() {
+    return handlerModuleInstance;
+  }
+
+  public void setHandlerModuleInstance(ModuleInstance handlerModuleInstance) {
+    this.handlerModuleInstance = handlerModuleInstance;
+  }
+
   /**
    * Constructor to be used from proxy. Does not log the request, as we do not
    * know the tenant yet.
@@ -77,6 +89,7 @@ public class ProxyContext {
     nanoTimeStart = 0;
     timerId = null;
     handlerRes = 0;
+    this.sample = MetricsHelper.getTimerSample();
   }
 
   /**
@@ -242,6 +255,8 @@ public class ProxyContext {
   public void responseError(int code, String msg) {
     logResponse("okapi", msg, code);
     closeTimer();
+    MetricsHelper.recordHttpServerProcessingTime(this.sample, this.tenant, code,
+        this.ctx.request().method().name(), this.handlerModuleInstance);
     HttpResponse.responseError(ctx, code, msg);
   }
 
@@ -267,6 +282,10 @@ public class ProxyContext {
 
   public void trace(String msg) {
     logger.trace("{} {}", getReqId(), msg);
+  }
+
+  public Timer.Sample getSample() {
+    return sample;
   }
 
 }

--- a/okapi-core/src/test/java/org/folio/okapi/MainDeployTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/MainDeployTest.java
@@ -11,6 +11,7 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.apache.logging.log4j.Logger;
 import org.folio.okapi.common.OkapiLogger;
+import org.folio.okapi.util.MetricsHelper;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -323,4 +324,24 @@ public class MainDeployTest {
       });
     });
   }
+
+  @Test
+  public void testEnableMetrics(TestContext context) {
+    async = context.async();
+
+    String[] args = { "-enable-metrics" };
+
+    context.assertFalse(MetricsHelper.isEnabled());
+
+    MainDeploy d = new MainDeploy();
+    d.init(args, res -> {
+      vertx = res.succeeded() ? res.result() : null;
+      Assert.assertTrue("main1 " + res.cause(), res.succeeded());
+      context.assertTrue(res.succeeded());
+      context.assertTrue(MetricsHelper.isEnabled());
+      MetricsHelper.setEnabled(false);
+      async.complete();
+    });
+  }
+
 }

--- a/okapi-core/src/test/java/org/folio/okapi/util/MetricsHelperTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/MetricsHelperTest.java
@@ -22,7 +22,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
 
 @TestMethodOrder(OrderAnnotation.class)
-public class MetricsHelperTest {
+class MetricsHelperTest {
 
   @AfterAll
   static void disableMetrics() {

--- a/okapi-core/src/test/java/org/folio/okapi/util/MetricsHelperTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/MetricsHelperTest.java
@@ -1,0 +1,148 @@
+package org.folio.okapi.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import org.folio.okapi.bean.ModuleDescriptor;
+import org.folio.okapi.bean.ModuleInstance;
+import org.folio.okapi.bean.RoutingEntry;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Timer;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.JsonObject;
+
+@TestMethodOrder(OrderAnnotation.class)
+public class MetricsHelperTest {
+
+  @AfterAll
+  public static void disableMetrics() {
+    MetricsHelper.setEnabled(false);
+  }
+
+  @BeforeEach
+  public void enableMetrics() {
+    MetricsHelper.setEnabled(true);
+  }
+
+  @Test
+  @Order(1)
+  public void testMetricsNotEnabled() {
+    MetricsHelper.setEnabled(false);
+    assertNull(MetricsHelper.getTimerSample());
+    assertNull(MetricsHelper.recordHttpClientResponse(null, "a", 0, "b", null));
+    assertNull(MetricsHelper.recordHttpServerProcessingTime(null, "a", 0, "b", null));
+    assertNull(MetricsHelper.recordHttpClientError("a", "b", "c"));
+  }
+
+  @Test
+  public void testMetricsEnabled() {
+    assertNotNull(MetricsHelper.getTimerSample());
+  }
+
+  @Test
+  public void testConfig() {
+    VertxOptions vopt = new VertxOptions();
+    MetricsHelper.config(vopt, null, null, null, null);
+    verifyConfig(vopt, "http://localhost:8086", "okapi", null, null);
+    MetricsHelper.config(vopt, "a", "b", "c", "d");
+    verifyConfig(vopt, "a", "b", "c", "d");
+  }
+
+  @Test
+  public void testRecordHttpServerProcessingTime() {
+    Timer.Sample sample = MetricsHelper.getTimerSample();
+    // null ModuleInstance should be OK
+    Timer timer = MetricsHelper.recordHttpServerProcessingTime(sample, "a", 200, "GET", null);
+    assertEquals(1, timer.count());
+
+    ModuleInstance mi = createModuleInstance(true);
+    timer = MetricsHelper.recordHttpServerProcessingTime(sample, "a", 200, "GET", mi);
+    assertEquals(1, timer.count());
+  }
+
+  @Test
+  public void testRecordHttpClientResponseTime() {
+    Timer.Sample sample = MetricsHelper.getTimerSample();
+    // null ModuleInstance should be OK
+    Timer timer = MetricsHelper.recordHttpClientResponse(sample, "a", 200, "GET", null);
+    assertEquals(1, timer.count());
+    ModuleInstance mi = createModuleInstance(true);
+    timer = MetricsHelper.recordHttpClientResponse(sample, "a", 200, "GET", mi);
+    assertEquals(1, timer.count());
+
+    // change module instance routing entry type
+    mi = createModuleInstance(false);
+    timer = MetricsHelper.recordHttpClientResponse(sample, "a", 200, "GET", mi);
+    assertEquals(1, timer.count());
+
+    // legacy case where module instance has no routing entry
+    mi = createModuleInstanceWithoutRoutingEntry(true);
+    timer = MetricsHelper.recordHttpClientResponse(sample, "a", 200, "GET", mi);
+    assertEquals(1, timer.count());
+    mi = createModuleInstanceWithoutRoutingEntry(false);
+    timer = MetricsHelper.recordHttpClientResponse(sample, "a", 200, "GET", mi);
+    assertEquals(1, timer.count());
+  }
+
+  @Test
+  public void testRecordHttpClientError() {
+    Counter counter = MetricsHelper.recordHttpClientError("a", "GET", "/a");
+    assertEquals(1, counter.count());
+    // increment by one
+    MetricsHelper.recordHttpClientError("a", "GET", "/a");
+    assertEquals(2, counter.count());
+  }
+
+  @Test
+  public void testGetHost() {
+    assertNotEquals(MetricsHelper.HOST_UNKNOWN, MetricsHelper.getHost());
+    try (MockedStatic<InetAddress> mocked = Mockito.mockStatic(InetAddress.class)) {
+      mocked.when(InetAddress::getLocalHost).thenThrow(UnknownHostException.class);
+      assertEquals(MetricsHelper.HOST_UNKNOWN, MetricsHelper.getHost());
+    }
+  }
+
+  private ModuleInstance createModuleInstance(boolean handler) {
+    ModuleDescriptor md = new ModuleDescriptor();
+    md.setId("abc-1.0");
+    RoutingEntry re = new RoutingEntry();
+    re.setPath("/a");
+    re.setPhase("auth");
+    return new ModuleInstance(md, re, "/", HttpMethod.GET, handler);
+  }
+
+  private ModuleInstance createModuleInstanceWithoutRoutingEntry(boolean handler) {
+    ModuleDescriptor md = new ModuleDescriptor();
+    md.setId("abc-1.0");
+    return new ModuleInstance(md, null, "/", HttpMethod.GET, handler);
+  }
+
+  private void verifyConfig(VertxOptions vopt, String url, String db, String user, String pass) {
+    JsonObject jo = vopt.getMetricsOptions().toJson().getJsonObject("influxDbOptions");
+    assertEquals(url, jo.getString("uri"));
+    assertEquals(db, jo.getString("db"));
+    if (user == null) {
+      assertFalse(jo.containsKey("userName"));
+    } else {
+      assertEquals(user, jo.getString("userName"));
+    }
+    if (pass == null) {
+      assertFalse(jo.containsKey("password"));
+    } else {
+      assertEquals(pass, jo.getString("password"));
+    }
+  }
+
+}

--- a/okapi-core/src/test/java/org/folio/okapi/util/MetricsHelperTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/MetricsHelperTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-
 import org.folio.okapi.bean.ModuleDescriptor;
 import org.folio.okapi.bean.ModuleInstance;
 import org.folio.okapi.bean.RoutingEntry;
@@ -16,7 +15,6 @@ import org.mockito.Mockito;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
-
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
 import io.vertx.core.VertxOptions;
@@ -27,18 +25,18 @@ import io.vertx.core.json.JsonObject;
 public class MetricsHelperTest {
 
   @AfterAll
-  public static void disableMetrics() {
+  static void disableMetrics() {
     MetricsHelper.setEnabled(false);
   }
 
   @BeforeEach
-  public void enableMetrics() {
+  void enableMetrics() {
     MetricsHelper.setEnabled(true);
   }
 
   @Test
   @Order(1)
-  public void testMetricsNotEnabled() {
+  void testMetricsNotEnabled() {
     MetricsHelper.setEnabled(false);
     assertNull(MetricsHelper.getTimerSample());
     assertNull(MetricsHelper.recordHttpClientResponse(null, "a", 0, "b", null));
@@ -47,12 +45,12 @@ public class MetricsHelperTest {
   }
 
   @Test
-  public void testMetricsEnabled() {
+  void testMetricsEnabled() {
     assertNotNull(MetricsHelper.getTimerSample());
   }
 
   @Test
-  public void testConfig() {
+  void testConfig() {
     VertxOptions vopt = new VertxOptions();
     MetricsHelper.config(vopt, null, null, null, null);
     verifyConfig(vopt, "http://localhost:8086", "okapi", null, null);
@@ -61,7 +59,7 @@ public class MetricsHelperTest {
   }
 
   @Test
-  public void testRecordHttpServerProcessingTime() {
+  void testRecordHttpServerProcessingTime() {
     Timer.Sample sample = MetricsHelper.getTimerSample();
     // null ModuleInstance should be OK
     Timer timer = MetricsHelper.recordHttpServerProcessingTime(sample, "a", 200, "GET", null);
@@ -73,7 +71,7 @@ public class MetricsHelperTest {
   }
 
   @Test
-  public void testRecordHttpClientResponseTime() {
+  void testRecordHttpClientResponseTime() {
     Timer.Sample sample = MetricsHelper.getTimerSample();
     // null ModuleInstance should be OK
     Timer timer = MetricsHelper.recordHttpClientResponse(sample, "a", 200, "GET", null);
@@ -97,7 +95,7 @@ public class MetricsHelperTest {
   }
 
   @Test
-  public void testRecordHttpClientError() {
+  void testRecordHttpClientError() {
     Counter counter = MetricsHelper.recordHttpClientError("a", "GET", "/a");
     assertEquals(1, counter.count());
     // increment by one
@@ -106,7 +104,7 @@ public class MetricsHelperTest {
   }
 
   @Test
-  public void testGetHost() {
+  void testGetHost() {
     assertNotEquals(MetricsHelper.HOST_UNKNOWN, MetricsHelper.getHost());
     try (MockedStatic<InetAddress> mocked = Mockito.mockStatic(InetAddress.class)) {
       mocked.when(InetAddress::getLocalHost).thenThrow(UnknownHostException.class);

--- a/okapi-core/src/test/java/org/folio/okapi/util/MetricsHelperTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/MetricsHelperTest.java
@@ -46,6 +46,7 @@ class MetricsHelperTest {
 
   @Test
   void testMetricsEnabled() {
+    assertTrue(MetricsHelper.isEnabled());
     assertNotNull(MetricsHelper.getTimerSample());
   }
 
@@ -67,6 +68,10 @@ class MetricsHelperTest {
 
     ModuleInstance mi = createModuleInstance(true);
     timer = MetricsHelper.recordHttpServerProcessingTime(sample, "a", 200, "GET", mi);
+    assertEquals(1, timer.count());
+
+    // null tenant and httpMethod
+    timer = MetricsHelper.recordHttpServerProcessingTime(sample, null, 200, null, mi);
     assertEquals(1, timer.count());
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -63,9 +63,10 @@
 
       <!-- START: versions that depend on the vertx-stack-depchain version -->
       <dependency>
-        <groupId>io.dropwizard.metrics</groupId>
-        <artifactId>metrics-graphite</artifactId>
-        <version>4.0.2</version>  <!-- https://github.com/vert-x3/vertx-dropwizard-metrics/blob/master/pom.xml -->
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-registry-influx</artifactId>
+        <version>1.4.2</version>  <!-- https://github.com/vert-x3/vertx-micrometer-metrics/blob/master/pom.xml -->
+        <!-- use 1.4.2 because 1.5.2 in above POM link does not work -->
       </dependency>
       <dependency>
         <groupId>com.hazelcast</groupId>


### PR DESCRIPTION
Please see [OKAPI-860](https://issues.folio.org/browse/OKAPI-860). Following meters (and tags) are defined and implemented for Okapi HTTP proxy calls. There is no error meter defined for server side because that is covered by server processingTime meter. The naming convention follows [Vert.x core tools metrics](https://vertx.io/docs/vertx-micrometer-metrics/java/#_vert_x_core_tools_metrics). Note, the dot in the name is converted to _ in InfluxDB automatically.

- org.folio.okapi.http.server.processingTime - metrics type is Micrometer Timer. Tags are below
  - host - Okapi instance. An example value: ip-172-31-19-200.ec2.internal/172.31.19.200
  - tenant - FOLIO tenant id. An example value: diku
  - code - HTTP response code. An example value: 200
  - method - HTTP request method. An example value: GET
  - module - FOLIO module id. An example value: mod-authtoken-2.6.0-SNAPSHOT.73
  - url - HTTP request url as defined in module descriptor. An example value: /users/ {id}
- org.folio.okapi.http.client.responseTime - metrics type is Micrometer Timer. Tags are below
  - all tags defined above plus
  - phase - FOLIO proxy phase. An example value: auth. The default value is handler
- org.folio.okapi.http.client.errors - metrics type is Micrometer Counter. Tags are below
  - tags: host, tenant, method, and url