### PR TITLE
Docker pull with authenticated user OKAPI-912

### DIFF
--- a/doc/guide.md
+++ b/doc/guide.md
@@ -2752,8 +2752,9 @@ with a path like in `https://folio.example.com/okapi`.
 is. Defaults to `unix:///var/run/docker.sock`.
 * `dockerRegistries`: List of registries to use for Docker image pull. The
 value is a JSON array of objects where each object may have the following properties
-`username`, `password`, `email`, `serveraddress` and `registry`. The first 4 properties
-are passed as autentication to the Docker registry - refer to
+`username`, `password`, `email`, `serveraddress`, `identitytoken`
+and `registry`. The first 5 properties
+are passed as autentication to the Docker registry if given - refer to
 [Docker Authenticaton](https://docs.docker.com/engine/api/v1.40/#section/Authentication).
 The optional `registry` is a prefix for the image to allow pull from other
 registry than DockerHub. And empty object in the `dockerRegistries` pulls

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -2751,12 +2751,14 @@ with a path like in `https://folio.example.com/okapi`.
 * `dockerUrl`: Tells the Okapi deployment where the Docker Daemon
 is. Defaults to `unix:///var/run/docker.sock`.
 * `dockerRegistries`: List of registries to use for Docker image pull. The
-value is a JSON array of of objects where each object may have the following properties
+value is a JSON array of objects where each object may have the following properties
 `username`, `password`, `email`, `serveraddress` and `registry`. The first 4 properties
 are passed as autentication to the Docker registry - refer to
 [Docker Authenticaton](https://docs.docker.com/engine/api/v1.40/#section/Authentication).
 The optional `registry` is a prefix for the image to allow pull from other
-registry than DockerHub.
+registry than DockerHub. And empty object in the `dockerRegistries` pulls
+from DockerHub without authentication. Omitting `dockerRegistries` does
+the same and is the behavior for earlier versions of Okapi as well.
 * `containerHost`: Host where containers are running (as seen from Okapi).
 Defaults to `localhost`.
 * `postgres_host` : PostgreSQL host. Defaults to `localhost`.

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -2751,8 +2751,12 @@ with a path like in `https://folio.example.com/okapi`.
 * `dockerUrl`: Tells the Okapi deployment where the Docker Daemon
 is. Defaults to `unix:///var/run/docker.sock`.
 * `dockerRegistries`: List of registries to use for Docker image pull. The
-value is a JSON array of of objects where each object may have the following values
-for docker authentication: `username`, `password`, `email`, `serveraddress`.
+value is a JSON array of of objects where each object may have the following properties
+`username`, `password`, `email`, `serveraddress` and `registry`. The first 4 properties
+are passed as autentication to the Docker registry - refer to
+[Docker Authenticaton](https://docs.docker.com/engine/api/v1.40/#section/Authentication).
+The optional `registry` is a prefix for the image to allow pull from other
+registry than DockerHub.
 * `containerHost`: Host where containers are running (as seen from Okapi).
 Defaults to `localhost`.
 * `postgres_host` : PostgreSQL host. Defaults to `localhost`.

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -2750,6 +2750,9 @@ there happens to be one, Okapi will remove it.  Note that it may end
 with a path like in `https://folio.example.com/okapi`.
 * `dockerUrl`: Tells the Okapi deployment where the Docker Daemon
 is. Defaults to `unix:///var/run/docker.sock`.
+* `dockerRegistries`: List of registries to use for Docker image pull. The
+value is a JSON array of of objects where each object may have the following values
+for docker authentication: `username`, `password`, `email`, `serveraddress`.
 * `containerHost`: Host where containers are running (as seen from Okapi).
 Defaults to `localhost`.
 * `postgres_host` : PostgreSQL host. Defaults to `localhost`.

--- a/okapi-core/src/main/java/org/folio/okapi/service/impl/DockerModuleHandle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/service/impl/DockerModuleHandle.java
@@ -256,7 +256,8 @@ public class DockerModuleHandle implements ModuleHandle {
         continue;
       }
       JsonObject authObject = new JsonObject();
-      for (String member : Arrays.asList("username", "password", "email", "serveraddress")) {
+      for (String member : Arrays.asList(
+          "username", "password", "email", "serveraddress", "identitytoken")) {
         String value = registry.getString(member);
         if (value != null) {
           authObject.put(member, value);

--- a/okapi-core/src/test/java/org/folio/okapi/service/impl/DockerModuleHandleTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/service/impl/DockerModuleHandleTest.java
@@ -156,9 +156,7 @@ public class DockerModuleHandleTest implements WithAssertions {
     int dockerPort = 9231;
 
     Router router = Router.router(vertx);
-    router.routeWithRegex("/.*").
-
-        handler(this::dockerMockHandle);
+    router.routeWithRegex("/.*").handler(this::dockerMockHandle);
 
     HttpServerOptions so = new HttpServerOptions().setHandle100ContinueAutomatically(true);
     HttpServer listen = vertx.createHttpServer(so)
@@ -200,7 +198,6 @@ public class DockerModuleHandleTest implements WithAssertions {
 
     conf.put("dockerRegistries", new JsonArray()
         .addNull()
-        .add(new JsonObject())
         .add(new JsonObject().put("username", "x").put("password", "y")));
     {
       DockerModuleHandle dh = new DockerModuleHandle(vertx, ld,
@@ -214,7 +211,6 @@ public class DockerModuleHandleTest implements WithAssertions {
     }
 
     conf.put("dockerRegistries", new JsonArray()
-        .add(new JsonObject())
         .add(new JsonObject().put("username", "x").put("password", "y"))
         .add(new JsonObject().put("username", "x").put("password", "x"))
         .add(new JsonObject().put("username", "x").put("password", "z")));
@@ -228,6 +224,33 @@ public class DockerModuleHandleTest implements WithAssertions {
       }));
       async.await();
     }
+
+    conf.put("dockerRegistries", new JsonArray()
+        .add(new JsonObject().put("registry", "localhost:5000")));
+    {
+      DockerModuleHandle dh = new DockerModuleHandle(vertx, ld,
+          "mod-users-5.0.0-SNAPSHOT", ports, "localhost:5000",
+          9231, conf);
+      Async async = context.async();
+      dh.pullImage().onComplete(context.asyncAssertSuccess(x -> {
+        async.complete();
+      }));
+      async.await();
+    }
+
+    conf.put("dockerRegistries", new JsonArray()
+        .add(new JsonObject().put("registry", "localhost:5000/")));
+    {
+      DockerModuleHandle dh = new DockerModuleHandle(vertx, ld,
+          "mod-users-5.0.0-SNAPSHOT", ports, "localhost:5000/",
+          9231, conf);
+      Async async = context.async();
+      dh.pullImage().onComplete(context.asyncAssertSuccess(x -> {
+        async.complete();
+      }));
+      async.await();
+    }
+
     listen.close(context.asyncAssertSuccess());
   }
 

--- a/okapi-core/src/test/java/org/folio/okapi/service/impl/DockerModuleHandleTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/service/impl/DockerModuleHandleTest.java
@@ -191,6 +191,9 @@ public class DockerModuleHandleTest implements WithAssertions {
     conf.put("dockerRegistries", new JsonArray());
     context.assertFalse(pullImage(context, vertx, "localhost", conf));
 
+    conf.put("dockerRegistries", new JsonArray().add(new JsonObject()));
+    context.assertTrue(pullImage(context, vertx, "localhost", conf));
+
     conf.put("dockerRegistries", new JsonArray()
         .addNull()
         .add(new JsonObject().put("username", "x").put("password", "y")));

--- a/okapi-core/src/test/java/org/folio/okapi/service/impl/DockerModuleHandleTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/service/impl/DockerModuleHandleTest.java
@@ -197,6 +197,20 @@ public class DockerModuleHandleTest implements WithAssertions {
     }
 
     conf.put("dockerRegistries", new JsonArray()
+        .add(new JsonObject())
+        .add(new JsonObject().put("username", "x").put("password", "y")));
+    {
+      DockerModuleHandle dh = new DockerModuleHandle(vertx, ld,
+          "mod-users-5.0.0-SNAPSHOT", ports, "localhost",
+          9231, conf);
+      Async async = context.async();
+      dh.pullImage().onComplete(context.asyncAssertSuccess(x -> {
+        async.complete();
+      }));
+      async.await();
+    }
+
+    conf.put("dockerRegistries", new JsonArray()
         .addNull()
         .add(new JsonObject().put("username", "x").put("password", "y")));
     {


### PR DESCRIPTION
Configuration property `dockerRegistries` includes list of registries
with authentication properties (as Docker uses them) and/or `registry` property. The latter to allow for pull on other repositories than DockerHub.