### PR TITLE
OkapiClient: use WebClient rather than HttpClient OKAPI-896

### DIFF
--- a/okapi-common/pom.xml
+++ b/okapi-common/pom.xml
@@ -31,6 +31,10 @@
       <artifactId>vertx-web</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web-client</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.z3950.zing</groupId>
       <artifactId>cql-java</artifactId>
       <version>1.13</version>


### PR DESCRIPTION
This makes OkapiClient simpler and allows the code to be compatible with
both Vert.x 4 and Vert.x 3.9 series.