### PR TITLE
Upgrade junit-bom from 5.6.2 to 5.7.0 OKAPI-923

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>5.6.2</version>
+        <version>5.7.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Version 5.7.0 fixes version check for JUnit4.

https://junit.org/junit5/docs/5.7.0/release-notes/index.html#new-features-and-improvements-3