### PR TITLE
update java check for openjdk-11 in okapi startup script

### DIFF
--- a/dist/okapi.sh
+++ b/dist/okapi.sh
@@ -141,13 +141,6 @@ java_check() {
       echo "Could not find any executable java binary."
       echo "Install java in your PATH or set JAVA_HOME"
       exit 1
-   else
-      VERSION=$("$JAVA" -version 2>&1 | awk -F '"' '/version/ { print $2 }' \
-              | awk -F '.' '{ print $1 }')
-      if [ "$VERSION" -lt "11" ];  then
-         echo "Java version 11 or higher is required."
-         exit 1
-      fi
    fi
 }  # end java_check
 

--- a/dist/okapi.sh
+++ b/dist/okapi.sh
@@ -143,10 +143,10 @@ java_check() {
       exit 1
    else
       VERSION=$("$JAVA" -version 2>&1 | awk -F '"' '/version/ { print $2 }' \
-              | awk -F '.' '{ print $2 }')
-      if [ "$VERSION" -lt "8" ];  then
-         echo "Java version 8 or higher is required."
-         exit 0
+              | awk -F '.' '{ print $1 }')
+      if [ "$VERSION" -lt "11" ];  then
+         echo "Java version 11 or higher is required."
+         exit 1
       fi
    fi
 }  # end java_check


### PR DESCRIPTION
The okapi startup script, okapi.sh, needs to be updated to check for openJDK-11.   The version check itself also needs to be updated to reflect the different format that openJDK-11 outputs with 'java -version'   With openJDK-8,  the version would be reported as '1.8.x'.   With openJDK-11, the format has changed to '11.x.x'.  