### PR TITLE
Fix Okapi Docker deployment URL/port mismatch on restart OKAPI-915

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/service/impl/DockerModuleHandle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/service/impl/DockerModuleHandle.java
@@ -297,7 +297,7 @@ public class DockerModuleHandle implements ModuleHandle {
       j.put("Cmd", a);
     }
     if (dockerArgs != null) {
-      JsonObject dockerArgsJson = new JsonObject(dockerArgs.properties());
+      JsonObject dockerArgsJson = new JsonObject(dockerArgs.properties()).copy();
       VariableSubstitutor.replace(dockerArgsJson, Integer.toString(hostPort), containerHost);
       j.mergeIn(dockerArgsJson);
     }

--- a/okapi-core/src/test/java/org/folio/okapi/service/impl/DockerModuleHandleTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/service/impl/DockerModuleHandleTest.java
@@ -363,5 +363,6 @@ public class DockerModuleHandleTest implements WithAssertions {
         .contains("\"%p\" : \"9232\"")
         .doesNotContain("foobar")  // no env values in the log because they may contain credentials
         .doesNotContain("uvwxyz");
+    Assert.assertEquals(launchDescriptor.getDockerArgs().properties().get("%p"), "%p");
   }
 }


### PR DESCRIPTION
Avoid tampering with dockerArgs. The LaunchDescriptor must not
be modified by Docker Deployment.. The %p-things and other must be
preserved. If not the port is not subsituted upon restart.