### PR TITLE
OKAPI-928: Move metrics to Okapi-common for sharing

### DIFF
--- a/okapi-common/pom.xml
+++ b/okapi-common/pom.xml
@@ -35,6 +35,22 @@
       <artifactId>vertx-web-client</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-micrometer-metrics</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-influx</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-jmx</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.z3950.zing</groupId>
       <artifactId>cql-java</artifactId>
       <version>1.13</version>

--- a/okapi-common/src/main/java/org/folio/okapi/common/MetricsUtil.java
+++ b/okapi-common/src/main/java/org/folio/okapi/common/MetricsUtil.java
@@ -1,0 +1,236 @@
+package org.folio.okapi.common;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.Timer.Sample;
+import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
+import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.instrument.config.MeterFilter;
+import io.micrometer.core.instrument.simple.SimpleConfig;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.influx.InfluxMeterRegistry;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.json.JsonObject;
+import io.vertx.micrometer.MicrometerMetricsOptions;
+import io.vertx.micrometer.VertxInfluxDbOptions;
+import io.vertx.micrometer.VertxJmxMetricsOptions;
+import io.vertx.micrometer.VertxPrometheusOptions;
+import io.vertx.micrometer.backends.JmxBackendRegistry;
+import io.vertx.micrometer.backends.PrometheusBackendRegistry;
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Provide the common need of Metrics handling.
+ */
+public class MetricsUtil {
+
+  private static final Logger logger = OkapiLogger.get(MetricsUtil.class);
+
+  public static final String METRICS_PREFIX = "org.folio";
+
+  public static final String ENABLE_METRICS = "vertx.metrics.options.enabled";
+
+  public static final String INFLUX_OPTS = "influxDbOptions";
+  public static final String PROMETHEUS_OPTS = "prometheusOptions";
+  public static final String JMX_OPTS = "jmxMetricsOptions";
+
+  public static final String SIMPLE_OPTS = "simpleOptions"; // used for tests
+
+  public static final String METRICS_FILTER = "metricsPrefixFilter";
+
+  private static final String TAG_HOST = "host";
+  private static final String HOST_ID = ManagementFactory.getRuntimeMXBean().getName();
+
+  private static boolean enabled = false;
+
+  public static boolean isEnabled() {
+    return enabled;
+  }
+
+  static void setEnabled(boolean enabled) {
+    MetricsUtil.enabled = enabled;
+  }
+
+  private static CompositeMeterRegistry registry = new CompositeMeterRegistry();
+
+  static CompositeMeterRegistry getRegistry() {
+    return registry;
+  }
+
+  private static JvmGcMetrics jvmGcMetrics;
+
+  private MetricsUtil() {
+  }
+
+  /**
+   * Initialize metrics utility.
+   *
+   * @param vertxOptions - {@link VertxOptions}
+   */
+  public static void init(VertxOptions vertxOptions) {
+
+    if (!"true".equalsIgnoreCase(System.getProperty(ENABLE_METRICS))) {
+      logger.debug("Metrics is not enabled");
+      enabled = false;
+      return;
+    }
+
+    logger.info("Enabling metrics for " + HOST_ID);
+
+    if (System.getProperty(SIMPLE_OPTS) != null) {
+      registry.add(new SimpleMeterRegistry(SimpleConfig.DEFAULT, Clock.SYSTEM));
+      logger.info("Added {} for {}", SIMPLE_OPTS, HOST_ID);
+    }
+
+    String influxDbOptionsString = System.getProperty(INFLUX_OPTS);
+    if (influxDbOptionsString != null) {
+      VertxInfluxDbOptions influxDbOptions = new VertxInfluxDbOptions()
+          .setEnabled(true);
+      influxDbOptions = new VertxInfluxDbOptions(
+          influxDbOptions.toJson().mergeIn(new JsonObject(influxDbOptionsString), true));
+      InfluxMeterRegistry influxMeterRegistry = new InfluxMeterRegistry(
+          influxDbOptions.toMicrometerConfig(), Clock.SYSTEM);
+      influxMeterRegistry.config().commonTags(TAG_HOST, HOST_ID);
+      registry.add(influxMeterRegistry);
+      logger.info("Added {} for {}", INFLUX_OPTS, HOST_ID);
+    }
+
+    String prometheusOptionsString = System.getProperty(PROMETHEUS_OPTS);
+    if (prometheusOptionsString != null) {
+      VertxPrometheusOptions prometheusOptions = new VertxPrometheusOptions()
+          .setEnabled(true)
+          .setStartEmbeddedServer(true)
+          .setEmbeddedServerOptions(new HttpServerOptions().setPort(9930));
+      prometheusOptions = new VertxPrometheusOptions(
+          prometheusOptions.toJson().mergeIn(new JsonObject(prometheusOptionsString), true));
+      PrometheusBackendRegistry prometheusBackendRegistry = new PrometheusBackendRegistry(
+          prometheusOptions);
+      prometheusBackendRegistry.init();
+      registry.add(prometheusBackendRegistry.getMeterRegistry());
+      logger.info("Added {} for {}", PROMETHEUS_OPTS, HOST_ID);
+    }
+
+    String jmxMetricsOptionsString = System.getProperty(JMX_OPTS);
+    if (jmxMetricsOptionsString != null) {
+      VertxJmxMetricsOptions jmxMetricsOptions = new VertxJmxMetricsOptions()
+          .setEnabled(true)
+          .setDomain(METRICS_PREFIX);
+      jmxMetricsOptions = new VertxJmxMetricsOptions(
+          jmxMetricsOptions.toJson().mergeIn(new JsonObject(jmxMetricsOptionsString), true));
+      registry.add(new JmxBackendRegistry(jmxMetricsOptions).getMeterRegistry());
+      logger.info("Added {} for {}", JMX_OPTS, HOST_ID);
+    }
+
+    if (registry.getRegistries().isEmpty()) {
+      logger.error("Cannot enable metrics. Check command line for backend config");
+      enabled = false;
+      return;
+    }
+
+    String metricsPrefixFilter = System.getProperty(METRICS_FILTER);
+    if (metricsPrefixFilter != null) {
+      logger.info("Adding metrics prefix filters");
+      String[] strs = metricsPrefixFilter.split(",");
+      for (int i = 0, n = strs.length; i < n; i++) {
+        String prefix = strs[i].trim();
+        logger.info("Allowing metrics with prefix {}", prefix);
+        registry.config().meterFilter(MeterFilter.acceptNameStartsWith(prefix));
+      }
+      logger.info("Denying metrics that have no prefix of {}", metricsPrefixFilter);
+      registry.config().meterFilter(MeterFilter.deny());
+    }
+
+    new ClassLoaderMetrics().bindTo(registry);
+    new JvmMemoryMetrics().bindTo(registry);
+    jvmGcMetrics = new JvmGcMetrics();
+    jvmGcMetrics.bindTo(registry);
+    new ProcessorMetrics().bindTo(registry);
+    new JvmThreadMetrics().bindTo(registry);
+
+    vertxOptions.setMetricsOptions(new MicrometerMetricsOptions()
+        .setEnabled(true)
+        .setMicrometerRegistry(registry));
+    enabled = true;
+    logger.info("Metrics enabled for " + HOST_ID);
+  }
+
+  /**
+   * Stop metrics utility and release resources.
+   */
+  public static void stop() {
+    if (!enabled && registry.getRegistries().isEmpty()) {
+      return;
+    }
+    logger.debug("Stopping metrics for " + HOST_ID);
+    enabled = false;
+    if (jvmGcMetrics != null) {
+      jvmGcMetrics.close();
+      jvmGcMetrics = null;
+    }
+    List<MeterRegistry> list = new ArrayList<>();
+    registry.getRegistries().forEach(r -> {
+      list.add(r);
+      r.close();
+    });
+    list.forEach(r -> registry.remove(r));
+    logger.debug("Metrics stopped for " + HOST_ID);
+  }
+
+  /**
+   * Return a {@link Sample} to help start timing a {@link Timer}.
+   *
+   * @return {@link Sample} or null if metrics is not enabled
+   */
+  public static Sample getTimerSample() {
+    return enabled ? Timer.start(registry) : null;
+  }
+
+  /**
+   * Record a {@link Counter} meter.
+   * 
+   * @param meterName - name of the {@link Counter} meter
+   * @param tags      - tags associated with the meter
+   * 
+   * @return {@link Counter} or null if metrics is not enabled
+   */
+  public static Counter recordCounter(String meterName, Iterable<Tag> tags) {
+    if (!enabled) {
+      return null;
+    }
+    logger.trace("Record counter for {} with tags {}", meterName, tags.toString());
+    Counter counter = Counter.builder(meterName).tags(tags).register(registry);
+    counter.increment();
+    return counter;
+  }
+
+  /**
+   * Record a {@link Timer} meter.
+   * 
+   * @param sample    - a {@link Sample} that tells the starting time of the Timer
+   * @param meterName - name of the {@link Counter} meter
+   * @param tags      - tags associated with the meter
+   * 
+   * @return @return {@link Timer} or null if metrics is not enabled
+   */
+  public static Timer recordTimer(Sample sample, String meterName, Iterable<Tag> tags) {
+    if (!enabled) {
+      return null;
+    }
+    logger.trace("Record Timer for {} with tags {}", meterName, tags.toString());
+    Timer timer = Timer.builder(meterName).tags(tags).register(registry);
+    sample.stop(timer);
+    return timer;
+  }
+
+}

