### PR TITLE
OKAPI-882, OKAPI-884: Password in log, variable expansion

### DIFF
--- a/doc/guide.md
+++ b/doc/guide.md
@@ -2799,14 +2799,17 @@ environment variable name and value respectively.
 
 When launching a module, a TCP listening port is assigned. The module
 should be listening on that port after successful deployment (serving
-HTTP requests).  The port is passed as `%p` in the value of properties
-`exec` and `cmdlineStart`. For Docker deployment, Okapi will map the
-exposed port (`EXPOSE`) to the dynamically assigned port.
+HTTP requests).  The port is passed as `%p` in the `exec` value,
+`cmdlineStart` value, and the `dockerArgs` properties values.
+For Docker deployment, Okapi will map the exposed port (`EXPOSE`) to
+the dynamically assigned port.
 
 When starting, Docker modules can be accessed from Okapi at the host
 given by setting `containerHost` - defaults to `localhost`.
 The value of `containerHost` can be referred to as `%c` in
-`dockerArgs` of the deployment.
+`dockerArgs` properties values of the deployment.
+
+Use `%%` for a literal `%` in `dockerArgs` properties values.
 
 It is also possible to refer to an already-launched process (maybe
 running in your development IDE), by POSTing a DeploymentDescriptor to

--- a/okapi-core/pom.xml
+++ b/okapi-core/pom.xml
@@ -121,6 +121,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>

--- a/okapi-core/src/main/java/org/folio/okapi/bean/AnyDescriptor.java
+++ b/okapi-core/src/main/java/org/folio/okapi/bean/AnyDescriptor.java
@@ -18,7 +18,8 @@ public class AnyDescriptor {
   }
 
   @JsonAnySetter
-  public void set(String fieldName, Object value) {
+  public AnyDescriptor set(String fieldName, Object value) {
     this.properties.put(fieldName, value);
+    return this;
   }
 }

