### PR TITLE
Fix Hazelcast Warnings (due to Java 9 or later) OKAPI-894

### DIFF
--- a/dist/okapi.sh
+++ b/dist/okapi.sh
@@ -82,6 +82,14 @@ parse_okapi_conf()  {
          OKAPI_OPTIONS+=" $CLUSTER_OPTIONS"
       fi
 
+      OKAPI_JAVA_OPTS+=" --add-modules java.se"
+      OKAPI_JAVA_OPTS+=" --add-exports java.base/jdk.internal.ref=ALL-UNNAMED"
+      OKAPI_JAVA_OPTS+=" --add-opens java.base/java.lang=ALL-UNNAMED"
+      OKAPI_JAVA_OPTS+=" --add-opens java.base/java.nio=ALL-UNNAMED"
+      OKAPI_JAVA_OPTS+=" --add-opens java.base/sun.nio.ch=ALL-UNNAMED"
+      OKAPI_JAVA_OPTS+=" --add-opens java.management/sun.management=ALL-UNNAMED"
+      OKAPI_JAVA_OPTS+=" --add-opens jdk.management/com.ibm.lang.management.internal=ALL-UNNAMED"
+      OKAPI_JAVA_OPTS+=" --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED"
    fi
 
    # Set performance metric options


### PR DESCRIPTION
No other way than passing a wealth of command-line arguments. This
is hereby done for the Debian package.