--- a/okapi-common/src/test/java/org/folio/okapi/common/MetricsUtilTest.java
+++ b/okapi-common/src/test/java/org/folio/okapi/common/MetricsUtilTest.java
@@ -1,0 +1,107 @@
+package org.folio.okapi.common;
+
+import static org.junit.Assert.*;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.Timer.Sample;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.vertx.core.VertxOptions;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+import org.junit.After;
+import org.junit.Test;
+
+public class MetricsUtilTest {
+
+  @After
+  public void teardown() {
+    MetricsUtil.stop();
+  }
+
+  @Test
+  public void testEnableMetricsWithoutSwitch() {
+    MetricsUtil.init(new VertxOptions());
+    verifyNotEnabled();
+  }
+
+  @Test
+  public void testEnableMetricsWithoutBackendOptions() {
+    System.getProperties().setProperty(MetricsUtil.ENABLE_METRICS, "true");
+    MetricsUtil.init(new VertxOptions());
+    verifyNotEnabled();
+    MetricsUtil.stop();
+    System.getProperties().remove(MetricsUtil.ENABLE_METRICS);
+  }
+
+  private void verifyNotEnabled() {
+    assertFalse(MetricsUtil.isEnabled());
+    assertTrue(MetricsUtil.getRegistry().getRegistries().isEmpty());
+    assertNull(MetricsUtil.getTimerSample());
+    assertNull(MetricsUtil.recordCounter("a", Collections.emptyList()));
+    assertNull(MetricsUtil.recordTimer(null, "a", Collections.emptyList()));
+  }
+
+  @Test
+  public void testEnableMetrics() {
+    Properties props = System.getProperties();
+    props.setProperty(MetricsUtil.ENABLE_METRICS, "true");
+    List<String> options = Arrays.asList(
+        MetricsUtil.SIMPLE_OPTS,
+        MetricsUtil.INFLUX_OPTS,
+        MetricsUtil.PROMETHEUS_OPTS,
+        MetricsUtil.JMX_OPTS);
+    options.forEach(option -> {
+      MetricsUtil.stop();
+      options.forEach(opt -> props.remove(opt));
+      props.setProperty(option, "{}");
+      if (props.getProperty(MetricsUtil.METRICS_FILTER) == null) {
+        props.setProperty(MetricsUtil.METRICS_FILTER, MetricsUtil.METRICS_PREFIX + ",b,c");
+      } else {
+        props.remove(MetricsUtil.METRICS_FILTER);
+      }
+      MetricsUtil.init(new VertxOptions());
+      assertTrue(MetricsUtil.isEnabled());
+      assertNotNull(MetricsUtil.getTimerSample());
+      assertEquals(1, MetricsUtil.getRegistry().getRegistries().size());
+    });
+    options.forEach(opt -> props.remove(opt));
+    props.remove(MetricsUtil.METRICS_FILTER);
+    props.remove(MetricsUtil.ENABLE_METRICS);
+  }
+
+  @Test
+  public void testDisableMetrics() {
+    MetricsUtil.setEnabled(true);
+    MetricsUtil.stop();
+    verifyNotEnabled();
+    MetricsUtil.getRegistry().add(new SimpleMeterRegistry());
+    MetricsUtil.stop();
+    verifyNotEnabled();
+  }
+
+  @Test
+  public void testRecordTimer() {
+    MetricsUtil.setEnabled(true);
+    MetricsUtil.getRegistry().add(new SimpleMeterRegistry());
+    Sample sample = MetricsUtil.getTimerSample();
+    Timer timer = MetricsUtil.recordTimer(sample, MetricsUtil.METRICS_PREFIX + ".a",
+        Arrays.asList(Tag.of("k", "v")));
+    assertNotNull(timer);
+    assertEquals(1, timer.count());
+  }
+
+  @Test
+  public void testRecordCounter() {
+    MetricsUtil.setEnabled(true);
+    MetricsUtil.getRegistry().add(new SimpleMeterRegistry());
+    Counter counter = MetricsUtil.recordCounter(MetricsUtil.METRICS_PREFIX + ".b",
+        Arrays.asList(Tag.of("k", "v")));
+    assertNotNull(counter);
+    assertEquals(1, counter.count(), 0.1);
+  }
+
+}

