### PR TITLE
Okapi 879 jdk11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,7 @@ buildMvn {
   publishAPI = 'yes'
   mvnDeploy = 'yes'
   runLintRamlCop = 'yes'
+  buildNode = 'jenkins-agent-java11'
 
   doDocker = {
     buildJavaDocker {

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ System requirements
 
 The Okapi software has the following compile-time dependencies:
 
-* Java 8
+* Java 11
 
 * Apache Maven 3.3.x or higher
 

--- a/debian/control
+++ b/debian/control
@@ -3,14 +3,14 @@ Section: net
 Priority: extra
 Maintainer: Index Data <support@indexdata.com>
 Build-Depends: debhelper (>=9),
-        openjdk-8-jdk,
+        openjdk-11-jdk,
         maven (>=3.3)
 Standards-Version: 3.9.6
 Homepage: https://github.com/folio-org/okapi
 
 Package: okapi
 Architecture: all
-Depends: openjdk-8-jdk | openjdk-8-jre,
+Depends: openjdk-11-jdk | openjdk-11-jre,
          jq,
          adduser,
          postgresql-client-common

--- a/okapi-core/Dockerfile
+++ b/okapi-core/Dockerfile
@@ -1,4 +1,4 @@
-FROM folioci/alpine-jre-openjdk8:latest
+FROM folioci/alpine-jre-openjdk11:latest
 
 ENV VERTICLE_FILE okapi-core-fat.jar
 

--- a/pom.xml
+++ b/pom.xml
@@ -135,10 +135,9 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
+        <version>3.8.1</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <release>11</release>
           <compilerArgument>-Xlint:unchecked</compilerArgument>
         </configuration>
       </plugin>


### PR DESCRIPTION
Tested building Okapi with JDK 11 and it seems fine. Since this PR changes the compile level to 11, we have to wait until Jenkins building environment is updated.