### PR TITLE
OKAPI-903: Logging object reference rather than JSON

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/service/impl/DockerModuleHandle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/service/impl/DockerModuleHandle.java
@@ -10,7 +10,6 @@ import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.RequestOptions;
 import io.vertx.core.json.DecodeException;
-import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.SocketAddress;
@@ -18,7 +17,6 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.function.Supplier;
 import org.apache.logging.log4j.Logger;
 import org.folio.okapi.bean.AnyDescriptor;
 import org.folio.okapi.bean.EnvEntry;
@@ -341,14 +339,19 @@ public class DockerModuleHandle implements ModuleHandle {
 
     String doc = j.encodePrettily();
 
-    logger.info("createContainer {}", (Supplier<String>) () -> {
-      if (! j.containsKey("env")) {
-        return doc;
+    if (logger.isInfoEnabled()) {
+      String logDoc = doc;
+
+      if (j.containsKey("env")) {
+        // don't show env variables that may contain sensitive credentials in the log
+        j.put("env", new JsonArray().add("..."));
+        logDoc = j.encodePrettily();
       }
-      // don't show env variables that may contain sensitive credentials in the log
-      j.put("env", new JsonArray().add("..."));
-      return j.encodePrettily();
-    });
+
+      // Cannot use a lambda because Mockito does not support
+      // matching a Supplier vararg when an Object vararg exists
+      logger.info("createContainer {}", logDoc);
+    }
 
     return doc;
   }

--- a/okapi-core/src/test/java/org/folio/okapi/service/impl/DockerModuleHandleTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/service/impl/DockerModuleHandleTest.java
@@ -15,7 +15,6 @@ import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import java.util.Base64;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Supplier;
 import org.apache.logging.log4j.Logger;
 import org.assertj.core.api.WithAssertions;
 import org.folio.okapi.bean.AnyDescriptor;
@@ -466,9 +465,10 @@ public class DockerModuleHandleTest implements WithAssertions {
     launchDescriptor.setDockerArgs(new AnyDescriptor().set("%p", "%p"));
     Logger logger = mock(Logger.class);
     StringBuilder logMessage = new StringBuilder();
+    when(logger.isInfoEnabled()).thenReturn(true);
     doAnswer(AdditionalAnswers.answerVoid(
-        (String msg, Supplier<Object> supplier) -> logMessage.append(msg).append(supplier.get())))
-    .when(logger).info(anyString(), any(Supplier.class));
+        (String msg, Object param) -> logMessage.append(msg).append(param.toString())))
+        .when(logger).info(anyString(), any(Object.class));
     DockerModuleHandle dockerModuleHandle = new DockerModuleHandle(Vertx.vertx(), launchDescriptor,
         "mod-users-5.0.0-SNAPSHOT", new Ports(9232, 9233), "localhost", 9232, new JsonObject(),
         logger);


### PR DESCRIPTION
Cannot use a lambda because Mockito does not support
matching a Supplier vararg when an Object vararg exists