### PR TITLE
Add more metrics backends (Prometheus and JMX) support

### DIFF
--- a/doc/guide.md
+++ b/doc/guide.md
@@ -3053,14 +3053,21 @@ Okapi uses Micrometer to managing metrics and reporting to backends. To enable i
 add Java parameter `-Dvertx.metrics.options.enabled=true` first.
 
 More Java parameters are needed to config which backends to use
-* `-DinfluxDbOptions='{"uri": "http://localhost:8086", "db":"okapi"}'` - Send metrics to InfluxDB
+* `-DinfluxDbOptions='{"uri": "http://localhost:8086", "db":"folio"}'` - Send metrics to InfluxDB
 * `-DprometheusOptions='{"embeddedServerOptions": {"port": 9930}}'` - Expose `<server>:9930/metrics` for Prometheus
-* `-DjmxMetricsOptions='{"domain": "org.folio.metrics"}'` - JMX
+* `-DjmxMetricsOptions='{"domain": "org.folio"}'` - JMX
 
 Another Java parameter can be used to filter metrics
 * `-DmetricsPrefixFilter=org.folio` - Will only report metrics with name starting `org.folio`
 
-A full example: `java -Dvertx.metrics.options.enabled=true -DmetricsPrefixFilter=org.folio -DinfluxDbOptions='{"uri": "http://localhost:8086", "db":"okapi"}' -DprometheusOptions='{"embeddedServerOptions": {"port": 9930}}' -DjmxMetricsOptions='{"domain": "org.folio"}' -jar okapi-core/target/okapi-core-fat.jar dev`
+A full example with all backends enabled and filter parameter configured:
+
+    java -Dvertx.metrics.options.enabled=true \
+      -DinfluxDbOptions='{"uri": "http://localhost:8086", "db":"folio"}' \
+      -DprometheusOptions='{"embeddedServerOptions": {"port": 9930}}' \
+      -DjmxMetricsOptions='{"domain": "org.folio"}' \
+      -DmetricsPrefixFilter=org.folio \
+      -jar okapi-core/target/okapi-core-fat.jar dev
 
 ## Module Reference
 

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -2802,7 +2802,6 @@ These options are at the end of the command line:
 * `-hazelcast-config-cp` _file_ -- Read Hazelcast config from class path
 * `-hazelcast-config-file` _file_ -- Read Hazelcast config from local file
 * `-hazelcast-config-url` _url_ -- Read Hazelcast config from URL
-* `-enable-metrics` -- Enables the sending of various metrics to InfluxDB
 * `-cluster-host` _ip_ -- Vertx cluster host
 * `-cluster-port` _port_ -- Vertx cluster port
 
@@ -3050,23 +3049,18 @@ Use `modulePermissions` to grant permissions for the token.
 
 ### Instrumentation
 
-Okapi pushes instrumentation data to an InfluxDB backend, from which
-they can be shown with something like Grafana. Vert.x pushes some numbers
-automatically, but various parts of Okapi push their own numbers explicitly,
-so we can classify by tenant or module. Individual
-modules may push their own numbers as well, as needed. It is hoped that they
-will use a key naming scheme that is close to what we do in Okapi.
+Okapi uses Micrometer to managing metrics and reporting to backends. To enable it,
+add Java parameter `-Dvertx.metrics.options.enabled=true` first.
 
-Enabling the metrics via `-enable-metrics` will start sending metrics to `localhost:8086`
+More Java parameters are needed to config which backends to use
+* `-DinfluxDbOptions='{"uri": "http://localhost:8086", "db":"okapi"}'` - Send metrics to InfluxDB
+* `-DprometheusOptions='{"embeddedServerOptions": {"port": 9930}}'` - Expose `<server>:9930/metrics` for Prometheus
+* `-DjmxMetricsOptions='{"domain": "org.folio.metrics"}'` - JMX
 
-Follwing Java parameters can be used to config InfluxDB connection.
-* `influxUrl` - default to `http://localhost:8086`
-* `influxDbName` - default to `okapi`
-* `influxUser` - default to null
-* `influxPassword` - default to null
+Another Java parameter can be used to filter metrics
+* `-DmetricsPrefixFilter=org.folio` - Will only report metrics with name starting `org.folio`
 