--- a/okapi-core/pom.xml
+++ b/okapi-core/pom.xml
@@ -50,18 +50,6 @@
       <artifactId>vertx-micrometer-metrics</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-registry-influx</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-registry-prometheus</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-registry-jmx</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-mongo-client</artifactId>
     </dependency>

--- a/okapi-core/pom.xml
+++ b/okapi-core/pom.xml
@@ -47,10 +47,6 @@
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
-      <artifactId>vertx-micrometer-metrics</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.vertx</groupId>
       <artifactId>vertx-mongo-client</artifactId>
     </dependency>
     <dependency>

--- a/okapi-core/src/main/java/org/folio/okapi/MainDeploy.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainDeploy.java
@@ -24,6 +24,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import org.apache.logging.log4j.Logger;
 import org.folio.okapi.common.Messages;
+import org.folio.okapi.common.MetricsUtil;
 import org.folio.okapi.common.OkapiLogger;
 import org.folio.okapi.util.MetricsHelper;
 
@@ -176,7 +177,7 @@ public class MainDeploy {
   }
 
   private void deploy(boolean clustered, Handler<AsyncResult<Vertx>> fut) {
-    MetricsHelper.init(vopt);
+    MetricsUtil.init(vopt);
     if (clustered) {
       deployClustered(fut);
     } else {

--- a/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
@@ -21,6 +21,7 @@ import org.folio.okapi.bean.Tenant;
 import org.folio.okapi.common.Config;
 import org.folio.okapi.common.ErrorType;
 import org.folio.okapi.common.Messages;
+import org.folio.okapi.common.MetricsUtil;
 import org.folio.okapi.common.ModuleId;
 import org.folio.okapi.common.ModuleVersionReporter;
 import org.folio.okapi.common.OkapiLogger;
@@ -194,7 +195,7 @@ public class MainVerticle extends AbstractVerticle {
   @Override
   public void stop(Promise<Void> promise) {
     logger.info("stop");
-    MetricsHelper.stop();
+    MetricsUtil.stop();
     Future<Void> future = Future.succeededFuture();
     if (deploymentManager != null) {
       future = future.compose(x -> deploymentManager.shutdown());


### PR DESCRIPTION
Moved some metrics code, for example supporting for different backends, to Okapi-common package, so RMB can use it without duplicating effort.