### PR TITLE
Make HealthManagerTest use port 9230 OKAPI-929

### DIFF
--- a/okapi-core/src/test/java/org/folio/okapi/managers/HealthManagerTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/managers/HealthManagerTest.java
@@ -16,6 +16,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(VertxExtension.class)
 public class HealthManagerTest {
 
+  private static final int PORT = 9230;
+
   @Test
   void testPort0(Vertx vertx, VertxTestContext context) {
     HealthManager m = new HealthManager(0);
@@ -23,12 +25,11 @@ public class HealthManagerTest {
   }
 
   @Test
-  void testPortReadinessPort9130(Vertx vertx, VertxTestContext context) {
-    final int port = 9130;
-    HealthManager m = new HealthManager(port);
+  void testPortReadinessPort(Vertx vertx, VertxTestContext context) {
+    HealthManager m = new HealthManager(PORT);
     m.init(vertx, Collections.emptyList()).onComplete(context.succeeding(res -> {
       WebClient client = WebClient.create(vertx);
-      client.get(port, "localhost", "/readiness")
+      client.get(PORT, "localhost", "/readiness")
           .send(context.succeeding(response -> {
             assertThat(response.statusCode()).isEqualTo(204);
             context.completeNow();
@@ -38,11 +39,10 @@ public class HealthManagerTest {
 
   @Test
   void testPortLivenessSuccess(Vertx vertx, VertxTestContext context) {
-    final int port = 9130;
-    HealthManager m = new HealthManager(port);
+    HealthManager m = new HealthManager(PORT);
     m.init(vertx, Arrays.asList(new IsAlive())).onComplete(context.succeeding(res -> {
       WebClient client = WebClient.create(vertx);
-      client.get(port, "localhost", "/liveness")
+      client.get(PORT, "localhost", "/liveness")
           .send(context.succeeding(response -> {
             assertThat(response.statusCode()).isEqualTo(204);
             context.completeNow();
@@ -52,11 +52,10 @@ public class HealthManagerTest {
 
   @Test
   void testPortLivenessFailure(Vertx vertx, VertxTestContext context) {
-    final int port = 9130;
-    HealthManager m = new HealthManager(port);
+    HealthManager m = new HealthManager(PORT);
     m.init(vertx, Arrays.asList(new IsAlive(), new IsNotAlive())).onComplete(context.succeeding(res -> {
       WebClient client = WebClient.create(vertx);
-      client.get(port, "localhost", "/liveness")
+      client.get(PORT, "localhost", "/liveness")
           .send(context.succeeding(response -> {
             assertThat(response.statusCode()).isEqualTo(500);
             assertThat(response.bodyAsString()).isEqualTo("my error");


### PR DESCRIPTION
Not 9130 which is the port that Okapi uses by default - including
the Debian package.