--- a/okapi-core/src/main/java/org/folio/okapi/bean/EnvEntry.java
+++ b/okapi-core/src/main/java/org/folio/okapi/bean/EnvEntry.java
@@ -8,6 +8,14 @@ public class EnvEntry {
   private String value;
   private String description;
 
+  public EnvEntry() {
+  }
+
+  public EnvEntry(String name, String value) {
+    this.name = name;
+    this.value = value;
+  }
+
   public String getName() {
     return name;
   }

--- a/okapi-core/src/main/java/org/folio/okapi/util/VariableSubstitutor.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/VariableSubstitutor.java
@@ -1,0 +1,107 @@
+package org.folio.okapi.util;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Substitute percent variables like %p, %c and %%. The percent variable name
+ * consists of a percent character and the following character.
+ */
+public final class VariableSubstitutor {
+  private VariableSubstitutor() {
+  }
+
+  /**
+   * Return {@code original} with percent variables replaced.
+   *
+   * <p>Replace %p by {@code valueP}, %c by {@code valueC}, %% by % and
+   * a percent sign followed by any other character by an empty string.
+   *
+   * <p>If valueP or valueC is null its replacement is an empty string.
+   *
+   * <p>Substitutions will not be substituted again:
+   *
+   * <p>{@code replace("%%p %%c %p %c", "p=%c", "c=%p") = "%p %c p=%c c=%p"}
+   */
+  public static String replace(String original, String valueP, String valueC) {
+    if (original == null) {
+      return null;
+    }
+    int pos = original.indexOf('%');
+    if (pos == -1) {
+      return original;
+    }
+    String p = valueP == null ? "" : valueP;
+    String c = valueC == null ? "" : valueC;
+    StringBuilder result = new StringBuilder(original.length() + c.length() + p.length());
+    result.append(original, 0, pos);
+    boolean isVariable = false;
+    for ( ; pos < original.length(); pos++) {
+      char current = original.charAt(pos);
+      if (! isVariable) {
+        if (current == '%') {
+          isVariable = true;
+        } else {
+          result.append(current);
+        }
+        continue;
+      }
+      isVariable = false;
+      switch (current) {
+        case 'p':
+          result.append(p);
+          break;
+        case 'c':
+          result.append(c);
+          break;
+        case '%':
+          result.append('%');
+          break;
+        default:
+          // replace undefined % variable by empty string
+      }
+    }
+    return result.toString();
+  }
+
+  /**
+   * Replace percent variables in each String that is an JsonArray element
+   * or a JsonObject value by using {@link #replace(String, String, String)}.
+   * No replacement in JsonObject keys.
+   *
+   * <p>Replace within the complete JSON tree of {@code json}.
+   */
+  public static void replace(JsonArray json, String valueP, String valueC) {
+    int n = json.size();
+    for (int i = 0; i < n; i++) {
+      Object value = json.getValue(i);
+      if (value instanceof JsonArray) {
+        replace((JsonArray) value, valueP, valueC);
+      } else if (value instanceof JsonObject) {
+        replace((JsonObject) value, valueP, valueC);
+      } else if (value instanceof String) {
+        json.set(i, replace((String) value, valueP, valueC));
+      }
+    }
+  }
+
+  /**
+   * Replace percent variables in each String that is an JsonArray element
+   * or a JsonObject value by using {@link #replace(String, String, String)}.
+   * No replacement in JsonObject keys.
+   *
+   * <p>Replace within the complete JSON tree of {@code json}.
+   */
+  public static void replace(JsonObject json, String valueP, String valueC) {
+    json.forEach(entry -> {
+      Object value = entry.getValue();
+      if (value instanceof JsonArray) {
+        replace((JsonArray) value, valueP, valueC);
+      } else if (value instanceof JsonObject) {
+        replace((JsonObject) value, valueP, valueC);
+      } else if (value instanceof String) {
+        entry.setValue(replace((String) value, valueP, valueC));
+      }
+    });
+  }
+}

--- a/okapi-core/src/test/java/org/folio/okapi/util/VariableSubstitutorTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/VariableSubstitutorTest.java
@@ -1,0 +1,64 @@
+package org.folio.okapi.util;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class VariableSubstitutorTest implements WithAssertions {
+  @ParameterizedTest
+  @CsvSource({
+      ",              ,     ,     ",
+      "'',            ,     ,     ''",
+      "p=%p and c=%c, ,     ,     p= and c=",
+      "%,             a,    bbb,  ''",
+      "%p,            a,    bbb,  a",
+      "%c,            a,    bbb,  bbb",
+      "%x,            a,    bbb,  ''",
+      "%%,            a,    bbb,  %",
+      "%%p %%c %p %c, p=%c, c=%p, %p %c p=%c c=%p",
+  })
+  void string(String original, String p, String c, String expected) {
+    assertThat(VariableSubstitutor.replace(original, p, c)).isEqualTo(expected);
+  }
+
+  @Test
+  void jsonArray() {
+    JsonArray jsonArray = new JsonArray()
+        .add("a %p")
+        .add(new JsonObject().put("key", "b %c").put("key2", new JsonArray().add("b2 %p")))
+        .add("c %c")
+        .add(new JsonArray().add("d %p"))
+        .add(6)
+        .add("e %p");
+    VariableSubstitutor.replace(jsonArray, "1234", "8.8.8.8");
+    assertThat(jsonArray).isEqualTo(new JsonArray()
+        .add("a 1234")
+        .add(new JsonObject().put("key", "b 8.8.8.8").put("key2", new JsonArray().add("b2 1234")))
+        .add("c 8.8.8.8")
+        .add(new JsonArray().add("d 1234"))
+        .add(6)
+        .add("e 1234"));
+  }
+
+  @Test
+  void jsonObject() {
+    JsonObject jsonObject = new JsonObject()
+        .put("a %p", "a %p")
+        .put("b %p", new JsonArray().add("b %c").add(new JsonObject().put("key", "b2 %p")))
+        .put("c %p", "c %p")
+        .put("d %c", new JsonObject().put("key", "b %c"))
+        .put("e %c", 6)
+        .put("f %p", "f %p");
+    VariableSubstitutor.replace(jsonObject, "1234", "8.8.8.8");
+    assertThat(jsonObject).isEqualTo(new JsonObject()
+        .put("a %p", "a 1234")
+        .put("b %p", new JsonArray().add("b 8.8.8.8").add(new JsonObject().put("key", "b2 1234")))
+        .put("c %p", "c 1234")
+        .put("d %c", new JsonObject().put("key", "b 8.8.8.8"))
+        .put("e %c", 6)
+        .put("f %p", "f 1234"));
+  }
+}

--- a/okapi-test-module/Dockerfile
+++ b/okapi-test-module/Dockerfile
@@ -1,12 +1,15 @@
 ###
 # vert.x docker example using a Java verticle packaged as a fatjar
 # To build:
-#  docker build -t okapi-test-module .
-# To run:
+#   docker build -t okapi-test-module .
+# To run directly:
 #   docker run -t -i -p 8080:8080 okapi-test-module
+# To let okapi run it:
+#   curl -w '\n' -D - -d @ModuleDescriptor.json http://localhost:9130/_/proxy/modules
+#   curl -w '\n' -D - -d '{"srvcId":"test-basic-1.0.0", "nodeId":"localhost"}' http://localhost:9130/_/discovery/modules
 ###
 
-FROM java:8
+FROM folioci/alpine-jre-openjdk11:latest
 
 # Set the location of the verticles
 ENV VERTICLE_HOME /usr/verticles

--- a/okapi-test-module/Dockerfile
+++ b/okapi-test-module/Dockerfile
@@ -5,7 +5,7 @@
 # To run directly:
 #   docker run -t -i -p 8080:8080 okapi-test-module
 # To let okapi run it:
-#   curl -w '\n' -D - -d @ModuleDescriptor.json http://localhost:9130/_/proxy/modules
+#   curl -w '\n' -D - -d @descriptors/ModuleDescriptor-dockerImage.json http://localhost:9130/_/proxy/modules
 #   curl -w '\n' -D - -d '{"srvcId":"test-basic-1.0.0", "nodeId":"localhost"}' http://localhost:9130/_/discovery/modules
 ###
 

--- a/okapi-test-module/ModuleDescriptor.json
+++ b/okapi-test-module/ModuleDescriptor.json
@@ -1,0 +1,21 @@
+{
+  "id": "test-basic-1.0.0",
+  "name": "Okapi test module",
+  "provides": [
+    {
+      "id": "test-basic",
+      "version": "2.2",
+      "handlers": [
+        {
+          "methods": [ "GET", "POST" ],
+          "pathPattern": "/testb",
+          "permissionsRequired": [ "test-basic.get.list" ]
+        }
+      ]
+    }
+  ],
+  "requires": [],
+  "launchDescriptor": {
+    "dockerImage": "okapi-test-module"
+  }
+}

--- a/okapi-test-module/descriptors/ModuleDescriptor-dockerImage.json
+++ b/okapi-test-module/descriptors/ModuleDescriptor-dockerImage.json
@@ -9,7 +9,18 @@
         {
           "methods": [ "GET", "POST" ],
           "pathPattern": "/testb",
-          "permissionsRequired": [ "test-basic.get.list" ]
+          "permissionsRequired": []
+        }
+      ]
+    },
+    {
+      "id": "recurse",
+      "version": "1.0",
+      "handlers": [
+        {
+          "methods": [ "GET" ],
+          "pathPattern": "/recurse",
+          "permissionsRequired": []
         }
       ]
     }
@@ -19,3 +30,4 @@
     "dockerImage": "okapi-test-module"
   }
 }
+


### PR DESCRIPTION
Okapi passes environment variables like DB_PASSWORD=mysecret
to Docker to deploy a module. These variables should be
suppressed in the log. (OKAPI-882)

Okapi expands the %p and %c variables in the complete JSON.
It should expand %p in exec, cmdlineStart and dockerArgs only,
and expand %c in dockerArgs only. (OKAPI-884)

For dockerArgs introduce %% to allow literal %.