### PR TITLE
Enable .deb packaging in the okapi pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library ('folio_jenkins_shared_libs@buildDeb') _
+@Library ('folio_jenkins_shared_libs') _
 
 buildMvn {
   publishModDescriptor = 'no'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-
+@Library ('folio_jenkins_shared_libs@buildDeb') _
 
 buildMvn {
   publishModDescriptor = 'no'
@@ -6,6 +6,7 @@ buildMvn {
   mvnDeploy = 'yes'
   runLintRamlCop = 'yes'
   buildNode = 'jenkins-agent-java11'
+  buildDeb = true
 
   doDocker = {
     buildJavaDocker {


### PR DESCRIPTION
Set 'buildDeb= true' option in Jenkinsfile to automatically build .deb package for okapi releases. 