### PR TITLE
Ignore pull image failure OKAPI-920

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/service/impl/DockerModuleHandle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/service/impl/DockerModuleHandle.java
@@ -367,7 +367,7 @@ public class DockerModuleHandle implements ModuleHandle {
   @Override
   public Future<Void> start() {
     if (dockerPull) {
-      return pullImage().compose(x -> prepareContainer());
+      return pullImage().onComplete(x -> prepareContainer());
     }
     return prepareContainer();
   }


### PR DESCRIPTION
This makes Okapi ignore pull error as earlier versions of Okapi. If the image is not locally cached, it will fail anyway later.