### PR TITLE
OKAPI-914 Use "id" keyword in ModuleDescriptor JSON Schema

### DIFF
--- a/okapi-core/src/main/raml/DeploymentDescriptor.json
+++ b/okapi-core/src/main/raml/DeploymentDescriptor.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "DeploymentDescriptor.json",
   "title": "DeploymentDescriptor",
   "description" : "Module deployment information. There are two modes: deployment managed by Okapi (with nodeId specified) and remote module (with URL specified).",
   "type": "object",

--- a/okapi-core/src/main/raml/DeploymentDescriptorList.json
+++ b/okapi-core/src/main/raml/DeploymentDescriptorList.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "DeploymentDescriptorList.json",
   "title": "DeploymentDescriptorList",
   "description": "Deployment information list",
   "type": "array",

--- a/okapi-core/src/main/raml/EnvEntry.json
+++ b/okapi-core/src/main/raml/EnvEntry.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "EnvEntry.json",
   "title": "EnvEntry",
   "description": "Environment Variable",
   "type": "object",

--- a/okapi-core/src/main/raml/EnvEntryList.json
+++ b/okapi-core/src/main/raml/EnvEntryList.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "EnvEntryList.json",
   "title": "EnvEntryList",
   "description": "List of environment variables",
   "type": "array",

--- a/okapi-core/src/main/raml/HealthDescriptor.json
+++ b/okapi-core/src/main/raml/HealthDescriptor.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "HealthDescriptor.json",
   "title": "HealthDescriptor",
   "description": "Health for an instance",
   "type": "object",

--- a/okapi-core/src/main/raml/HealthDescriptorList.json
+++ b/okapi-core/src/main/raml/HealthDescriptorList.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "HealthDescriptorList.json",
   "title": "HealthDescriptorList",
   "description": "List of health descriptors",
   "type": "array",

--- a/okapi-core/src/main/raml/HealthStatus.json
+++ b/okapi-core/src/main/raml/HealthStatus.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "HealthStatus.json",
   "title": "Health for module as seen from proxy",
   "description": "Proxy health status",
   "type": "object",

--- a/okapi-core/src/main/raml/HealthStatusList.json
+++ b/okapi-core/src/main/raml/HealthStatusList.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "HealthStatusList.json",
   "title": "HealthStatusList",
   "description": "Health for each module as seen from proxy",
   "type": "array",

--- a/okapi-core/src/main/raml/InstallJob.json
+++ b/okapi-core/src/main/raml/InstallJob.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "InstallJob.json",
   "title": "InstallJob",
   "description": "Install job",
   "type": "object",

--- a/okapi-core/src/main/raml/InstallJobList.json
+++ b/okapi-core/src/main/raml/InstallJobList.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "InstallJobList.json",
   "title": "InstallJobList",
   "description": "List of install jobs",
   "type": "array",

--- a/okapi-core/src/main/raml/InterfaceDescriptor.json
+++ b/okapi-core/src/main/raml/InterfaceDescriptor.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "InterfaceDescriptor.json",
   "title": "InterfaceDescriptor",
   "description": "An interface that a module can provide",
   "type": "object",

--- a/okapi-core/src/main/raml/InterfaceList.json
+++ b/okapi-core/src/main/raml/InterfaceList.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "InterfaceList.json",
   "title": "InterfaceList",
   "description": "Interface List",
   "type": "array",

--- a/okapi-core/src/main/raml/InterfaceReference.json
+++ b/okapi-core/src/main/raml/InterfaceReference.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "InterfaceReference.json",
   "title": "InterfaceReference",
   "description": "A reference to an interfaceDescriptor, by name and version",
   "type": "object",

--- a/okapi-core/src/main/raml/LaunchDescriptor.json
+++ b/okapi-core/src/main/raml/LaunchDescriptor.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "LaunchDescriptor.json",
   "title": "LaunchDescriptor",
   "description": "Specifies how a module is deployed and undeployed",
   "type": [ "object", "null" ],

--- a/okapi-core/src/main/raml/ModuleDescriptor.json
+++ b/okapi-core/src/main/raml/ModuleDescriptor.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "ModuleDescriptor.json",
   "title": "ModuleDescriptor",
   "description": "A FOLIO Module",
   "type": "object",

--- a/okapi-core/src/main/raml/ModuleList.json
+++ b/okapi-core/src/main/raml/ModuleList.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "ModuleList.json",
   "title": "ModuleList",
   "description": "List of Module Descriptors",
   "type": "array",

--- a/okapi-core/src/main/raml/NodeDescriptor.json
+++ b/okapi-core/src/main/raml/NodeDescriptor.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "NodeDescriptor.json",
   "title": "NodeDescriptor",
   "description": "Deployment node information",
   "type": "object",

--- a/okapi-core/src/main/raml/NodeDescriptorList.json
+++ b/okapi-core/src/main/raml/NodeDescriptorList.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "NodeDescriptorList.json",
   "title": "NodeDescriptorList",
   "description": "List of Nodes",
   "type": "array",

--- a/okapi-core/src/main/raml/Permission.json
+++ b/okapi-core/src/main/raml/Permission.json
@@ -1,4 +1,5 @@
 {
+  "id": "Permission.json",
   "title": "Permissions Definition Schema",
   "description": "Permission entity",
   "type": "object",

--- a/okapi-core/src/main/raml/Permission.json
+++ b/okapi-core/src/main/raml/Permission.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "id": "Permission.json",
   "title": "Permissions Definition Schema",
   "description": "Permission entity",

--- a/okapi-core/src/main/raml/PullDescriptor.json
+++ b/okapi-core/src/main/raml/PullDescriptor.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "PullDescriptor.json",
   "title": "PullDescriptor",
   "description": "Information controlling the pull facility",
   "type": "object",

--- a/okapi-core/src/main/raml/RoutingEntry.json
+++ b/okapi-core/src/main/raml/RoutingEntry.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "RoutingEntry.json",
   "title": "RoutingEntry",
   "description": "Okapi proxy routing entry",
   "type": "object",

--- a/okapi-core/src/main/raml/TenantDescriptor.json
+++ b/okapi-core/src/main/raml/TenantDescriptor.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "TenantDescriptor.json",
   "title": "TenantDescriptor",
   "description": "Tenant information",
   "type": "object",

--- a/okapi-core/src/main/raml/TenantList.json
+++ b/okapi-core/src/main/raml/TenantList.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "TenantList.json",
   "title": "TenantList",
   "description": "List of Tenants",
   "type": "array",

--- a/okapi-core/src/main/raml/TenantModuleDescriptor.json
+++ b/okapi-core/src/main/raml/TenantModuleDescriptor.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "TenantModuleDescriptor.json",
   "title": "TenantModuleDescriptor",
   "description": "Module transitions",
   "type": "object",

--- a/okapi-core/src/main/raml/TenantModuleDescriptorList.json
+++ b/okapi-core/src/main/raml/TenantModuleDescriptorList.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "TenantModuleDescriptorList.json",
   "title": "TenantModuleDescriptorList",
   "description": "List of module transitions",
   "type": "array",

--- a/okapi-core/src/main/raml/UiModuleDescriptor.json
+++ b/okapi-core/src/main/raml/UiModuleDescriptor.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "UiModuleDescriptor.json",
   "title": "UiModuleDescriptor",
   "description": "UI Module description",
   "type": ["object", "null"],


### PR DESCRIPTION
Refer to [OKAPI-914](https://issues.folio.org/browse/OKAPI-914).

Enables the use of stand-alone '[ajv](https://github.com/ajv-validator/ajv)' schema validator, as well as other tools.