### PR TITLE
OKAPI-921 skip token cache if no request token is present

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -213,8 +213,7 @@ public class ProxyService {
 
     String pathComponent = pathPattern == null ? req.path() : pathPattern;
 
-    CacheEntry cached = tokenCache == null ? null
-        : tokenCache.get(tenant, req.method().name(),
+    CacheEntry cached = tokenCache.get(tenant, req.method().name(),
             pathComponent, req.getHeader(XOkapiHeaders.USER_ID),
             token);
 

--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -203,9 +203,20 @@ public class ProxyService {
    */
   private boolean checkTokenCache(String tenant, HttpServerRequest req, String pathPattern,
       ModuleInstance mi) {
-    CacheEntry cached =
-        tokenCache.get(tenant, req.method().name(), pathPattern == null ? req.path() : pathPattern,
-            req.getHeader(XOkapiHeaders.USER_ID), req.headers().get(XOkapiHeaders.TOKEN));
+    String token = req.headers().get(XOkapiHeaders.TOKEN);
+    if (token == null) {
+      mi.setAuthToken(null);
+      mi.setUserId(null);
+      mi.setPermissions(null);
+      return false;
+    }
+
+    String pathComponent = pathPattern == null ? req.path() : pathPattern;
+
+    CacheEntry cached = tokenCache == null ? null
+        : tokenCache.get(tenant, req.method().name(),
+            pathComponent, req.getHeader(XOkapiHeaders.USER_ID),
+            token);
 
     if (cached != null) {
       mi.setAuthToken(cached.token);
@@ -539,13 +550,17 @@ public class ProxyService {
         }
 
         mi.setAuthToken(tok);
-        tokenCache.put(pc.getTenant(),
+
+        String originalToken = req.getHeader(XOkapiHeaders.TOKEN);
+        if (originalToken != null) {
+          tokenCache.put(pc.getTenant(),
             req.method().name(),
             pathPattern == null ? req.path() : pathPattern,
             res.getHeader(XOkapiHeaders.USER_ID),
             res.getHeader(XOkapiHeaders.PERMISSIONS),
-            req.getHeader(XOkapiHeaders.TOKEN),
+            originalToken,
             tok);
+        }
       }
     }
     MetricsHelper.recordCodeExecutionTime(sample, "ProxyService.authResponse");

--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -554,12 +554,12 @@ public class ProxyService {
         String originalToken = req.getHeader(XOkapiHeaders.TOKEN);
         if (originalToken != null) {
           tokenCache.put(pc.getTenant(),
-            req.method().name(),
-            pathPattern == null ? req.path() : pathPattern,
-            res.getHeader(XOkapiHeaders.USER_ID),
-            res.getHeader(XOkapiHeaders.PERMISSIONS),
-            originalToken,
-            tok);
+              req.method().name(),
+              pathPattern == null ? req.path() : pathPattern,
+              res.getHeader(XOkapiHeaders.USER_ID),
+              res.getHeader(XOkapiHeaders.PERMISSIONS),
+              originalToken,
+              tok);
         }
       }
     }


### PR DESCRIPTION
## Overview
instead of explicitly incorporating things like tenant and userId into the cache key we use the entire token in the request as part of the cache key since it includes this information. In doing so, we need to ensure that we don't allow cache keys w/ token=null. See [OKAPI-921](https://issues.folio.org/browse/OKAPI-921)

Additional context: [FOLIO-2839](https://issues.folio.org/browse/FOLIO-2839)