-For example: `java -DinfluxUrl=http://influx.yourdomain.io:8086 -jar okapi-core/target/okapi-core-fat.jar dev -enable-metrics` then metrics
-will be sent to `http://influx.yourdomain.io:8086`
+A full example: `java -Dvertx.metrics.options.enabled=true -DmetricsPrefixFilter=org.folio -DinfluxDbOptions='{"uri": "http://localhost:8086", "db":"okapi"}' -DprometheusOptions='{"embeddedServerOptions": {"port": 9930}}' -DjmxMetricsOptions='{"domain": "org.folio"}' -jar okapi-core/target/okapi-core-fat.jar dev`
 
 ## Module Reference
 

--- a/okapi-core/pom.xml
+++ b/okapi-core/pom.xml
@@ -54,6 +54,14 @@
       <artifactId>micrometer-registry-influx</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-jmx</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-mongo-client</artifactId>
     </dependency>

--- a/okapi-core/src/main/java/org/folio/okapi/MainDeploy.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainDeploy.java
@@ -30,6 +30,8 @@ import org.folio.okapi.util.MetricsHelper;
 @java.lang.SuppressWarnings({"squid:S3776"})
 public class MainDeploy {
 
+  private static final Logger logger = OkapiLogger.get(MainDeploy.class);
+
   private static final String CANNOT_LOAD_STR = "Cannot load ";
 
   private final VertxOptions vopt = new VertxOptions();
@@ -52,9 +54,7 @@ public class MainDeploy {
   void init(String[] args, Handler<AsyncResult<Vertx>> fut) {
     vopt.setPreferNativeTransport(true);
     try {
-      final Logger logger = OkapiLogger.get();
       Messages.setLanguage(System.getProperty("lang", "en"));
-
       if (args.length < 1) {
         printUsage();
         fut.handle(Future.failedFuture(messages.getMessage("10600")));
@@ -68,12 +68,12 @@ public class MainDeploy {
         case "dev":
         case "initdatabase":
         case "purgedatabase":
-          deploy(new MainVerticle(), Vertx.vertx(vopt), fut);
+          deploy(false, fut);
           break;
         case "cluster":
         case "proxy":
         case "deployment":
-          deployClustered(logger, fut);
+          deploy(true, fut);
           break;
         default:
           fut.handle(Future.failedFuture(messages.getMessage("10601", mode)));
@@ -99,14 +99,6 @@ public class MainDeploy {
       return true;
     }
     return false;
-  }
-
-  private void enableMetrics() {
-    String influxUrl = System.getProperty("influxUrl");
-    String influxDbName = System.getProperty("influxDbName");
-    String influxUserName = System.getProperty("influxUserName");
-    String influxPassword = System.getProperty("influxPassword");
-    MetricsHelper.config(vopt, influxUrl, influxDbName, influxUserName, influxPassword);
   }
 
   private boolean parseOptions(String[] args, Handler<AsyncResult<Vertx>> fut) {
@@ -148,8 +140,6 @@ public class MainDeploy {
         clusterHost = args[++i];
       } else if ("-cluster-port".equals(args[i]) && i < args.length - 1) {
         clusterPort = Integer.parseInt(args[++i]);
-      } else if ("-enable-metrics".equals(args[i])) {
-        enableMetrics();
       } else if ("-conf".equals(args[i]) && i < args.length - 1) {
         if (readConf(args[++i], fut)) {
           return true;
@@ -182,11 +172,19 @@ public class MainDeploy {
         + "  -hazelcast-config-file file   Read Hazelcast config from local file\n"
         + "  -hazelcast-config-url url     Read Hazelcast config from URL\n"
         + "  -cluster-host ip              Vertx cluster host\n"
-        + "  -cluster-port port            Vertx cluster port\n"
-        + "  -enable-metrics\n");
+        + "  -cluster-port port            Vertx cluster port\n");
   }
 
-  private void deployClustered(final Logger logger, Handler<AsyncResult<Vertx>> fut) {
+  private void deploy(boolean clustered, Handler<AsyncResult<Vertx>> fut) {
+    MetricsHelper.init(vopt);
+    if (clustered) {
+      deployClustered(fut);
+    } else {
+      deployVerticle(new MainVerticle(), Vertx.vertx(vopt), fut);
+    }
+  }
+
+  private void deployClustered(Handler<AsyncResult<Vertx>> fut) {
     if (hazelcastConfig == null) {
       hazelcastConfig = ConfigUtil.loadConfig();
       if (clusterHost != null) {
@@ -217,14 +215,14 @@ public class MainDeploy {
       if (res.succeeded()) {
         MainVerticle v = new MainVerticle();
         v.setClusterManager(mgr);
-        deploy(v, res.result(), fut);
+        deployVerticle(v, res.result(), fut);
       } else {
         fut.handle(Future.failedFuture(res.cause()));
       }
     });
   }
 
-  private void deploy(Verticle v, Vertx vertx, Handler<AsyncResult<Vertx>> fut) {
+  private void deployVerticle(Verticle v, Vertx vertx, Handler<AsyncResult<Vertx>> fut) {
     DeploymentOptions opt = new DeploymentOptions().setConfig(conf);
     vertx.deployVerticle(v, opt, dep -> {
       if (dep.failed()) {

--- a/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
@@ -43,6 +43,7 @@ import org.folio.okapi.service.impl.TenantStoreNull;
 import org.folio.okapi.util.CorsHelper;
 import org.folio.okapi.util.EventBusChecker;
 import org.folio.okapi.util.LogHelper;
+import org.folio.okapi.util.MetricsHelper;
 import org.folio.okapi.util.OkapiError;
 
 @java.lang.SuppressWarnings({"squid:S1192"})
@@ -193,6 +194,7 @@ public class MainVerticle extends AbstractVerticle {
   @Override
   public void stop(Promise<Void> promise) {
     logger.info("stop");
+    MetricsHelper.stop();
     Future<Void> future = Future.succeededFuture();
     if (deploymentManager != null) {
       future = future.compose(x -> deploymentManager.shutdown());

--- a/okapi-core/src/test/java/org/folio/okapi/MainDeployTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/MainDeployTest.java
@@ -320,23 +320,4 @@ public class MainDeployTest {
     });
   }
 
-  @Test
-  public void testEnableMetrics(TestContext context) {
-    async = context.async();
-
-    String[] args = { "-enable-metrics" };
-
-    context.assertFalse(MetricsHelper.isEnabled());
-
-    MainDeploy d = new MainDeploy();
-    d.init(args, res -> {
-      vertx = res.succeeded() ? res.result() : null;
-      Assert.assertTrue("main1 " + res.cause(), res.succeeded());
-      context.assertTrue(res.succeeded());
-      context.assertTrue(MetricsHelper.isEnabled());
-      MetricsHelper.setEnabled(false);
-      async.complete();
-    });
-  }
-
 }

--- a/okapi-core/src/test/java/org/folio/okapi/util/MetricsHelperTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/MetricsHelperTest.java
@@ -2,9 +2,9 @@ package org.folio.okapi.util;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
-
-import java.net.InetAddress;
-import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import org.folio.okapi.bean.ModuleDescriptor;
 import org.folio.okapi.bean.ModuleInstance;
@@ -12,54 +12,87 @@ import org.folio.okapi.bean.RoutingEntry;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
-import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.core.json.JsonObject;
 
 @TestMethodOrder(OrderAnnotation.class)
 class MetricsHelperTest {
 
-  @AfterAll
-  static void disableMetrics() {
-    MetricsHelper.setEnabled(false);
-  }
+  private static final CompositeMeterRegistry registry = MetricsHelper.getRegistry();
 
   @BeforeEach
-  void enableMetrics() {
+  void setup() {
     MetricsHelper.setEnabled(true);
+    registry.add(new SimpleMeterRegistry());
+    assertEquals(1, registry.getRegistries().size());
+  }
+
+  @AfterEach
+  void teardown() {
+    MetricsHelper.stop();
+    assertTrue(registry.getRegistries().isEmpty());
   }
 
   @Test
   @Order(1)
-  void testMetricsNotEnabled() {
-    MetricsHelper.setEnabled(false);
+  void testEnableMetricsWithoutSwitch() {
+    MetricsHelper.init(new VertxOptions());
     assertNull(MetricsHelper.getTimerSample());
     assertNull(MetricsHelper.recordHttpClientResponse(null, "a", 0, "b", null));
     assertNull(MetricsHelper.recordHttpServerProcessingTime(null, "a", 0, "b", null));
     assertNull(MetricsHelper.recordHttpClientError("a", "b", "c"));
     assertNull(MetricsHelper.recordCodeExecutionTime(null, "a"));
+    assertNull(MetricsHelper.recordTokenCacheCached("a", "b", "c", "d"));
+    assertNull(MetricsHelper.recordTokenCacheExpired("a", "b", "c", "d"));
+    assertNull(MetricsHelper.recordTokenCacheHit("a", "b", "c", "d"));
+    assertNull(MetricsHelper.recordTokenCacheMiss("a", "b", "c", "d"));
   }
 
   @Test
-  void testMetricsEnabled() {
-    assertTrue(MetricsHelper.isEnabled());
-    assertNotNull(MetricsHelper.getTimerSample());
+  @Order(2)
+  void testEnableMetricsWithoutBackendOptions() {
+    MetricsHelper.stop();
+    System.getProperties().setProperty(MetricsHelper.ENABLE_METRICS, "true");
+    MetricsHelper.init(new VertxOptions());
+    assertFalse(MetricsHelper.isEnabled());
+    assertNull(MetricsHelper.getTimerSample());
+    assertTrue(registry.getRegistries().isEmpty());
+    System.getProperties().remove(MetricsHelper.ENABLE_METRICS);
   }
 
   @Test
-  void testConfig() {
-    VertxOptions vopt = new VertxOptions();
-    MetricsHelper.config(vopt, null, null, null, null);
-    verifyConfig(vopt, "http://localhost:8086", "okapi", null, null);
-    MetricsHelper.config(vopt, "a", "b", "c", "d");
-    verifyConfig(vopt, "a", "b", "c", "d");
+  @Order(3)
+  void testEnableMetrics() {
+    Properties props = System.getProperties();
+    props.setProperty(MetricsHelper.ENABLE_METRICS, "true");
+    List<String> options = Arrays.asList(
+        MetricsHelper.INFLUX_OPTS,
+        MetricsHelper.PROMETHEUS_OPTS,
+        MetricsHelper.JMX_OPTS);
+    options.forEach(option -> {
+      MetricsHelper.stop();
+      options.forEach(opt -> props.remove(opt));
+      props.setProperty(option, "{}");
+      if (props.getProperty(MetricsHelper.METRICS_FILTER) == null) {
+        props.setProperty(MetricsHelper.METRICS_FILTER, MetricsHelper.METRICS_PREFIX + ",b,c");
+      } else {
+        props.remove(MetricsHelper.METRICS_FILTER);
+      }
+      MetricsHelper.init(new VertxOptions());
+      assertTrue(MetricsHelper.isEnabled());
+      assertNotNull(MetricsHelper.getTimerSample());
+      assertEquals(1, registry.getRegistries().size());
+    });
+    options.forEach(opt -> props.remove(opt));
+    props.remove(MetricsHelper.METRICS_FILTER);
+    System.getProperties().remove(MetricsHelper.ENABLE_METRICS);
   }
 
   @Test
@@ -114,18 +147,16 @@ class MetricsHelperTest {
         .build();
 
     // test case where there is no userId
-    MetricsHelper.recordTokenCacheCached("tenant",  "GET",  "/foo/bar", null);
-    
-    Counter cachedCounter =
-        MetricsHelper.recordTokenCacheCached("tenant", "GET", "/foo/bar", userId);
+    MetricsHelper.recordTokenCacheCached("tenant", "GET", "/foo/bar", null);
+
+    Counter cachedCounter = MetricsHelper.recordTokenCacheCached("tenant", "GET", "/foo/bar", userId);
     assertEquals(1, cachedCounter.count());
     cache.put("tenant", "GET", "/foo/bar", userId, "perms", "keyToken", "tokenToCache");
     assertEquals(2, cachedCounter.count());
     cache.put("tenant", "GET", "/foo/bar", anotherUserId, "perms", "keyToken", "tokenToCache");
     assertEquals(2, cachedCounter.count());
 
-    Counter missedCounter =
-        MetricsHelper.recordTokenCacheMiss("tenant", "POST", "/foo/bar/123", userId);
+    Counter missedCounter = MetricsHelper.recordTokenCacheMiss("tenant", "POST", "/foo/bar/123", userId);
     assertEquals(1, missedCounter.count());
     cache.get("tenant", "POST", "/foo/bar/123", userId, "keyToken");
     assertEquals(2, missedCounter.count());
@@ -135,14 +166,13 @@ class MetricsHelperTest {
     cache.get("tenant", "GET", "/foo/bar", userId, "keyToken");
     assertEquals(2, hitCounter.count());
 
-    Counter expiresCounter =
-        MetricsHelper.recordTokenCacheExpired("tenant", "GET", "/foo/bar", userId);
+    Counter expiresCounter = MetricsHelper.recordTokenCacheExpired("tenant", "GET", "/foo/bar", userId);
     assertEquals(1, expiresCounter.count());
 
     await().with()
-      .pollInterval(10, TimeUnit.MILLISECONDS)
-      .atMost(ttl + 20, TimeUnit.MILLISECONDS)
-      .until(() -> cache.get("tenant", "GET", "/foo/bar", userId, "keyToken") == null);
+        .pollInterval(10, TimeUnit.MILLISECONDS)
+        .atMost(ttl + 20, TimeUnit.MILLISECONDS)
+        .until(() -> cache.get("tenant", "GET", "/foo/bar", userId, "keyToken") == null);
 
     assertEquals(2, expiresCounter.count());
   }
@@ -163,15 +193,6 @@ class MetricsHelperTest {
     assertEquals(1, timer.count());
   }
 
-  @Test
-  void testGetHost() {
-    assertNotEquals(MetricsHelper.HOST_UNKNOWN, MetricsHelper.getHost());
-    try (MockedStatic<InetAddress> mocked = Mockito.mockStatic(InetAddress.class)) {
-      mocked.when(InetAddress::getLocalHost).thenThrow(UnknownHostException.class);
-      assertEquals(MetricsHelper.HOST_UNKNOWN, MetricsHelper.getHost());
-    }
-  }
-
   private ModuleInstance createModuleInstance(boolean handler) {
     ModuleDescriptor md = new ModuleDescriptor();
     md.setId("abc-1.0");
@@ -185,22 +206,6 @@ class MetricsHelperTest {
     ModuleDescriptor md = new ModuleDescriptor();
     md.setId("abc-1.0");
     return new ModuleInstance(md, null, "/", HttpMethod.GET, handler);
-  }
-
-  private void verifyConfig(VertxOptions vopt, String url, String db, String user, String pass) {
-    JsonObject jo = vopt.getMetricsOptions().toJson().getJsonObject("influxDbOptions");
-    assertEquals(url, jo.getString("uri"));
-    assertEquals(db, jo.getString("db"));
-    if (user == null) {
-      assertFalse(jo.containsKey("userName"));
-    } else {
-      assertEquals(user, jo.getString("userName"));
-    }
-    if (pass == null) {
-      assertFalse(jo.containsKey("password"));
-    } else {
-      assertEquals(pass, jo.getString("password"));
-    }
   }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,16 @@
         <!-- use 1.4.2 because 1.5.2 in above POM link does not work -->
       </dependency>
       <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-registry-prometheus</artifactId>
+        <version>1.5.2</version> <!-- https://github.com/vert-x3/vertx-micrometer-metrics/blob/master/pom.xml -->
+      </dependency>
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-registry-jmx</artifactId>
+        <version>1.5.2</version> <!-- https://github.com/vert-x3/vertx-micrometer-metrics/blob/master/pom.xml -->
+      </dependency>
+      <dependency>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast</artifactId>
         <version>4.0.2</version>  <!-- https://github.com/vert-x3/vertx-hazelcast/blob/master/pom.xml -->


### PR DESCRIPTION
Added metrics support for backend Prometheus (and JMX). Documentation is updated as below. I will create a follow up ticket to move some stuff to okapi-common, so RMB can use it directly.

### Instrumentation

Okapi uses Micrometer to managing metrics and reporting to backends. To enable it,
add Java parameter `-Dvertx.metrics.options.enabled=true` first.

More Java parameters are needed to config which backends to use
* `-DinfluxDbOptions='{"uri": "http://localhost:8086", "db":"okapi"}'` - Send metrics to InfluxDB
* `-DprometheusOptions='{"embeddedServerOptions": {"port": 9930}}'` - Expose `<server>:9930/metrics` for Prometheus
* `-DjmxMetricsOptions='{"domain": "org.folio.metrics"}'` - JMX

Another Java parameter can be used to filter metrics
* `-DmetricsPrefixFilter=org.folio` - Will only report metrics with name starting `org.folio`

A full example: `java -Dvertx.metrics.options.enabled=true -DmetricsPrefixFilter=org.folio -DinfluxDbOptions='{"uri": "http://localhost:8086", "db":"okapi"}' -DprometheusOptions='{"embeddedServerOptions": {"port": 9930}}' -DjmxMetricsOptions='{"domain": "org.folio"}' -jar okapi-core/target/okapi-core-fat.jar dev`
