### PR TITLE
Okapi 916 match path using hash

### DIFF
--- a/doc/guide.md
+++ b/doc/guide.md
@@ -1994,7 +1994,7 @@ cat > /tmp/okapi-proxy-foo.json <<END
         {
           "methods": [ "GET", "POST" ],
           "pathPattern": "/testb",
-          "permissionsRequired": [] 
+          "permissionsRequired": [ ]
         }
       ]
     }

--- a/okapi-core/src/main/java/org/folio/okapi/MainDeploy.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainDeploy.java
@@ -26,7 +26,6 @@ import org.apache.logging.log4j.Logger;
 import org.folio.okapi.common.Messages;
 import org.folio.okapi.common.MetricsUtil;
 import org.folio.okapi.common.OkapiLogger;
-import org.folio.okapi.util.MetricsHelper;
 
 @java.lang.SuppressWarnings({"squid:S3776"})
 public class MainDeploy {

--- a/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
@@ -398,12 +398,8 @@ public class MainVerticle extends AbstractVerticle {
   }
 
   private Future<Void> startRedeploy() {
-    return discoveryManager.restartModules().compose(res -> {
-      if (!enableProxy) {
-        return Future.succeededFuture();
-      }
-      return tenantManager.startTimers(discoveryManager);
-    });
+    return discoveryManager.restartModules()
+        .compose(res -> tenantManager.startTimers(discoveryManager));
   }
 
 }

--- a/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
@@ -163,7 +163,6 @@ public class MainVerticle extends AbstractVerticle {
       moduleManager = new ModuleManager(moduleStore);
       TenantStore tenantStore = storage.getTenantStore();
       tenantManager = new TenantManager(moduleManager, tenantStore);
-      moduleManager.setTenantManager(tenantManager);
       discoveryManager.setModuleManager(moduleManager);
       logger.info("Proxy using {} storage", storageType);
       PullManager pullManager = new PullManager(vertx, moduleManager);
@@ -179,7 +178,6 @@ public class MainVerticle extends AbstractVerticle {
       moduleManager.forceLocalMap(); // make sure it is not shared
       tenantManager = new TenantManager(moduleManager, new TenantStoreNull());
       tenantManager.forceLocalMap();
-      moduleManager.setTenantManager(tenantManager);
       discoveryManager.setModuleManager(moduleManager);
       InternalModule internalModule = new InternalModule(
           null, null, deploymentManager, null,

--- a/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
@@ -265,7 +265,7 @@ public class MainVerticle extends AbstractVerticle {
           okapiModule, interfaceVersion);
       moduleManager.create(md, true, true, true).onFailure(cause1 ->
           promise.fail(cause1) // something went badly wrong
-      ).onComplete(ires -> {
+      ).onSuccess(ires -> {
         checkSuperTenant(okapiModule, promise);
       });
     });

--- a/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
@@ -44,7 +44,6 @@ import org.folio.okapi.service.impl.TenantStoreNull;
 import org.folio.okapi.util.CorsHelper;
 import org.folio.okapi.util.EventBusChecker;
 import org.folio.okapi.util.LogHelper;
-import org.folio.okapi.util.MetricsHelper;
 import org.folio.okapi.util.OkapiError;
 
 @java.lang.SuppressWarnings({"squid:S1192"})

--- a/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
@@ -250,25 +250,22 @@ public class MainVerticle extends AbstractVerticle {
     final ModuleDescriptor md = InternalModule.moduleDescriptor(okapiVersion);
     final String okapiModule = md.getId();
     final String interfaceVersion = md.getProvides()[0].getVersion();
-    moduleManager.get(okapiModule).onComplete(gres -> {
-      if (gres.succeeded()) { // we already have one, go on
-        logger.debug("checkInternalModules: Already have {} "
-            + " with interface version {}", okapiModule, interfaceVersion);
-        // See Okapi-359 about version checks across the cluster
-        checkSuperTenant(okapiModule, promise);
-        return;
-      }
-      if (OkapiError.getType(gres.cause()) != ErrorType.NOT_FOUND) {
-        promise.fail(gres.cause()); // something went badly wrong
+    moduleManager.get(okapiModule).onSuccess(gres -> {
+      // we already have one, go on
+      logger.debug("checkInternalModules: Already have {} "
+          + " with interface version {}", okapiModule, interfaceVersion);
+      // See Okapi-359 about version checks across the cluster
+      checkSuperTenant(okapiModule, promise);
+    }).onFailure(cause -> {
+      if (OkapiError.getType(cause) != ErrorType.NOT_FOUND) {
+        promise.fail(cause); // something went badly wrong
         return;
       }
       logger.debug("Creating the internal Okapi module {} with interface version {}",
           okapiModule, interfaceVersion);
-      moduleManager.create(md, true, true, true).onComplete(ires -> {
-        if (ires.failed()) {
-          promise.fail(ires.cause()); // something went badly wrong
-          return;
-        }
+      moduleManager.create(md, true, true, true).onFailure(cause1 ->
+          promise.fail(cause1) // something went badly wrong
+      ).onComplete(ires -> {
         checkSuperTenant(okapiModule, promise);
       });
     });
@@ -276,52 +273,48 @@ public class MainVerticle extends AbstractVerticle {
   }
 
   private void checkSuperTenant(String okapiModule, Promise<Void> promise) {
-    tenantManager.get(XOkapiHeaders.SUPERTENANT_ID).onComplete(gres -> {
-      if (gres.succeeded()) { // we already have one, go on
-        logger.info("checkSuperTenant: Already have " + XOkapiHeaders.SUPERTENANT_ID);
-        Tenant st = gres.result();
-        Set<String> enabledMods = st.getEnabled().keySet();
-        if (enabledMods.contains(okapiModule)) {
-          logger.info("checkSuperTenant: enabled version is {}", okapiModule);
-          promise.complete();
-          return;
-        }
-        // Check version compatibility
-        String enver = "";
-        for (String emod : enabledMods) {
-          if (emod.startsWith("okapi-")) {
-            enver = emod;
-          }
-        }
-        final String ev = enver;
-        logger.debug("checkSuperTenant: Enabled version is '{}', not '{}'",
-            ev, okapiModule);
-        // See Okapi-359 about version checks across the cluster
-        if (ModuleId.compare(ev, okapiModule) >= 4) {
-          logger.warn("checkSuperTenant: This Okapi is too old,"
-                  + "{} we already have {} in the database. Use that!",
-              okapiVersion, ev);
-          promise.complete();
-          return;
-        }
-        logger.info("checkSuperTenant: Need to upgrade the stored version from {} to {}",
-            ev, okapiModule);
-        // Use the commit, easier interface.
-        // the internal module can not have dependencies
-        // See Okapi-359 about version checks across the cluster
-        tenantManager.updateModuleCommit(st, ev, okapiModule).onComplete(ures -> {
-          if (ures.failed()) {
-            promise.fail(ures.cause());
-            return;
-          }
-          logger.info("Upgraded the InternalModule version from '{}' to '{}' for {}",
-              ev, okapiModule, XOkapiHeaders.SUPERTENANT_ID);
-          promise.complete();
-        });
+    tenantManager.get(XOkapiHeaders.SUPERTENANT_ID).onSuccess(tenant -> {
+      // we already have one, go on
+      logger.info("checkSuperTenant: Already have " + XOkapiHeaders.SUPERTENANT_ID);
+      Set<String> enabledMods = tenant.getEnabled().keySet();
+      if (enabledMods.contains(okapiModule)) {
+        logger.info("checkSuperTenant: enabled version is {}", okapiModule);
+        promise.complete();
         return;
       }
-      if (OkapiError.getType(gres.cause()) != ErrorType.NOT_FOUND) {
-        promise.fail(gres.cause()); // something went badly wrong
+      // Check version compatibility
+      String enver = "";
+      for (String emod : enabledMods) {
+        if (emod.startsWith("okapi-")) {
+          enver = emod;
+        }
+      }
+      final String ev = enver;
+      logger.debug("checkSuperTenant: Enabled version is '{}', not '{}'",
+          ev, okapiModule);
+      // See Okapi-359 about version checks across the cluster
+      if (ModuleId.compare(ev, okapiModule) >= 4) {
+        logger.warn("checkSuperTenant: This Okapi is too old,"
+                + "{} we already have {} in the database. Use that!",
+            okapiVersion, ev);
+        promise.complete();
+        return;
+      }
+      logger.info("checkSuperTenant: Need to upgrade the stored version from {} to {}",
+          ev, okapiModule);
+      // Use the commit, easier interface.
+      // the internal module can not have dependencies
+      // See Okapi-359 about version checks across the cluster
+      tenantManager.updateModuleCommit(tenant, ev, okapiModule).onFailure(cause ->
+          promise.fail(cause)
+      ).onSuccess(res -> {
+        logger.info("Upgraded the InternalModule version from '{}' to '{}' for {}",
+            ev, okapiModule, XOkapiHeaders.SUPERTENANT_ID);
+        promise.complete();
+      });
+    }).onFailure(cause -> {
+      if (OkapiError.getType(cause) != ErrorType.NOT_FOUND) {
+        promise.fail(cause); // something went badly wrong
         return;
       }
       logger.info("Creating the superTenant " + XOkapiHeaders.SUPERTENANT_ID);

--- a/okapi-core/src/main/java/org/folio/okapi/managers/DeploymentManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/DeploymentManager.java
@@ -86,23 +86,17 @@ public class DeploymentManager {
     eventBus.consumer(nd.getUrl() + "/deploy", message -> {
       String b = (String) message.body();
       DeploymentDescriptor dd = Json.decodeValue(b, DeploymentDescriptor.class);
-      deploy(dd).onComplete(res -> {
-        if (res.failed()) {
-          message.fail(OkapiError.getType(res.cause()).ordinal(), res.cause().getMessage());
-        } else {
-          message.reply(Json.encodePrettily(res.result()));
-        }
-      });
+      deploy(dd).onFailure(cause ->
+          message.fail(OkapiError.getType(cause).ordinal(), cause.getMessage())
+      ).onSuccess(res -> message.reply(Json.encodePrettily(res)));
     });
     eventBus.consumer(nd.getUrl() + "/undeploy", message -> {
       String instId = (String) message.body();
-      undeploy(instId).onComplete(res -> {
-        if (res.failed()) {
-          message.fail(400, res.cause().getMessage());
-        } else {
-          message.reply(null);
-        }
-      });
+      undeploy(instId).onFailure(cause ->
+          message.fail(400, cause.getMessage())
+      ).onSuccess(res ->
+          message.reply(null)
+      );
     });
     return dm.addNode(nd);
   }

--- a/okapi-core/src/main/java/org/folio/okapi/managers/DiscoveryManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/DiscoveryManager.java
@@ -229,7 +229,6 @@ public class DiscoveryManager implements NodeListener {
 
     List<Future> futures = new LinkedList<>();
     for (DeploymentDescriptor dd : ddList) {
-      logger.info("removeAndUndeploy {} {}", dd.getSrvcId(), dd.getInstId());
       futures.add(callUndeploy(dd)
           .compose(res -> deploymentStore.delete(dd.getInstId()))
           .mapEmpty());
@@ -243,10 +242,8 @@ public class DiscoveryManager implements NodeListener {
         md.getSrvcId(), md.getInstId(), md.getNodeId());
     final String nodeId = md.getNodeId();
     if (nodeId == null) {
-      logger.info("callUndeploy remove");
       return remove(md.getSrvcId(), md.getInstId()).mapEmpty();
     }
-    logger.info("callUndeploy calling..");
     return getNode(nodeId).compose(res ->
         vertx.eventBus().request(res.getUrl() + "/undeploy", md.getInstId(),
             deliveryOptions).mapEmpty()

--- a/okapi-core/src/main/java/org/folio/okapi/managers/DiscoveryManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/DiscoveryManager.java
@@ -436,12 +436,9 @@ public class DiscoveryManager implements NodeListener {
         return;
       }
       req.result().end();
-      req.result().onComplete(res -> {
-        if (res.failed()) {
-          promise.handle(fail(res.cause(), hd));
-          return;
-        }
-        HttpClientResponse response = res.result();
+      req.result().onFailure(cause ->
+          promise.handle(fail(cause, hd))
+      ).onSuccess(response -> {
         response.endHandler(x -> {
           hd.setHealthMessage("OK");
           hd.setHealthStatus(true);

--- a/okapi-core/src/main/java/org/folio/okapi/managers/InternalModule.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/InternalModule.java
@@ -6,8 +6,8 @@ import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.Json;
 import io.vertx.ext.web.RoutingContext;
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -632,11 +632,7 @@ public class InternalModule {
     }
     StringBuilder uriEncoded = new StringBuilder(uri);
     for (String id : ids) {
-      try {
-        uriEncoded.append("/" + URLEncoder.encode(id, "UTF-8"));
-      } catch (UnsupportedEncodingException ex) {
-        return Future.failedFuture(messages.getMessage("11600", id, ex.getMessage()));
-      }
+      uriEncoded.append("/" + URLEncoder.encode(id, StandardCharsets.UTF_8));
     }
     pc.getCtx().response().putHeader("Location", uriEncoded.toString());
     pc.getCtx().response().setStatusCode(201);

--- a/okapi-core/src/main/java/org/folio/okapi/managers/InternalModule.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/InternalModule.java
@@ -904,7 +904,14 @@ public class InternalModule {
   }
 
   private Future<String> deleteModule(String id) {
-    return moduleManager.delete(id).compose(res -> Future.succeededFuture(""));
+    return tenantManager.getModuleUser(id)
+        .compose(tenants -> {
+          if (!tenants.isEmpty()) {
+            return Future.failedFuture(new OkapiError(ErrorType.USER,
+                messages.getMessage("10206", id, tenants.get(0))));
+          }
+          return moduleManager.delete(id).compose(res -> Future.succeededFuture(""));
+        });
   }
 
   private Future<String> getDeployment(String id) {

--- a/okapi-core/src/main/java/org/folio/okapi/managers/InternalModule.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/InternalModule.java
@@ -910,7 +910,7 @@ public class InternalModule {
             return Future.failedFuture(new OkapiError(ErrorType.USER,
                 messages.getMessage("10206", id, tenants.get(0))));
           }
-          return moduleManager.delete(id).compose(res -> Future.succeededFuture(""));
+          return moduleManager.delete(id).map("");
         });
   }
 

--- a/okapi-core/src/main/java/org/folio/okapi/managers/ModuleManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ModuleManager.java
@@ -181,22 +181,18 @@ public class ModuleManager {
         .compose(ares -> deleteCheckDep(id, ares))
         .compose(res -> {
           if (moduleStore == null) {
-            return Future.succeededFuture(Boolean.TRUE);
+            return Future.succeededFuture();
           } else {
-            return moduleStore.delete(id);
+            return moduleStore.delete(id).mapEmpty();
           }
         })
-        .compose(res -> {
-          if (Boolean.FALSE.equals(res)) {
-            return Future.failedFuture(new OkapiError(ErrorType.NOT_FOUND, id));
-          }
-          return deleteInternal(id).mapEmpty();
-        });
+        .compose(res -> deleteInternal(id).mapEmpty());
   }
 
   private Future<Void> deleteCheckDep(String id, LinkedHashMap<String, ModuleDescriptor> mods) {
     if (!mods.containsKey(id)) {
-      return Future.failedFuture(new OkapiError(ErrorType.NOT_FOUND, messages.getMessage("10207")));
+      return Future.failedFuture(
+          new OkapiError(ErrorType.NOT_FOUND, messages.getMessage("10207", id)));
     }
     mods.remove(id);
     String res = DepResolution.checkAllDependencies(mods);

--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -132,14 +132,14 @@ public class ProxyService {
     pc.logResponse(mi.getModuleDescriptor().getId(), url, statusCode);
   }
 
-  private boolean match(RoutingEntry e, HttpServerRequest req) {
+  private static boolean match(RoutingEntry e, HttpServerRequest req) {
     Timer.Sample sample = MetricsHelper.getTimerSample();
     boolean matchResult = e.match(req.uri(), req.method().name());
     MetricsHelper.recordCodeExecutionTime(sample, "ProxyService.match");
     return matchResult;
   }
 
-  private boolean resolveRedirects(ProxyContext pc,
+  private static boolean resolveRedirects(ProxyContext pc,
                                    List<ModuleInstance> mods, RoutingEntry re,
                                    List<ModuleDescriptor> enabledModules,
                                    final String loop, final String uri) {
@@ -1300,8 +1300,11 @@ public class ProxyService {
           logger.debug("authForSystemInterface: {}",
               () -> Json.encode(cli.getRespHeaders().entries()));
           String modTok = cli.getRespHeaders().get(XOkapiHeaders.MODULE_TOKENS);
-          JsonObject jo = new JsonObject(modTok);
-          String token = jo.getString(modId, deftok);
+          String token = null;
+          if (modTok != null) {
+            JsonObject jo = new JsonObject(modTok);
+            token = jo.getString(modId, deftok);
+          }
           logger.debug("authForSystemInterface: Got token {}", token);
           return doCallSystemInterface(headers, tenantId, token, inst, null, request);
         });

--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -191,10 +191,7 @@ public class ProxyService {
         logger.debug("getModulesForRequest:  Added {} {} {} {} / {}",
             mi.getModuleDescriptor().getId(),
             re.getPathPattern(), re.getPath(), re.getPhase(), re.getLevel());
-      }
-    }
-    for (ModuleInstance mi : mods) {
-      if (!mi.isHandler()) {
+      } else {
         mi.setAuthToken(req.headers().get(XOkapiHeaders.TOKEN));
       }
     }

--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -81,6 +81,8 @@ public class ProxyService {
   private static final String TOKEN_CACHE_MAX_SIZE = "token_cache_max_size";
   private static final String TOKEN_CACHE_TTL_MS = "token_cache_ttl_ms";
   private static final Messages messages = Messages.getInstance();
+  private static final Comparator<ModuleInstance> compareInstanceLevel =
+      Comparator.comparing((ModuleInstance a) -> a.getRoutingEntry().getPhaseLevel());
   private final TokenCache tokenCache;
 
   /**
@@ -195,9 +197,7 @@ public class ProxyService {
         mi.setAuthToken(req.headers().get(XOkapiHeaders.TOKEN));
       }
     }
-    Comparator<ModuleInstance> cmp = Comparator.comparing((ModuleInstance a)
-        -> a.getRoutingEntry().getPhaseLevel());
-    mods.sort(cmp);
+    mods.sort(compareInstanceLevel);
     Iterator<ModuleInstance> iter = mods.iterator();
     boolean found = false;
     while (iter.hasNext()) {

--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -567,7 +567,9 @@ public class ProxyService {
           return;
         }
         ModuleCache cache = cacheRes.result();
+        final Timer.Sample sample = MetricsHelper.getTimerSample();
         List<ModuleInstance> l = getModulesForRequest(pc, cache);
+        MetricsHelper.recordCodeExecutionTime(sample, "ProxyService.getModulesForRequest");
         if (l == null) {
           stream.resume();
           return; // ctx already set up

--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -133,13 +133,6 @@ public class ProxyService {
     pc.logResponse(mi.getModuleDescriptor().getId(), url, statusCode);
   }
 
-  private static boolean match(RoutingEntry e, HttpServerRequest req) {
-    Timer.Sample sample = MetricsHelper.getTimerSample();
-    boolean matchResult = e.match(req.uri(), req.method().name());
-    MetricsHelper.recordCodeExecutionTime(sample, "ProxyService.match");
-    return matchResult;
-  }
-
   /**
    * Checks for a cached token, userId, permissions and updates the provided ModuleInstance
    * accordingly.

--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -79,7 +79,7 @@ public class ProxyService {
   private static final String REDIRECTQUERY = "redirect-query"; // See redirectProxy below
   private static final String TOKEN_CACHE_MAX_SIZE = "token_cache_max_size";
   private static final String TOKEN_CACHE_TTL_MS = "token_cache_ttl_ms";
-  private final Messages messages = Messages.getInstance();
+  private static final Messages messages = Messages.getInstance();
   private final TokenCache tokenCache;
 
   /**

--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -183,7 +183,13 @@ public class ProxyService {
   private List<ModuleInstance> getModulesForRequest(ProxyContext pc, ModuleCache moduleCache) {
     HttpServerRequest req = pc.getCtx().request();
     final String id = req.getHeader(XOkapiHeaders.MODULE_ID);
-    List<ModuleInstance> mods = moduleCache.lookup(req.uri(), req.method(), id);
+    List<ModuleInstance> mods = null;
+    try {
+      mods = moduleCache.lookup(req.uri(), req.method(), id);
+    } catch (IllegalArgumentException e) {
+      pc.responseError(500, e.getMessage());
+      return null;
+    }
     boolean skipAuth = false;
     for (ModuleInstance mi : mods) {
       if (mi.isHandler()) {

--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -230,17 +230,6 @@ public class ProxyService {
     }
   }
 
-  private List<ModuleInstance> getModulesForRequest2(ProxyContext pc,
-                                                    List<ModuleDescriptor> enabledModules) {
-    HttpServerRequest req = pc.getCtx().request();
-    final String id = req.getHeader(XOkapiHeaders.MODULE_ID);
-    List<ModuleInstance> mods = moduleCache.lookup(req.uri(), req.method(), id, enabledModules);
-    Comparator<ModuleInstance> cmp =
-        Comparator.comparing((ModuleInstance a) -> a.getRoutingEntry().getPhaseLevel());
-    mods.sort(cmp);
-    return mods;
-  }
-
   /**
    * Builds the pipeline of modules to be invoked for a request. Sets the
    * default authToken for each ModuleInstance. Later, these can be overwritten

--- a/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
@@ -61,6 +61,7 @@ public class TenantManager implements Liveness {
   private Messages messages = Messages.getInstance();
   private Vertx vertx;
   private Map<String, ModuleCache> enabledModulesCache = new HashMap<>();
+  // tenants with new permission module (_tenantPermissions version 1.1 or later)
   private Map<String, Boolean> expandedModulesCache = new HashMap<>();
 
   /**

--- a/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.util.Supplier;
 import org.folio.okapi.bean.InstallJob;
 import org.folio.okapi.bean.InterfaceDescriptor;
 import org.folio.okapi.bean.ModuleDescriptor;
@@ -38,6 +37,7 @@ import org.folio.okapi.service.TenantStore;
 import org.folio.okapi.util.DepResolution;
 import org.folio.okapi.util.LockedTypedMap1;
 import org.folio.okapi.util.LockedTypedMap2;
+import org.folio.okapi.util.ModuleCache;
 import org.folio.okapi.util.OkapiError;
 import org.folio.okapi.util.ProxyContext;
 import org.folio.okapi.util.TenantInstallOptions;
@@ -60,11 +60,14 @@ public class TenantManager implements Liveness {
   private Set<String> timers = new HashSet<>();
   private Messages messages = Messages.getInstance();
   private Vertx vertx;
+  private Map<String, ModuleCache> enabledModulesCache = new HashMap<>();
+  private Map<String, Boolean> expandedModulesCache = new HashMap<>();
 
   /**
    * Create tenant manager.
+   *
    * @param moduleManager module manager
-   * @param tenantStore tenant storage
+   * @param tenantStore   tenant storage
    */
   public TenantManager(ModuleManager moduleManager, TenantStore tenantStore) {
     this.moduleManager = moduleManager;
@@ -230,6 +233,41 @@ public class TenantManager implements Liveness {
     });
   }
 
+  Future<Void> enableAndDisableCheck(Tenant tenant, ModuleDescriptor modFrom,
+                                     ModuleDescriptor modTo) {
+
+    return getEnabledModules(tenant).compose(modlist -> {
+      HashMap<String, ModuleDescriptor> mods = new HashMap<>(modlist.size());
+      for (ModuleDescriptor md : modlist) {
+        mods.put(md.getId(), md);
+      }
+      if (modTo == null) {
+        String deps = DepResolution.checkAllDependencies(mods);
+        if (!deps.isEmpty()) {
+          return Future.succeededFuture(); // failures even before we remove a module
+        }
+      }
+      if (modFrom != null) {
+        mods.remove(modFrom.getId());
+      }
+      if (modTo != null) {
+        ModuleDescriptor already = mods.get(modTo.getId());
+        if (already != null) {
+          return Future.failedFuture(new OkapiError(ErrorType.USER,
+              "Module " + modTo.getId() + " already provided"));
+        }
+        mods.put(modTo.getId(), modTo);
+      }
+      String conflicts = DepResolution.checkAllConflicts(mods);
+      String deps = DepResolution.checkAllDependencies(mods);
+      if (!conflicts.isEmpty() || !deps.isEmpty()) {
+        return Future.failedFuture(new OkapiError(ErrorType.USER, conflicts + " " + deps));
+      }
+      return Future.succeededFuture();
+    });
+  }
+
+
   Future<String> enableAndDisableModule(
       String tenantId, TenantInstallOptions options, String moduleFrom,
       TenantModuleDescriptor td, ProxyContext pc) {
@@ -246,7 +284,7 @@ public class TenantManager implements Liveness {
                   Future<Void> future = Future.succeededFuture();
                   if (options.getDepCheck()) {
                     future = future
-                        .compose(x -> moduleManager.enableAndDisableCheck(tenant, mdFrom, mdTo));
+                        .compose(x -> enableAndDisableCheck(tenant, mdFrom, mdTo));
                   }
                   return future
                       .compose(x -> enableAndDisableModule(tenant, options, mdFrom, mdTo, pc));
@@ -398,13 +436,15 @@ public class TenantManager implements Liveness {
     String moduleTo = mdTo != null ? mdTo.getId() : null;
 
     Promise<Void> promise = Promise.promise();
-    return updateModuleCommit(tenant, moduleFrom, moduleTo).compose(ures -> {
-      if (moduleTo != null) {
-        EventBus eb = vertx.eventBus();
-        eb.publish(EVENT_NAME, tenant.getId());
-      }
-      return Future.succeededFuture();
-    });
+    return updateModuleCommit(tenant, moduleFrom, moduleTo)
+        .compose(x -> reloadEnabledModules(tenant))
+        .compose(x -> {
+          if (moduleTo != null) {
+            EventBus eb = vertx.eventBus();
+            eb.publish(EVENT_NAME, tenant.getId());
+          }
+          return Future.succeededFuture();
+        });
   }
 
   /**
@@ -417,7 +457,7 @@ public class TenantManager implements Liveness {
     return tenants.getKeys().compose(res -> {
       for (String tenantId : res) {
         logger.info("starting {}", tenantId);
-        handleTimer(tenantId);
+        reloadEnabledModules(tenantId).onComplete(x -> handleTimer(tenantId));
       }
       consumeTimers();
       return Future.succeededFuture();
@@ -435,7 +475,7 @@ public class TenantManager implements Liveness {
     EventBus eb = vertx.eventBus();
     eb.consumer(EVENT_NAME, res -> {
       String tenantId = (String) res.body();
-      handleTimer(tenantId);
+      reloadEnabledModules(tenantId).onComplete(x -> handleTimer(tenantId));
     });
   }
 
@@ -458,7 +498,7 @@ public class TenantManager implements Liveness {
         return;
       }
       Tenant tenant = tres.result();
-      moduleManager.getEnabledModules(tenant).onComplete(mres -> {
+      getEnabledModules(tenant).onComplete(mres -> {
         if (mres.failed()) {
           stopTimer(tenantId, moduleId, seq1);
           return;
@@ -697,7 +737,7 @@ public class TenantManager implements Liveness {
    */
 
   private Future<ModuleDescriptor> findSystemInterface(Tenant tenant, String interfaceName) {
-    return moduleManager.getEnabledModules(tenant).compose(res -> {
+    return getEnabledModules(tenant).compose(res -> {
       for (ModuleDescriptor md : res) {
         if (md.getSystemInterface(interfaceName) != null) {
           return Future.succeededFuture(md);
@@ -715,7 +755,7 @@ public class TenantManager implements Liveness {
 
   private Future<List<InterfaceDescriptor>> listInterfaces(Tenant tenant, boolean full,
                                                            String interfaceType) {
-    return moduleManager.getEnabledModules(tenant).compose(modlist -> {
+    return getEnabledModules(tenant).compose(modlist -> {
       List<InterfaceDescriptor> intList = new LinkedList<>();
       Set<String> ids = new HashSet<>();
       for (ModuleDescriptor md : modlist) {
@@ -743,7 +783,7 @@ public class TenantManager implements Liveness {
 
     return tenants.getNotFound(tenantId).compose(tenant -> {
       List<ModuleDescriptor> mdList = new LinkedList<>();
-      return moduleManager.getEnabledModules(tenant).compose(modlist -> {
+      return getEnabledModules(tenant).compose(modlist -> {
         for (ModuleDescriptor md : modlist) {
           for (InterfaceDescriptor provide : md.getProvidesList()) {
             if (interfaceName.equals(provide.getId())
@@ -1043,6 +1083,66 @@ public class TenantManager implements Liveness {
         return CompositeFuture.all(futures).mapEmpty();
       });
     });
+  }
+
+  /**
+   * Get module cache for tenant.
+   * @param tenant Tenant
+   * @return Module Cache
+   */
+  public Future<ModuleCache> getModuleCache(Tenant tenant) {
+    logger.info("getEnabledModules tenant={}", tenant.getId());
+    if (!enabledModulesCache.containsKey(tenant.getId())) {
+      return Future.succeededFuture(new ModuleCache(new LinkedList<>()));
+    }
+    return Future.succeededFuture(enabledModulesCache.get(tenant.getId()));
+  }
+
+  /**
+   * Return modules enabled for tenant.
+   * @param tenant Tenant
+   * @return list of modules
+   */
+  public Future<List<ModuleDescriptor>> getEnabledModules(Tenant tenant) {
+    return getModuleCache(tenant).map(cache -> cache.getModules());
+  }
+
+  private Future<Void> reloadEnabledModules(String tenantId) {
+    return tenants.get(tenantId).compose(tenant -> {
+      if (tenant == null) {
+        enabledModulesCache.remove(tenantId);
+        return Future.succeededFuture();
+      }
+      return reloadEnabledModules(tenant);
+    });
+  }
+
+  private Future<Void> reloadEnabledModules(Tenant tenant) {
+    List<ModuleDescriptor> mdl = new LinkedList<>();
+    List<Future> futures = new LinkedList<>();
+    for (String tenantId : tenant.getEnabled().keySet()) {
+      futures.add(moduleManager.get(tenantId).compose(md -> {
+        InterfaceDescriptor id = md.getSystemInterface("_tenantPermissions");
+        if (id != null) {
+          expandedModulesCache.put(tenant.getId(), !id.getVersion().equals("1.0"));
+        }
+        mdl.add(md);
+        return Future.succeededFuture();
+      }));
+    }
+    return CompositeFuture.all(futures).compose(res -> {
+      enabledModulesCache.put(tenant.getId(), new ModuleCache(mdl));
+      return Future.succeededFuture();
+    });
+  }
+
+  /**
+   * Return if permissions should be expanded.
+   * @param tenantId Tenant ID
+   * @return TRUE if expansion; FALSE if no expansion; null if not known
+   */
+  Boolean getExpandModulePermissions(String tenantId) {
+    return expandedModulesCache.get(tenantId);
   }
 
   @Override

--- a/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
@@ -1091,7 +1091,6 @@ public class TenantManager implements Liveness {
    * @return Module Cache
    */
   public Future<ModuleCache> getModuleCache(Tenant tenant) {
-    logger.info("getEnabledModules tenant={}", tenant.getId());
     if (!enabledModulesCache.containsKey(tenant.getId())) {
       return Future.succeededFuture(new ModuleCache(new LinkedList<>()));
     }

--- a/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
@@ -905,6 +905,7 @@ public class TenantManager implements Liveness {
             return;
           }
           if (x.failed()) {
+            logger.warn("job failed", x.cause());
             promise.fail(x.cause());
             return;
           }

--- a/okapi-core/src/main/java/org/folio/okapi/util/ModuleCache.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/ModuleCache.java
@@ -2,39 +2,39 @@ package org.folio.okapi.util;
 
 import io.vertx.core.http.HttpMethod;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
+import org.apache.logging.log4j.Logger;
 import org.folio.okapi.bean.ModuleDescriptor;
 import org.folio.okapi.bean.ModuleInstance;
 import org.folio.okapi.bean.RoutingEntry;
+import org.folio.okapi.common.OkapiLogger;
 
 public class ModuleCache {
+  private static final Logger logger = OkapiLogger.get();
+
   Map<String, List<ModuleInstance>> proxyMap = new HashMap<>();
   Map<String, List<ModuleInstance>> multiMap = new HashMap<>();
   Map<String, List<ModuleInstance>> filterMap = new HashMap<>();
-  Set<String> modules = new HashSet<>();
 
-  String getPatternPrefix(RoutingEntry re) {
+  static String getPatternPrefix(RoutingEntry re) {
     String pathPattern = re.getPathPattern();
     if (pathPattern == null) {
       return "/";
     }
-    int i = 0;
-    while (i < pathPattern.length()) {
-      if (pathPattern.charAt(i) == '*' || pathPattern.charAt(i) == '{') {
+    int index = 0;
+    while (index < pathPattern.length()) {
+      if (pathPattern.charAt(index) == '*' || pathPattern.charAt(index) == '{') {
         break;
       }
-      i++;
+      index++;
     }
-    return pathPattern.substring(0, i);
+    return pathPattern.substring(0, index);
   }
 
-  void add(ModuleDescriptor moduleDescriptor, Map<String, List<ModuleInstance>> map,
-           List<RoutingEntry> entries) {
+  static void add(ModuleDescriptor moduleDescriptor, Map<String, List<ModuleInstance>> map,
+                  List<RoutingEntry> entries) {
     for (RoutingEntry routingEntry : entries) {
       String prefix = getPatternPrefix(routingEntry);
       List<ModuleInstance> list = map.get(prefix);
@@ -42,21 +42,39 @@ public class ModuleCache {
         list = new LinkedList<>();
         map.put(prefix, list);
       }
-      list.add(new ModuleInstance(moduleDescriptor, routingEntry, null, HttpMethod.GET, false));
+      list.add(new ModuleInstance(moduleDescriptor, routingEntry,
+          null /* not in use for the match */,
+          HttpMethod.GET /* not in use for the match */,
+          false /* not in use for the match */));
     }
   }
 
-  void add(ModuleDescriptor moduleDescriptor) {
+  /**
+   * Add module to ModuleCache.
+   * @param moduleDescriptor module descriptor
+   */
+  public void add(ModuleDescriptor moduleDescriptor) {
     add(moduleDescriptor, proxyMap, moduleDescriptor.getProxyRoutingEntries());
     add(moduleDescriptor, multiMap, moduleDescriptor.getMultiRoutingEntries());
     add(moduleDescriptor, filterMap, moduleDescriptor.getFilterRoutingEntries());
   }
 
-  List<ModuleInstance> lookup(String uri, HttpMethod method, Map<String, List<ModuleInstance>> map,
-                              boolean handler) {
+  /**
+   * clear module cache.
+   */
+  public void clear() {
+    proxyMap.clear();
+    multiMap.clear();
+    filterMap.clear();
+  }
+
+  static List<ModuleInstance> lookup(String uri, HttpMethod method, Map<String,
+      List<ModuleInstance>> map, boolean handler) {
     List<ModuleInstance> returnList = new LinkedList<>();
+    logger.info("lookup uri={}", uri);
     String tryUri = uri;
     while (true) {
+      logger.info("tryUri = {}", tryUri);
       List<ModuleInstance> gotInstances = map.get(tryUri);
       if (gotInstances != null) {
         for (ModuleInstance candiate : gotInstances) {
@@ -66,11 +84,14 @@ public class ModuleCache {
           }
         }
       }
-      int index = tryUri.lastIndexOf('/');
-      if (index == -1) {
+      int index = tryUri.length() - 1;
+      while (index > 0 && tryUri.charAt(index - 1) != '/') {
+        --index;
+      }
+      if (index <= 0) {
         break;
       }
-      tryUri = tryUri.substring(0, index + 1);
+      tryUri = tryUri.substring(0, index);
     }
     return returnList;
   }
@@ -80,37 +101,15 @@ public class ModuleCache {
    * @param uri request uri
    * @param method HTTP method
    * @param id Proxy-ID for multi lookup; otherwise null
-   * @param enabledModules enabled modules for tenant
    * @return module instances that match
    */
-  public List<ModuleInstance> lookup(String uri, HttpMethod method, String id,
-                              List<ModuleDescriptor> enabledModules) {
-    // add modules to cache we don't know about
-    for (ModuleDescriptor md : enabledModules) {
-      if (modules.add(md.getId())) {
-        add(md);
-      }
-    }
+  public List<ModuleInstance> lookup(String uri, HttpMethod method, String id) {
     // perform lookup
-    List<ModuleInstance> instances = lookup(uri, method, filterMap, false);
+    List<ModuleInstance> instances = ModuleCache.lookup(uri, method, filterMap, false);
     if (id == null) {
       instances.addAll(lookup(uri, method, proxyMap, true));
     } else {
       instances.addAll(lookup(uri, method, multiMap, false));
-    }
-    // remove from the result those that are not enabled for tenant=enabledModules
-    Iterator<ModuleInstance> iterator = instances.iterator();
-    while (iterator.hasNext()) {
-      ModuleInstance next = iterator.next();
-      boolean found = false;
-      for (ModuleDescriptor md : enabledModules) {
-        if (next.getModuleDescriptor().getId().equals(md.getId())) {
-          found = true;
-        }
-      }
-      if (!found) {
-        iterator.remove();
-      }
     }
     return instances;
   }

--- a/okapi-core/src/main/java/org/folio/okapi/util/ModuleCache.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/ModuleCache.java
@@ -2,17 +2,22 @@ package org.folio.okapi.util;
 
 import io.vertx.core.http.HttpMethod;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.logging.log4j.Logger;
 import org.folio.okapi.bean.ModuleDescriptor;
 import org.folio.okapi.bean.ModuleInstance;
 import org.folio.okapi.bean.RoutingEntry;
+import org.folio.okapi.common.Messages;
 import org.folio.okapi.common.OkapiLogger;
 
 public class ModuleCache {
   private static final Logger logger = OkapiLogger.get();
+  private static final Messages messages = Messages.getInstance();
 
   static class ModuleCacheEntry {
     final ModuleDescriptor moduleDescriptor;
@@ -85,6 +90,48 @@ public class ModuleCache {
     add(moduleDescriptor, filterMap, moduleDescriptor.getFilterRoutingEntries());
   }
 
+  private void resolveRedirect(List<ModuleInstance> instances, RoutingEntry re, String loop,
+                               Set<RoutingEntry> routingEntries,
+                               HttpMethod method, String uri) {
+    if (re.getProxyType() != RoutingEntry.ProxyType.REDIRECT) {
+      return;
+    }
+    logger.debug("resolveRedirect begin redirectPath={}", re.getRedirectPath());
+    boolean found = false;
+    final String redirectPath = re.getRedirectPath();
+
+    List<ModuleInstance> lookup = lookup(redirectPath, method, filterMap, false, null);
+    for (ModuleInstance instance : lookup) {
+      RoutingEntry tryre = instance.getRoutingEntry();
+      String redirectUri = re.getRedirectUri(uri);
+      found = true;
+      if (routingEntries.add(tryre)) {
+        ModuleInstance mi = new ModuleInstance(instance.getModuleDescriptor(), tryre, redirectUri,
+            method, false);
+        instances.add(mi);
+        resolveRedirect(instances, tryre, loop + " -> " + redirectPath, routingEntries,
+            method, redirectUri);
+      } else {
+        throw new IllegalArgumentException(messages.getMessage("10100", loop, redirectPath));
+      }
+    }
+    lookup = lookup(redirectPath, method, proxyMap, true, null);
+    for (ModuleInstance instance : lookup) {
+      RoutingEntry tryre = instance.getRoutingEntry();
+      String redirectUri = re.getRedirectUri(uri);
+      found = true;
+      if (routingEntries.add(tryre)) {
+        ModuleInstance mi = new ModuleInstance(instance.getModuleDescriptor(), tryre, redirectUri,
+            method, true);
+        instances.add(mi);
+      }
+    }
+    logger.debug("resolveRedirect end redirectPath={} found={}", re.getRedirectPath(), found);
+    if (!found) {
+      throw new IllegalArgumentException(messages.getMessage("10101", uri, redirectPath));
+    }
+  }
+
   static List<ModuleInstance> lookup(String uri, HttpMethod method, Map<String,
       List<ModuleCacheEntry>> map, boolean handler, String id) {
     List<ModuleInstance> instances = new LinkedList<>();
@@ -127,19 +174,24 @@ public class ModuleCache {
    * @param method HTTP method
    * @param id Proxy-ID for multi lookup; otherwise null
    * @return module instances that match
+   * @throws IllegalArgumentException for redirect errors
    */
   public List<ModuleInstance> lookup(String uri, HttpMethod method, String id) {
-    logger.debug("lookup {} {} id={}", method.name(), uri, id);
-    StringBuilder str = new StringBuilder();
-    for (ModuleDescriptor md : moduleDescriptors) {
-      if (str.length() > 0) {
-        str.append(", ");
-      }
-      str.append(md.getId());
-    }
-    logger.debug("Available modules {}", str);
-    // perform lookup
+    logger.debug("lookup {} {} id={}", () -> method.name(), () -> uri, () -> id);
+    logger.debug("Available modules {}", () -> ModuleUtil.moduleList(moduleDescriptors));
+    // perform lookup of filters
     List<ModuleInstance> instances = ModuleCache.lookup(uri, method, filterMap, false, null);
+    // handle redirects
+    Set<RoutingEntry> visitRoutingEntries = new HashSet<>();
+    Iterator<ModuleInstance> iterator = instances.iterator();
+    while (iterator.hasNext()) {
+      ModuleInstance next = iterator.next();
+      if (visitRoutingEntries.add(next.getRoutingEntry())) {
+        resolveRedirect(instances, next.getRoutingEntry(), "", visitRoutingEntries, method, uri);
+        iterator = instances.iterator();
+      }
+    }
+    // perform lookup of proxy or multi
     if (id == null) {
       instances.addAll(lookup(uri, method, proxyMap, true, null));
     } else {

--- a/okapi-core/src/main/java/org/folio/okapi/util/ModuleCache.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/ModuleCache.java
@@ -58,17 +58,20 @@ public class ModuleCache {
     if (pathPattern == null) {
       return "/"; // anything but pathPattern is legacy so we don't care about those
     }
-    int index = 0;
-    while (index < pathPattern.length()) {
-      if (pathPattern.charAt(index) == '*' || pathPattern.charAt(index) == '{') {
-        while (index > 0 && pathPattern.charAt(index - 1) != '/') {
-          --index;
-        }
-        break;
+    int lastSlash = 0;
+    for (int i = 0; i < pathPattern.length(); i++) {
+      switch (pathPattern.charAt(i)) {
+        case '*':
+        case '{':
+          return pathPattern.substring(0, lastSlash);
+        case '/':
+          lastSlash = i + 1;
+          break;
+        default:
+          break;
       }
-      index++;
     }
-    return pathPattern.substring(0, index);
+    return pathPattern;
   }
 
   static void add(ModuleDescriptor moduleDescriptor, Map<String, List<ModuleCacheEntry>> map,
@@ -156,14 +159,11 @@ public class ModuleCache {
           }
         }
       }
-      int index = tryUri.length() - 1;
-      while (index > 0 && tryUri.charAt(index - 1) != '/') {
-        --index;
-      }
-      if (index <= 0) {
+      int index = tryUri.lastIndexOf('/', tryUri.length() - 2);
+      if (index < 0) {
         break;
       }
-      tryUri = tryUri.substring(0, index);
+      tryUri = tryUri.substring(0, index + 1);
     }
     return instances;
   }

--- a/okapi-core/src/main/java/org/folio/okapi/util/ModuleCache.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/ModuleCache.java
@@ -180,7 +180,7 @@ public class ModuleCache {
     logger.debug("lookup {} {} id={}", () -> method.name(), () -> uri, () -> id);
     logger.debug("Available modules {}", () -> ModuleUtil.moduleList(moduleDescriptors));
     // perform lookup of filters
-    List<ModuleInstance> instances = ModuleCache.lookup(uri, method, filterMap, false, null);
+    List<ModuleInstance> instances = lookup(uri, method, filterMap, false, null);
     // handle redirects
     Set<RoutingEntry> visitRoutingEntries = new HashSet<>();
     Iterator<ModuleInstance> iterator = instances.iterator();

--- a/okapi-core/src/main/java/org/folio/okapi/util/ModuleCache.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/ModuleCache.java
@@ -1,0 +1,118 @@
+package org.folio.okapi.util;
+
+import io.vertx.core.http.HttpMethod;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.folio.okapi.bean.ModuleDescriptor;
+import org.folio.okapi.bean.ModuleInstance;
+import org.folio.okapi.bean.RoutingEntry;
+
+public class ModuleCache {
+  Map<String, List<ModuleInstance>> proxyMap = new HashMap<>();
+  Map<String, List<ModuleInstance>> multiMap = new HashMap<>();
+  Map<String, List<ModuleInstance>> filterMap = new HashMap<>();
+  Set<String> modules = new HashSet<>();
+
+  String getPatternPrefix(RoutingEntry re) {
+    String pathPattern = re.getPathPattern();
+    if (pathPattern == null) {
+      return "/";
+    }
+    int i = 0;
+    while (i < pathPattern.length()) {
+      if (pathPattern.charAt(i) == '*' || pathPattern.charAt(i) == '{') {
+        break;
+      }
+      i++;
+    }
+    return pathPattern.substring(0, i);
+  }
+
+  void add(ModuleDescriptor moduleDescriptor, Map<String, List<ModuleInstance>> map,
+           List<RoutingEntry> entries) {
+    for (RoutingEntry routingEntry : entries) {
+      String prefix = getPatternPrefix(routingEntry);
+      List<ModuleInstance> list = map.get(prefix);
+      if (list == null) {
+        list = new LinkedList<>();
+        map.put(prefix, list);
+      }
+      list.add(new ModuleInstance(moduleDescriptor, routingEntry, null, HttpMethod.GET, false));
+    }
+  }
+
+  void add(ModuleDescriptor moduleDescriptor) {
+    add(moduleDescriptor, proxyMap, moduleDescriptor.getProxyRoutingEntries());
+    add(moduleDescriptor, multiMap, moduleDescriptor.getMultiRoutingEntries());
+    add(moduleDescriptor, filterMap, moduleDescriptor.getFilterRoutingEntries());
+  }
+
+  List<ModuleInstance> lookup(String uri, HttpMethod method, Map<String, List<ModuleInstance>> map,
+                              boolean handler) {
+    List<ModuleInstance> returnList = new LinkedList<>();
+    String tryUri = uri;
+    while (true) {
+      List<ModuleInstance> gotInstances = map.get(tryUri);
+      if (gotInstances != null) {
+        for (ModuleInstance candiate : gotInstances) {
+          if (candiate.getRoutingEntry().match(uri, method.name())) {
+            returnList.add(new ModuleInstance(candiate.getModuleDescriptor(),
+                candiate.getRoutingEntry(), uri, method, handler));
+          }
+        }
+      }
+      int index = tryUri.lastIndexOf('/');
+      if (index == -1) {
+        break;
+      }
+      tryUri = tryUri.substring(0, index + 1);
+    }
+    return returnList;
+  }
+
+  /**
+   * Find module instances for uri(path) and method.
+   * @param uri request uri
+   * @param method HTTP method
+   * @param id Proxy-ID for multi lookup; otherwise null
+   * @param enabledModules enabled modules for tenant
+   * @return module instances that match
+   */
+  public List<ModuleInstance> lookup(String uri, HttpMethod method, String id,
+                              List<ModuleDescriptor> enabledModules) {
+    // add modules to cache we don't know about
+    for (ModuleDescriptor md : enabledModules) {
+      if (modules.add(md.getId())) {
+        add(md);
+      }
+    }
+    // perform lookup
+    List<ModuleInstance> instances = lookup(uri, method, filterMap, false);
+    if (id == null) {
+      instances.addAll(lookup(uri, method, proxyMap, true));
+    } else {
+      instances.addAll(lookup(uri, method, multiMap, false));
+    }
+    // remove from the result those that are not enabled for tenant=enabledModules
+    Iterator<ModuleInstance> iterator = instances.iterator();
+    while (iterator.hasNext()) {
+      ModuleInstance next = iterator.next();
+      boolean found = false;
+      for (ModuleDescriptor md : enabledModules) {
+        if (next.getModuleDescriptor().getId().equals(md.getId())) {
+          found = true;
+        }
+      }
+      if (!found) {
+        iterator.remove();
+      }
+    }
+    return instances;
+  }
+}
+

--- a/okapi-core/src/main/java/org/folio/okapi/util/ModuleCache.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/ModuleCache.java
@@ -76,7 +76,7 @@ public class ModuleCache {
   }
 
   static List<ModuleInstance> lookup(String uri, HttpMethod method, Map<String,
-      List<ModuleCacheEntry>> map, boolean handler) {
+      List<ModuleCacheEntry>> map, boolean handler, String id) {
     List<ModuleInstance> returnList = new LinkedList<>();
     logger.info("lookup uri={}", uri);
     String tryUri = uri;
@@ -85,7 +85,8 @@ public class ModuleCache {
       List<ModuleCacheEntry> gotInstances = map.get(tryUri);
       if (gotInstances != null) {
         for (ModuleCacheEntry candiate : gotInstances) {
-          if (candiate.routingEntry.match(uri, method.name())) {
+          if (candiate.routingEntry.match(uri, method.name())
+              && (id == null || id.equals(candiate.moduleDescriptor.getId()))) {
             returnList.add(new ModuleInstance(candiate.moduleDescriptor,
                 candiate.routingEntry, uri, method, handler));
           }
@@ -112,11 +113,11 @@ public class ModuleCache {
    */
   public List<ModuleInstance> lookup(String uri, HttpMethod method, String id) {
     // perform lookup
-    List<ModuleInstance> instances = ModuleCache.lookup(uri, method, filterMap, false);
+    List<ModuleInstance> instances = ModuleCache.lookup(uri, method, filterMap, false, null);
     if (id == null) {
-      instances.addAll(lookup(uri, method, proxyMap, true));
+      instances.addAll(lookup(uri, method, proxyMap, true, null));
     } else {
-      instances.addAll(lookup(uri, method, multiMap, false));
+      instances.addAll(lookup(uri, method, multiMap, false, id));
     }
     return instances;
   }

--- a/okapi-core/src/main/java/org/folio/okapi/util/ModuleUtil.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/ModuleUtil.java
@@ -148,4 +148,19 @@ public class ModuleUtil {
     return ml;
   }
 
+  /**
+   * Return comma separated list of Module Descriptors.
+   * @param moduleDescriptors list of modules
+   * @return comma separated list
+   */
+  public static String moduleList(List<ModuleDescriptor> moduleDescriptors) {
+    StringBuilder str = new StringBuilder();
+    for (ModuleDescriptor md : moduleDescriptors) {
+      if (str.length() > 0) {
+        str.append(", ");
+      }
+      str.append(md.getId());
+    }
+    return str.toString();
+  }
 }

--- a/okapi-core/src/main/raml/okapi.raml
+++ b/okapi-core/src/main/raml/okapi.raml
@@ -186,6 +186,7 @@ types:
       description: Remove registration for a given instance
       responses:
         204:
+          description: No Content
           headers:
             X-Okapi-Trace:
               description: Okapi trace and timing
@@ -468,7 +469,10 @@ types:
           headers:
             X-Okapi-Trace:
               description: Okapi trace and timing
-
+        404:
+          description: Not Found
+          body:
+            text/plain:
 /_/proxy/tenants:
   description: Tenants service
   post:

--- a/okapi-core/src/main/resources/infra-messages/Messages_en.properties
+++ b/okapi-core/src/main/resources/infra-messages/Messages_en.properties
@@ -20,7 +20,7 @@
 10204=update: module {0}: {1}
 10205=update: module {0} is used by tenant {1}
 10206=delete: module {0} is used by tenant {1}
-10207=delete: module does not exist
+10207=delete: module {0} does not exist
 10208=delete: module {0}: {1}
 
 #ProxyContent

--- a/okapi-core/src/test/java/org/folio/okapi/MainDeployTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/MainDeployTest.java
@@ -11,7 +11,6 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.apache.logging.log4j.Logger;
 import org.folio.okapi.common.OkapiLogger;
-import org.folio.okapi.util.MetricsHelper;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;

--- a/okapi-core/src/test/java/org/folio/okapi/ModuleTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ModuleTest.java
@@ -625,10 +625,22 @@ public class ModuleTest {
 
     // Clean up (in reverse order)
     logger.debug("testFilters starting to clean up");
-    given().delete(locPostEnable).then().log().ifValidationFails().statusCode(204);
-    given().delete(locationPostDeployment).then().log().ifValidationFails().statusCode(204);
+    c = api.createRestAssured3();
+    c.given().delete(locPostEnable).then().log().ifValidationFails().statusCode(204);
+    Assert.assertTrue("raml: " + c.getLastReport().toString(),
+        c.getLastReport().isEmpty());
+
+    c = api.createRestAssured3();
+    c.given().delete(locationPostDeployment).then().log().ifValidationFails().statusCode(204);
+    Assert.assertTrue("raml: " + c.getLastReport().toString(),
+        c.getLastReport().isEmpty());
     locationPostDeployment = null;
-    given().delete(locPostModule).then().log().ifValidationFails().statusCode(204);
+
+    c = api.createRestAssured3();
+    c.given().delete(locPostModule).then().log().ifValidationFails().statusCode(204);
+    Assert.assertTrue("raml: " + c.getLastReport().toString(),
+        c.getLastReport().isEmpty());
+
     given().delete(locPreEnable).then().log().ifValidationFails().statusCode(204);
     given().delete(locationPreDeployment).then().log().ifValidationFails().statusCode(204);
     locationPreDeployment = null;
@@ -1432,7 +1444,10 @@ public class ModuleTest {
 
     given().delete(locAuthEnable).then().log().ifValidationFails().statusCode(204);
     given().delete(locAuthDeployment).then().log().ifValidationFails().statusCode(204);
-    given().delete(locAuthModule).then().log().ifValidationFails().statusCode(204);
+    c = api.createRestAssured3();
+    c.given().delete(locAuthModule).then().log().ifValidationFails().statusCode(204);
+    Assert.assertTrue("raml: " + c.getLastReport().toString(),
+        c.getLastReport().isEmpty());
 
     given().delete(locSampleEnable2).then().log().ifValidationFails().statusCode(204);
     given().delete(locationSampleDeployment2).then().log().ifValidationFails().statusCode(204);
@@ -2825,5 +2840,15 @@ public class ModuleTest {
         .statusCode(404);
     Assert.assertTrue("raml: " + c.getLastReport().toString(),
         c.getLastReport().isEmpty());
+  }
+
+  @Test
+  public void testDeleteNonExistingModule() {
+    RestAssuredClient c = api.createRestAssured3();
+    c.given().delete("/_/proxy/modules/foo-1.0.0")
+        .then().statusCode(404).body(containsString("delete: module foo-1.0.0 does not exist"));
+    Assert.assertTrue("raml: " + c.getLastReport().toString(),
+        c.getLastReport().isEmpty());
+
   }
 }

--- a/okapi-core/src/test/java/org/folio/okapi/ModuleTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ModuleTest.java
@@ -106,6 +106,11 @@ public class ModuleTest {
     + "  \"description\" : \"Okapi built-in super tenant\"" + LS
     + "} ]";
 
+  private void assertEmptyReport(RestAssuredClient c) {
+    Assert.assertTrue("raml: " + c.getLastReport().toString(),
+        c.getLastReport().isEmpty());
+  }
+
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {
     api = RamlLoaders.fromFile("src/main/raml").load("okapi.raml");
@@ -289,8 +294,7 @@ public class ModuleTest {
       .header("Location",containsString("/_/proxy/modules"))
       .log().ifValidationFails()
       .extract().header("Location");
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
     return loc;
   }
 
@@ -318,8 +322,7 @@ public class ModuleTest {
       .header("Location",containsString("/_/discovery/modules"))
       .log().ifValidationFails()
       .extract().header("Location");
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
     return loc;
   }
 
@@ -627,19 +630,16 @@ public class ModuleTest {
     logger.debug("testFilters starting to clean up");
     c = api.createRestAssured3();
     c.given().delete(locPostEnable).then().log().ifValidationFails().statusCode(204);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     c = api.createRestAssured3();
     c.given().delete(locationPostDeployment).then().log().ifValidationFails().statusCode(204);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
+    assertEmptyReport(c);
     locationPostDeployment = null;
 
     c = api.createRestAssured3();
     c.given().delete(locPostModule).then().log().ifValidationFails().statusCode(204);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     given().delete(locPreEnable).then().log().ifValidationFails().statusCode(204);
     given().delete(locationPreDeployment).then().log().ifValidationFails().statusCode(204);
@@ -703,7 +703,7 @@ public class ModuleTest {
       .then()
       .statusCode(200)
       .body(equalTo("[ " + internalModuleDoc + " ]"));
-    Assert.assertTrue(c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     // Check that we refuse the request with a trailing slash
     given()
@@ -877,15 +877,13 @@ public class ModuleTest {
       .then()
       .statusCode(201)
       .extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
     String locSampleModule = r.getHeader("Location");
     Assert.assertEquals("/_/proxy/modules/sample-module-1%2B1", locSampleModule);
     Assert.assertEquals("/_/proxy/modules/sample-module-1+1", UrlDecoder.decode(locSampleModule));
 
     // Damn restAssured encodes the urls in get(), so we need to decode this here.
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     // post it again.. Allowed because it is the same MD
     c = api.createRestAssured3();
@@ -897,8 +895,7 @@ public class ModuleTest {
       .statusCode(201)
       .extract().response();
     Assert.assertEquals(r.getHeader("Location"), locSampleModule);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     // post it again with slight modification
     c = api.createRestAssured3();
@@ -909,8 +906,7 @@ public class ModuleTest {
       .then()
       .statusCode(400)
       .extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     given()
       .header("Content-Type", "application/json")
@@ -926,8 +922,7 @@ public class ModuleTest {
       .post("/_/discovery/modules")
       .then()
       .statusCode(400);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     c = api.createRestAssured3();
     c.given()
@@ -936,8 +931,7 @@ public class ModuleTest {
       .post("/_/discovery/modules")
       .then()
       .statusCode(404);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     c = api.createRestAssured3();
     c.given()
@@ -946,8 +940,7 @@ public class ModuleTest {
       .post("/_/discovery/modules")
       .then()
       .statusCode(404);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     // Get the module
     c = api.createRestAssured3();
@@ -955,8 +948,7 @@ public class ModuleTest {
       .get(locSampleModule)
       .then()
       .statusCode(200).body(equalTo(docSampleModule));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     // List the one module, and the built-in.
     final String expOneModList = "[ "
@@ -970,7 +962,7 @@ public class ModuleTest {
       .then()
       .statusCode(200)
       .body(equalTo(expOneModList));
-    Assert.assertTrue(c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     // Deploy the module - use the node name, not node id
     final String docDeploy = "{" + LS
@@ -985,8 +977,7 @@ public class ModuleTest {
       .post("/_/discovery/modules")
       .then()
       .statusCode(201).extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
     locationSampleDeployment = r.header("Location");
 
     r = c.given()
@@ -995,8 +986,7 @@ public class ModuleTest {
       .post("/_/discovery/modules")
       .then()
       .statusCode(400).extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     // Create a tenant and enable the module
     final String locTenant = createTenant();
@@ -1102,8 +1092,7 @@ public class ModuleTest {
       .then()
       .statusCode(201)
       .extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
     final String locEmptyModule = r.getHeader("Location");
     final String locEnableEmpty = enableModule("empty-module-1.0");
 
@@ -1446,8 +1435,7 @@ public class ModuleTest {
     given().delete(locAuthDeployment).then().log().ifValidationFails().statusCode(204);
     c = api.createRestAssured3();
     c.given().delete(locAuthModule).then().log().ifValidationFails().statusCode(204);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     given().delete(locSampleEnable2).then().log().ifValidationFails().statusCode(204);
     given().delete(locationSampleDeployment2).then().log().ifValidationFails().statusCode(204);
@@ -1493,8 +1481,7 @@ public class ModuleTest {
     c = api.createRestAssured3();
     c.given().get("/_/discovery/nodes").then().statusCode(200)
       .body(equalTo(nodeListDoc));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     c = api.createRestAssured3();
     c.given()
@@ -1504,8 +1491,7 @@ public class ModuleTest {
       .then()
       .log().ifValidationFails()
       .statusCode(200);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     c = api.createRestAssured3();
     c.given().get("/_/discovery/nodes")
@@ -1513,8 +1499,7 @@ public class ModuleTest {
       .statusCode(200)
       .body(equalTo(nodeListDoc.replaceFirst("node1", "NewName")))
       .log().ifValidationFails();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     // Test some bad PUTs
     c = api.createRestAssured3();
@@ -1524,8 +1509,7 @@ public class ModuleTest {
       .put("/_/discovery/nodes/foobarhost")
       .then()
       .statusCode(404);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     c = api.createRestAssured3();
     c.given()
@@ -1534,8 +1518,7 @@ public class ModuleTest {
       .put("/_/discovery/nodes/localhost")
       .then()
       .statusCode(400);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     c = api.createRestAssured3();
     c.given()
@@ -1544,8 +1527,7 @@ public class ModuleTest {
       .put("/_/discovery/nodes/localhost")
       .then()
       .statusCode(400);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     // Get it in various ways
     c = api.createRestAssured3();
@@ -1554,8 +1536,7 @@ public class ModuleTest {
       .statusCode(200)
       .body(equalTo(nodeDoc))
       .log().ifValidationFails();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     c = api.createRestAssured3();
     c.given().get("/_/discovery/nodes/NewName")
@@ -1563,8 +1544,7 @@ public class ModuleTest {
       .statusCode(200)
       .body(equalTo(nodeDoc))
       .log().ifValidationFails();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     logger.info("node test!!!!!!!!!!!!");
     c = api.createRestAssured3();
@@ -1573,8 +1553,7 @@ public class ModuleTest {
       .statusCode(200) // when testing with curl, you need use http%3A%2F%2Flocal...
       .body(equalTo(nodeDoc))
       .log().ifValidationFails();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     checkDbIsEmpty("testDiscoveryNodes done", context);
     async.complete();
@@ -1614,35 +1593,30 @@ public class ModuleTest {
       //.log().all()
       .statusCode(201)
       .extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
     final String locationSampleModule = r.getHeader("Location");
 
     c = api.createRestAssured3();
     c.given().get("/_/deployment/modules")
       .then().statusCode(200)
       .body(equalTo("[ ]"));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     c = api.createRestAssured3();
     c.given().get("/_/deployment/modules/not_found")
       .then().statusCode(404);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     c = api.createRestAssured3();
     c.given().get("/_/discovery/modules")
       .then().statusCode(200)
       .body(equalTo("[ ]"));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     c = api.createRestAssured3();
     c.given().get("/_/discovery/modules/not_found")
       .then().statusCode(404);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     final String doc1 = "{" + LS
       + "  \"instId\" : \"localhost-9231\"," + LS // set so we can compare with result
@@ -1671,8 +1645,7 @@ public class ModuleTest {
     c.given().header("Content-Type", "application/json")
       .body(doc1a).post("/_/discovery/modules")
       .then().statusCode(400).body(containsString("missing nodeId"));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     // missing instId
     final String docNoInstId = "{" + LS
@@ -1682,8 +1655,7 @@ public class ModuleTest {
     c.given().header("Content-Type", "application/json")
       .body(docNoInstId).post("/_/discovery/modules")
       .then().statusCode(400).body(containsString("Needs instId"));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     // unknown nodeId
     final String doc1b = "{" + LS
@@ -1699,8 +1671,7 @@ public class ModuleTest {
     c.given().header("Content-Type", "application/json")
       .body(doc1b).post("/_/discovery/modules")
       .then().statusCode(404);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     final String doc2 = "{" + LS
       + "  \"instId\" : \"localhost-9231\"," + LS
@@ -1720,43 +1691,37 @@ public class ModuleTest {
       .body(equalTo(doc2))
       .extract().response();
     locationSampleDeployment = r.getHeader("Location");
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     c = api.createRestAssured3();
     c.given().get(locationSampleDeployment).then().statusCode(200)
       .body(equalTo(doc2));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     c = api.createRestAssured3();
     c.given().get("/_/deployment/modules")
       .then().statusCode(200)
       .body(equalTo("[ " + doc2 + " ]"));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     c = api.createRestAssured3();
     c.given().header("Content-Type", "application/json")
       .body(doc2).post("/_/discovery/modules")
       .then().statusCode(400);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     c = api.createRestAssured3();
     c.given().get("/_/discovery/modules/sample-module-5.0")
       .then().statusCode(200)
       .body(equalTo("[ " + doc2 + " ]"));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     c = api.createRestAssured3();
     c.given().get("/_/discovery/modules")
       .then().statusCode(200)
       .log().ifValidationFails()
       .body(equalTo("[ " + doc2 + " ]"));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     c = api.createRestAssured3();
 
@@ -1770,16 +1735,8 @@ public class ModuleTest {
       .body(envDoc).post("/_/env")
       .then().statusCode(201)
       .log().ifValidationFails();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
-    ////////////////
-    /*
-    c = api.createRestAssured3();
-    c.given().delete(locationSampleModule).then().statusCode(204);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
-*/
     if ("inmemory".equals(conf.getString("storage"))) {
       testDeployment2(async, context, locationSampleModule);
     } else {
@@ -1790,8 +1747,7 @@ public class ModuleTest {
       String loc = "http://localhost:9230/_/deployment/modules/" + instId;
       c = api.createRestAssured3();
       c.given().delete(loc).then().statusCode(204);
-      Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
+      assertEmptyReport(c);
 
       undeployFirst(x -> {
         conf.remove("mongo_db_init");
@@ -1831,8 +1787,7 @@ public class ModuleTest {
 
     c = api.createRestAssured3();
     c.given().delete(locationSampleModule1).then().statusCode(204);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     c = api.createRestAssured3();
     c.given()
@@ -1840,18 +1795,15 @@ public class ModuleTest {
       .delete("/_/env/name1")
       .then().statusCode(204)
       .log().ifValidationFails();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     c = api.createRestAssured3();
     c.given().delete(locationSampleDeployment).then().statusCode(204);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     c = api.createRestAssured3();
     c.given().delete(locationSampleDeployment).then().statusCode(404);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
     locationSampleDeployment = null;
 
     // Verify that the list works also after delete
@@ -1859,22 +1811,19 @@ public class ModuleTest {
     c.given().get("/_/deployment/modules")
       .then().statusCode(200)
       .body(equalTo("[ ]"));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     // verify that module5 is no longer there
     c = api.createRestAssured3();
     c.given().get("/_/discovery/modules/sample-module-5.0")
       .then().statusCode(404);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     // verify that a never-seen module returns the same
     c = api.createRestAssured3();
     c.given().get("/_/discovery/modules/UNKNOWN-MODULE")
       .then().statusCode(404);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     // Deploy a module via its own LaunchDescriptor
     final String docSampleModule = "{" + LS
@@ -1907,8 +1856,7 @@ public class ModuleTest {
       //.log().all()
       .statusCode(201)
       .extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
     final String locationSampleModule = r.getHeader("Location");
 
     // Specify the node via url, to test that too
@@ -1933,8 +1881,7 @@ public class ModuleTest {
       .then().statusCode(201)
       .body(equalTo(DeployResp))
       .extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
     locationSampleDeployment = r.getHeader("Location");
 
     // Would be nice to verify that the module works, but too much hassle with
@@ -1942,21 +1889,18 @@ public class ModuleTest {
     // Undeploy.
     c = api.createRestAssured3();
     c.given().delete(locationSampleDeployment).then().statusCode(204);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
     // Undeploy again, to see it is gone
     c = api.createRestAssured3();
     c.given().delete(locationSampleDeployment).then().statusCode(404);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
     locationSampleDeployment = null;
 
     // and delete from the proxy
     c = api.createRestAssured3();
     c.given().delete(locationSampleModule)
       .then().statusCode(204);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     checkDbIsEmpty("testDeployment done", context);
 
@@ -2214,8 +2158,7 @@ public class ModuleTest {
       .header("Content-Type", "application/json")
       .body(docUiModuleInput).post("/_/proxy/modules").then().statusCode(201)
       .body(equalTo(docUiModuleOutput)).extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     String location = r.getHeader("Location");
 
@@ -2223,8 +2166,7 @@ public class ModuleTest {
     c.given()
       .get(location)
       .then().statusCode(200).body(equalTo(docUiModuleOutput));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     given().delete(location)
       .then().statusCode(204);
@@ -2270,8 +2212,7 @@ public class ModuleTest {
       .statusCode(201)
       .log().ifValidationFails()
       .extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
     final String locationSampleModule1 = r.getHeader("Location");
 
     final String docSampleModule2 = "{" + LS
@@ -2300,8 +2241,7 @@ public class ModuleTest {
       .statusCode(201)
       .log().ifValidationFails()
       .extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
     final String locationSampleModule2 = r.getHeader("Location");
 
     updateCreateTenant();
@@ -2319,8 +2259,7 @@ public class ModuleTest {
       .then()
       .statusCode(400)
       .extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     c = api.createRestAssured3();
     c.given().get("/_/proxy/tenants/" + okapiTenant + "/interfaces?full=true")
@@ -2336,8 +2275,7 @@ public class ModuleTest {
                     + "  } ]" + LS
                     + "} ]"))
             .log().ifValidationFails();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-            c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     c = api.createRestAssured3();
     c.given().get("/_/proxy/tenants/" + okapiTenant + "/interfaces?full=false")
@@ -2347,8 +2285,7 @@ public class ModuleTest {
                     + "  \"version\" : \"1.0\"" + LS
                     + "} ]"))
             .log().ifValidationFails();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-            c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     c = api.createRestAssured3();
     c.given().get("/_/proxy/tenants/" + okapiTenant + "/interfaces?full=false&type=proxy")
@@ -2358,63 +2295,53 @@ public class ModuleTest {
                     + "  \"version\" : \"1.0\"" + LS
                     + "} ]"))
             .log().ifValidationFails();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-            c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     c = api.createRestAssured3();
     c.given().get("/_/proxy/tenants/" + okapiTenant + "/interfaces?full=false&type=system")
             .then().statusCode(200)
             .body(equalTo("[ ]"))
             .log().ifValidationFails();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-            c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     c = api.createRestAssured3();
     c.given().get("/_/proxy/tenants/" + okapiTenant + "/interfaces/sample")
             .then().statusCode(200)
             .body(equalTo("[ {" + LS + "  \"id\" : \"sample-module-1\"" + LS + "} ]"))
             .log().ifValidationFails();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-            c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     c = api.createRestAssured3();
     c.given().get("/_/proxy/tenants/" + okapiTenant + "/interfaces/sample?type=proxy")
             .then().statusCode(200)
             .body(equalTo("[ {" + LS + "  \"id\" : \"sample-module-1\"" + LS + "} ]"))
             .log().ifValidationFails();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-            c.getLastReport().isEmpty());
-
+    assertEmptyReport(c);
 
     c = api.createRestAssured3();
     c.given().get("/_/proxy/tenants/" + "foo" + "/interfaces/sample")
       .then().statusCode(404);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     c = api.createRestAssured3();
     c.given().get("/_/proxy/tenants/" + okapiTenant + "/interfaces/bar")
       .then().statusCode(200).body(equalTo("[ ]"));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     c = api.createRestAssured3();
     r = c.given().delete(locEnable1)
       .then().statusCode(204).extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     c = api.createRestAssured3();
     r = c.given().delete(locationSampleModule1)
       .then().statusCode(204).extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     c = api.createRestAssured3();
     r = c.given().delete(locationSampleModule2)
       .then().statusCode(204).extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     final String docSampleModule3 = "{" + LS
       + "  \"id\" : \"sample-module-3\"," + LS
@@ -2442,8 +2369,7 @@ public class ModuleTest {
       .statusCode(201)
       .log().ifValidationFails()
       .extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
     final String locationSampleModule3 = r.getHeader("Location");
 
     final String docSampleModule4 = "{" + LS
@@ -2476,15 +2402,13 @@ public class ModuleTest {
       .statusCode(201)
       .log().ifValidationFails()
       .extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
     final String locationSampleModule4 = r.getHeader("Location");
 
     c = api.createRestAssured3();
     c.given().get("/_/proxy/tenants/" + okapiTenant + "/interfaces/sample")
       .then().statusCode(200).body(equalTo("[ ]"));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     final String locEnable3 = enableModule("sample-module-3");
     this.locationSampleDeployment = deployModule("sample-module-3");
@@ -2499,8 +2423,7 @@ public class ModuleTest {
       + "}, {" + LS
       + "  \"id\" : \"sample-module-4\"" + LS
       + "} ]"));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
     given()
       .header("X-Okapi-Tenant", okapiTenant)
       .get("/testb")
@@ -2547,36 +2470,34 @@ public class ModuleTest {
     c = api.createRestAssured3();
     r = c.given().delete(locEnable3)
       .then().statusCode(204).extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
+
     c = api.createRestAssured3();
     r = c.given().delete(locEnable4)
       .then().statusCode(204).extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
+
     c = api.createRestAssured3();
     r = c.given().delete(locationSampleModule3)
       .then().statusCode(204).extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
+
     c = api.createRestAssured3();
     r = c.given().delete(locationSampleModule4)
       .then().statusCode(204).extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     c = api.createRestAssured3();
     r = c.given().delete(locationSampleDeployment)
       .then().statusCode(204).extract().response();
     locationSampleDeployment = null;
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
+
     c = api.createRestAssured3();
     r = c.given().delete(locationHeaderDeployment)
       .then().statusCode(204).extract().response();
     locationHeaderDeployment = null;
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
     async.complete();
   }
 
@@ -2585,13 +2506,10 @@ public class ModuleTest {
     logger.info("testVersion starting");
     async = context.async();
     RestAssuredClient c;
-    Response r;
 
     c = api.createRestAssured3();
-    r = c.given().get("/_/version").then().statusCode(200).log().ifValidationFails().extract().response();
-
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    c.given().get("/_/version").then().statusCode(200).log().ifValidationFails().extract().response();
+    assertEmptyReport(c);
     async.complete();
   }
 
@@ -2617,8 +2535,7 @@ public class ModuleTest {
       .statusCode(201)
       .log().ifValidationFails()
       .extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     docSampleModule = "{" + LS
       + "  \"id\" : \"sample-1.2.3-SNAPSHOT.5\"," + LS
@@ -2634,8 +2551,7 @@ public class ModuleTest {
       .statusCode(201)
       .log().ifValidationFails()
       .extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     docSampleModule = "{" + LS
       + "  \"id\" : \"sample-1.2.3-alpha.1+2017\"," + LS
@@ -2651,8 +2567,7 @@ public class ModuleTest {
         .statusCode(201)
         .log().ifValidationFails()
         .extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     async.complete();
   }
@@ -2679,15 +2594,14 @@ public class ModuleTest {
         .then()
         .statusCode(201)
         .log().ifValidationFails();
-      Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
+      assertEmptyReport(c);
     }
     c = api.createRestAssured3();
     r = c.given()
       .get("/_/proxy/modules")
       .then()
       .statusCode(200).log().ifValidationFails().extract().response();
-    Assert.assertTrue(c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     async.complete();
   }
@@ -2776,8 +2690,7 @@ public class ModuleTest {
         .body(new JsonObject().put("name", "name1").put("value", "value1").encode()).post("/_/env")
         .then().statusCode(201)
         .log().ifValidationFails();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     c = api.createRestAssured3();
     c.given()
@@ -2785,8 +2698,7 @@ public class ModuleTest {
         .get("/_/env/name1")
         .then().statusCode(200)
         .log().ifValidationFails();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     c = api.createRestAssured3();
     c.given()
@@ -2794,8 +2706,7 @@ public class ModuleTest {
         .delete("/_/env/name1")
         .then().statusCode(204)
         .log().ifValidationFails();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     undeployFirstAndDeploy(context, context.asyncAssertSuccess());
     async.await();
@@ -2807,8 +2718,7 @@ public class ModuleTest {
         .get("/_/env/name1")
         .then().statusCode(404)
         .log().ifValidationFails();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
+    assertEmptyReport(c);
   }
 
 
@@ -2821,13 +2731,11 @@ public class ModuleTest {
 
     c = api.createRestAssured3();
     c.given().get("/_/proxy/tenants/" + tenant).then().statusCode(404);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     c = api.createRestAssured3();
     c.given().delete("/_/proxy/tenants/" + tenant).then().statusCode(404);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
+    assertEmptyReport(c);
 
     final String docEnable = "{" + LS
         + "  \"id\" : \"" + "mod-1.2.3"+ "\"" + LS
@@ -2838,8 +2746,7 @@ public class ModuleTest {
         .post("/_/proxy/tenants/" + tenant + "/modules")
         .then()
         .statusCode(404);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
+    assertEmptyReport(c);
   }
 
   @Test
@@ -2847,8 +2754,6 @@ public class ModuleTest {
     RestAssuredClient c = api.createRestAssured3();
     c.given().delete("/_/proxy/modules/foo-1.0.0")
         .then().statusCode(404).body(containsString("delete: module foo-1.0.0 does not exist"));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
-
+    assertEmptyReport(c);
   }
 }

--- a/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
@@ -51,6 +51,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -1896,6 +1897,7 @@ public class ProxyTest {
    * looping redirects. These are expected to fail.
    *
    */
+  @Ignore
   @Test
   public void testRedirect(TestContext context) {
     Async async = context.async();

--- a/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
@@ -51,7 +51,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -1897,7 +1896,6 @@ public class ProxyTest {
    * looping redirects. These are expected to fail.
    *
    */
-  @Ignore
   @Test
   public void testRedirect(TestContext context) {
     Async async = context.async();
@@ -2140,14 +2138,14 @@ public class ProxyTest {
       .body(containsString("loop:"))
       .log().ifValidationFails();
 
-    // redirect to multiple modules
+    // redirect to multiple modules, but only one is executed
     given()
       .header("X-Okapi-Tenant", okapiTenant)
       .header("Content-Type", "application/json")
       .body("{}")
       .post("/multiple")
       .then().statusCode(200)
-      .body(containsString("Hello Hello")) // test-module run twice
+      .body(containsString("Hello {}")) // test-module run once
       .log().ifValidationFails();
 
     // Redirect with parameters

--- a/okapi-core/src/test/java/org/folio/okapi/util/ModuleCacheTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/ModuleCacheTest.java
@@ -22,7 +22,7 @@ class ModuleCacheTest {
   @CsvSource({
       "/, /",
       "/{id}, /",
-      "{id},",
+      "{id}, ''",
       "/a/b{id}, /a/",
       "/a/*c, /a/",
       "/a/b*, /a/",
@@ -30,13 +30,9 @@ class ModuleCacheTest {
       "/a/b, /a/b",
       "/a/{id}, /a/",
   })
-  void testGetPatternPrefix(ArgumentsAccessor accessor) {
+  void testGetPatternPrefix(String pathPattern, String expect) {
     RoutingEntry routingEntry = new RoutingEntry();
-    routingEntry.setPathPattern(accessor.getString(0));
-    String expect = accessor.getString(1);
-    if (expect == null) {
-      expect = "";
-    }
+    routingEntry.setPathPattern(pathPattern);
     assertThat(ModuleCache.getPatternPrefix(routingEntry)).isEqualTo(expect);
   }
 

--- a/okapi-core/src/test/java/org/folio/okapi/util/ModuleCacheTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/ModuleCacheTest.java
@@ -18,15 +18,16 @@ class ModuleCacheTest {
   void testLookupEmpty() {
     Map<String, List<ModuleCache.ModuleCacheEntry>> map = new HashMap<>();
 
-    assertThat(ModuleCache.lookup("", HttpMethod.GET, map, true)).isEmpty();
-    assertThat(ModuleCache.lookup("/", HttpMethod.GET, map, true)).isEmpty();
-    assertThat(ModuleCache.lookup("/a", HttpMethod.GET, map, true)).isEmpty();
-    assertThat(ModuleCache.lookup("/a/b", HttpMethod.GET, map, true)).isEmpty();
+    assertThat(ModuleCache.lookup("", HttpMethod.GET, map, true, null)).isEmpty();
+    assertThat(ModuleCache.lookup("/", HttpMethod.GET, map, true, null)).isEmpty();
+    assertThat(ModuleCache.lookup("/a", HttpMethod.GET, map, true, null)).isEmpty();
+    assertThat(ModuleCache.lookup("/a/b", HttpMethod.GET, map, true, null)).isEmpty();
   }
 
   @Test
   void testLookupRoutingEntries() {
     ModuleDescriptor md = new ModuleDescriptor();
+    md.setId("module-1.0.0");
     List<RoutingEntry> routingEntries = new LinkedList<>();
     RoutingEntry routingEntry1 = new RoutingEntry();
     routingEntry1.setPathPattern("/a/b");
@@ -52,30 +53,36 @@ class ModuleCacheTest {
     Map<String, List<ModuleCache.ModuleCacheEntry>> map = new HashMap<>();
     ModuleCache.add(md, map, routingEntries);
 
-    assertThat(ModuleCache.lookup("", HttpMethod.GET, map, true)).isEmpty();
-    assertThat(ModuleCache.lookup("/", HttpMethod.GET, map, true)).isEmpty();
-    assertThat(ModuleCache.lookup("/a", HttpMethod.GET, map, true)).isEmpty();
-    List<ModuleInstance> instances = ModuleCache.lookup("/a/b", HttpMethod.GET, map, true);
+    assertThat(ModuleCache.lookup("", HttpMethod.GET, map, true, null)).isEmpty();
+    assertThat(ModuleCache.lookup("/", HttpMethod.GET, map, true, null)).isEmpty();
+    assertThat(ModuleCache.lookup("/a", HttpMethod.GET, map, true, null)).isEmpty();
+    List<ModuleInstance> instances = ModuleCache.lookup("/a/b", HttpMethod.GET, map, true, null);
     assertThat(instances.size()).isEqualTo(1);
     assertThat(instances.get(0).getRoutingEntry()).isEqualTo(routingEntry1);
 
-    instances = ModuleCache.lookup("/a/b", HttpMethod.POST, map, true);
+    instances = ModuleCache.lookup("/a/b", HttpMethod.GET, map, true, "module-1.0.0");
+    assertThat(instances.size()).isEqualTo(1);
+    assertThat(instances.get(0).getRoutingEntry()).isEqualTo(routingEntry1);
+
+    assertThat(ModuleCache.lookup("/a", HttpMethod.GET, map, true, "other-1.0.0")).isEmpty();
+
+    instances = ModuleCache.lookup("/a/b", HttpMethod.POST, map, true, null);
     assertThat(instances.size()).isEqualTo(1);
     assertThat(instances.get(0).getRoutingEntry()).isEqualTo(routingEntry2);
 
-    assertThat(ModuleCache.lookup("/a", HttpMethod.PUT, map, true)).isEmpty();
-    assertThat(ModuleCache.lookup("/a/b/", HttpMethod.GET, map, true)).isEmpty();
+    assertThat(ModuleCache.lookup("/a", HttpMethod.PUT, map, true, null)).isEmpty();
+    assertThat(ModuleCache.lookup("/a/b/", HttpMethod.GET, map, true, null)).isEmpty();
 
-    instances = ModuleCache.lookup("/a/b/id/c", HttpMethod.GET, map, true);
+    instances = ModuleCache.lookup("/a/b/id/c", HttpMethod.GET, map, true, null);
     assertThat(instances.size()).isEqualTo(1);
     assertThat(instances.get(0).getRoutingEntry()).isEqualTo(routingEntry3);
 
-    instances = ModuleCache.lookup("/p/id/y", HttpMethod.GET, map, true);
+    instances = ModuleCache.lookup("/p/id/y", HttpMethod.GET, map, true, null);
     assertThat(instances.size()).isEqualTo(1);
     assertThat(instances.get(0).getRoutingEntry()).isEqualTo(routingEntry4);
 
-    assertThat(ModuleCache.lookup("/old/foo", HttpMethod.GET, map, true)).isEmpty();
-    instances = ModuleCache.lookup("/old/type", HttpMethod.GET, map, true);
+    assertThat(ModuleCache.lookup("/old/foo", HttpMethod.GET, map, true, null)).isEmpty();
+    instances = ModuleCache.lookup("/old/type", HttpMethod.GET, map, true, null);
     assertThat(instances.size()).isEqualTo(1);
     assertThat(instances.get(0).getRoutingEntry()).isEqualTo(routingEntry5);
   }

--- a/okapi-core/src/test/java/org/folio/okapi/util/ModuleCacheTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/ModuleCacheTest.java
@@ -113,9 +113,9 @@ class ModuleCacheTest {
     instances = ModuleCache.lookup("/p/id/y", HttpMethod.GET, map, true, null);
     assertThat(instances).extracting(routingEntry).containsExactly(routingEntry4);
 
-    ModuleCache.lookup("/p/id/z", HttpMethod.GET, map, true, null).isEmpty();
-    ModuleCache.lookup("/p/id", HttpMethod.GET, map, true, null).isEmpty();
-    ModuleCache.lookup("/p/id/y/z", HttpMethod.GET, map, true, null).isEmpty();
+    assertThat(ModuleCache.lookup("/p/id/z", HttpMethod.GET, map, true, null)).isEmpty();
+    assertThat(ModuleCache.lookup("/p/id", HttpMethod.GET, map, true, null)).isEmpty();
+    assertThat(ModuleCache.lookup("/p/id/y/z", HttpMethod.GET, map, true, null)).isEmpty();
 
     instances = ModuleCache.lookup("/perms/users", HttpMethod.GET, map, true, null);
     assertThat(instances).extracting(routingEntry).containsExactly(routingEntry5);

--- a/okapi-core/src/test/java/org/folio/okapi/util/ModuleCacheTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/ModuleCacheTest.java
@@ -11,10 +11,43 @@ import org.folio.okapi.bean.ModuleInstance;
 import org.folio.okapi.bean.RoutingEntry;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ModuleCacheTest {
+  @ParameterizedTest
+  @CsvSource({
+      "/, /",
+      "/{id}, /",
+      "{id},",
+      "/a/b{id}, /a/",
+      "/a/*c, /a/",
+      "/a/b*, /a/",
+      "/a/b/, /a/b/",
+      "/a/b, /a/b",
+      "/a/{id}, /a/",
+  })
+  void testGetPatternPrefix(ArgumentsAccessor accessor) {
+    RoutingEntry routingEntry = new RoutingEntry();
+    routingEntry.setPathPattern(accessor.getString(0));
+    String expect = accessor.getString(1);
+    if (expect == null) {
+      expect = "";
+    }
+    assertThat(ModuleCache.getPatternPrefix(routingEntry)).isEqualTo(expect);
+  }
+
+  @Test
+  void testPathPrefix()
+  {
+    RoutingEntry routingEntry = new RoutingEntry();
+    routingEntry.setPath("/a/b");
+    assertThat(ModuleCache.getPatternPrefix(routingEntry)).isEqualTo("/");
+  }
+
   @Test
   void testLookupEmpty() {
     Map<String, List<ModuleCache.ModuleCacheEntry>> map = new HashMap<>();

--- a/okapi-core/src/test/java/org/folio/okapi/util/ModuleCacheTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/ModuleCacheTest.java
@@ -126,7 +126,7 @@ class ModuleCacheTest {
     instances = ModuleCache.lookup("/perms/users1", HttpMethod.GET, map, true, null);
     assertThat(instances).extracting(routingEntry).containsExactly(routingEntry5);
 
-    ModuleCache.lookup("/perms/user", HttpMethod.GET, map, true, null).isEmpty();
+    assertThat(ModuleCache.lookup("/perms/user", HttpMethod.GET, map, true, null)).isEmpty();
 
     assertThat(ModuleCache.lookup("/old/foo", HttpMethod.GET, map, true, null)).isEmpty();
     instances = ModuleCache.lookup("/old/type", HttpMethod.GET, map, true, null);

--- a/okapi-core/src/test/java/org/folio/okapi/util/ModuleCacheTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/ModuleCacheTest.java
@@ -1,0 +1,117 @@
+package org.folio.okapi.util;
+
+import io.vertx.core.http.HttpMethod;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.folio.okapi.bean.InterfaceDescriptor;
+import org.folio.okapi.bean.ModuleDescriptor;
+import org.folio.okapi.bean.ModuleInstance;
+import org.folio.okapi.bean.RoutingEntry;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.in;
+
+
+public class ModuleCacheTest {
+  @Test
+  void testLookupEmpty() {
+    Map<String, List<ModuleInstance>> map = new HashMap<>();
+
+    assertThat(ModuleCache.lookup("", HttpMethod.GET, map, true)).isEmpty();
+    assertThat(ModuleCache.lookup("/", HttpMethod.GET, map, true)).isEmpty();
+    assertThat(ModuleCache.lookup("/a", HttpMethod.GET, map, true)).isEmpty();
+    assertThat(ModuleCache.lookup("/a/b", HttpMethod.GET, map, true)).isEmpty();
+  }
+
+  @Test
+  void testLookupRoutingEntries() {
+    Map<String, List<ModuleInstance>> map = new HashMap<>();
+    ModuleDescriptor md = new ModuleDescriptor();
+    List<RoutingEntry> routingEntries = new LinkedList<>();
+    RoutingEntry routingEntry1 = new RoutingEntry();
+    routingEntry1.setPathPattern("/a/b");
+    routingEntry1.setMethods(new String[] {"GET"});
+    routingEntries.add(routingEntry1);
+    RoutingEntry routingEntry2 = new RoutingEntry();
+    routingEntry2.setPathPattern("/a/b");
+    routingEntry2.setMethods(new String[] {"POST"});
+    routingEntries.add(routingEntry2);
+    RoutingEntry routingEntry3 = new RoutingEntry();
+    routingEntry3.setPathPattern("/a/b/{id}/c");
+    routingEntry3.setMethods(new String[] {"GET"});
+    routingEntries.add(routingEntry3);
+    RoutingEntry routingEntry4 = new RoutingEntry();
+    routingEntry4.setPathPattern("/p/*/y");
+    routingEntry4.setMethods(new String[] {"GET"});
+    routingEntries.add(routingEntry4);
+    RoutingEntry routingEntry5 = new RoutingEntry();
+    routingEntry5.setPath("/old/type");
+    routingEntry5.setMethods(new String[] {"GET"});
+    routingEntries.add(routingEntry5);
+    ModuleCache.add(md, map, routingEntries);
+
+    assertThat(ModuleCache.lookup("", HttpMethod.GET, map, true)).isEmpty();
+    assertThat(ModuleCache.lookup("/", HttpMethod.GET, map, true)).isEmpty();
+    assertThat(ModuleCache.lookup("/a", HttpMethod.GET, map, true)).isEmpty();
+    List<ModuleInstance> instances = ModuleCache.lookup("/a/b", HttpMethod.GET, map, true);
+    assertThat(instances.size()).isEqualTo(1);
+    assertThat(instances.get(0).getRoutingEntry()).isEqualTo(routingEntry1);
+
+    instances = ModuleCache.lookup("/a/b", HttpMethod.POST, map, true);
+    assertThat(instances.size()).isEqualTo(1);
+    assertThat(instances.get(0).getRoutingEntry()).isEqualTo(routingEntry2);
+
+    assertThat(ModuleCache.lookup("/a", HttpMethod.PUT, map, true)).isEmpty();
+    assertThat(ModuleCache.lookup("/a/b/", HttpMethod.GET, map, true)).isEmpty();
+
+    instances = ModuleCache.lookup("/a/b/id/c", HttpMethod.GET, map, true);
+    assertThat(instances.size()).isEqualTo(1);
+    assertThat(instances.get(0).getRoutingEntry()).isEqualTo(routingEntry3);
+
+    instances = ModuleCache.lookup("/p/id/y", HttpMethod.GET, map, true);
+    assertThat(instances.size()).isEqualTo(1);
+    assertThat(instances.get(0).getRoutingEntry()).isEqualTo(routingEntry4);
+
+    assertThat(ModuleCache.lookup("/old/foo", HttpMethod.GET, map, true)).isEmpty();
+    instances = ModuleCache.lookup("/old/type", HttpMethod.GET, map, true);
+    assertThat(instances.size()).isEqualTo(1);
+    assertThat(instances.get(0).getRoutingEntry()).isEqualTo(routingEntry5);
+  }
+
+  @Test
+  void testModules() {
+    ModuleCache moduleCache = new ModuleCache();
+
+    RoutingEntry[] routingEntries = new RoutingEntry[2];
+    RoutingEntry routingEntry1 = routingEntries[0] = new RoutingEntry();
+    routingEntry1.setPathPattern("/a/{id}");
+    routingEntry1.setMethods(new String[] {"GET"});
+
+    RoutingEntry routingEntry2 = routingEntries[1] = new RoutingEntry();
+    routingEntry2.setPathPattern("/a");
+    routingEntry2.setMethods(new String[] {"POST"});
+
+    InterfaceDescriptor[] interfaceDescriptors = new InterfaceDescriptor[1];
+    InterfaceDescriptor interfaceDescriptor = interfaceDescriptors[0] = new InterfaceDescriptor();
+    interfaceDescriptor.setId("int");
+    interfaceDescriptor.setHandlers(routingEntries);
+
+    ModuleDescriptor regularModule = new ModuleDescriptor();
+    regularModule.setProvides(interfaceDescriptors);
+    regularModule.setId("regular-1.0.0");
+    moduleCache.add(regularModule);
+
+    List<ModuleInstance> instances = moduleCache.lookup("/a/id", HttpMethod.GET, null);
+    assertThat(instances.size()).isEqualTo(1);
+    assertThat(instances.get(0).getRoutingEntry()).isEqualTo(routingEntry1);
+
+    assertThat(moduleCache.lookup("/a/id", HttpMethod.GET, "module-id")).isEmpty();
+
+    moduleCache.clear();
+    assertThat(moduleCache.lookup("/a/id", HttpMethod.GET, null)).isEmpty();
+  }
+}

--- a/okapi-core/src/test/java/org/folio/okapi/util/ModuleCacheTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/ModuleCacheTest.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import org.folio.okapi.bean.InterfaceDescriptor;
 import org.folio.okapi.bean.ModuleDescriptor;
 import org.folio.okapi.bean.ModuleInstance;
@@ -12,12 +13,13 @@ import org.folio.okapi.bean.RoutingEntry;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ModuleCacheTest {
+  Function<ModuleInstance, RoutingEntry> routingEntry = ModuleInstance::getRoutingEntry;
+
   @ParameterizedTest
   @CsvSource({
       "/, /",
@@ -91,52 +93,44 @@ class ModuleCacheTest {
     assertThat(ModuleCache.lookup("/", HttpMethod.GET, map, true, null)).isEmpty();
     assertThat(ModuleCache.lookup("/a", HttpMethod.GET, map, true, null)).isEmpty();
     List<ModuleInstance> instances = ModuleCache.lookup("/a/b", HttpMethod.GET, map, true, null);
-    assertThat(instances.size()).isEqualTo(1);
-    assertThat(instances.get(0).getRoutingEntry()).isEqualTo(routingEntry1);
+
+    assertThat(instances).extracting(routingEntry).containsExactly(routingEntry1);
 
     instances = ModuleCache.lookup("/a/b", HttpMethod.GET, map, true, "module-1.0.0");
-    assertThat(instances.size()).isEqualTo(1);
-    assertThat(instances.get(0).getRoutingEntry()).isEqualTo(routingEntry1);
+    assertThat(instances).extracting(routingEntry).containsExactly(routingEntry1);
 
     assertThat(ModuleCache.lookup("/a", HttpMethod.GET, map, true, "other-1.0.0")).isEmpty();
 
     instances = ModuleCache.lookup("/a/b", HttpMethod.POST, map, true, null);
-    assertThat(instances.size()).isEqualTo(1);
-    assertThat(instances.get(0).getRoutingEntry()).isEqualTo(routingEntry2);
+    assertThat(instances).extracting(routingEntry).containsExactly(routingEntry2);
 
     assertThat(ModuleCache.lookup("/a", HttpMethod.PUT, map, true, null)).isEmpty();
     assertThat(ModuleCache.lookup("/a/b/", HttpMethod.GET, map, true, null)).isEmpty();
 
     instances = ModuleCache.lookup("/a/b/id/c", HttpMethod.GET, map, true, null);
-    assertThat(instances.size()).isEqualTo(1);
-    assertThat(instances.get(0).getRoutingEntry()).isEqualTo(routingEntry3);
+    assertThat(instances).extracting(routingEntry).containsExactly(routingEntry3);
 
     instances = ModuleCache.lookup("/p/id/y", HttpMethod.GET, map, true, null);
-    assertThat(instances.size()).isEqualTo(1);
-    assertThat(instances.get(0).getRoutingEntry()).isEqualTo(routingEntry4);
+    assertThat(instances).extracting(routingEntry).containsExactly(routingEntry4);
 
     ModuleCache.lookup("/p/id/z", HttpMethod.GET, map, true, null).isEmpty();
     ModuleCache.lookup("/p/id", HttpMethod.GET, map, true, null).isEmpty();
     ModuleCache.lookup("/p/id/y/z", HttpMethod.GET, map, true, null).isEmpty();
 
     instances = ModuleCache.lookup("/perms/users", HttpMethod.GET, map, true, null);
-    assertThat(instances.size()).isEqualTo(1);
-    assertThat(instances.get(0).getRoutingEntry()).isEqualTo(routingEntry5);
+    assertThat(instances).extracting(routingEntry).containsExactly(routingEntry5);
 
     instances = ModuleCache.lookup("/perms/users/y", HttpMethod.GET, map, true, null);
-    assertThat(instances.size()).isEqualTo(1);
-    assertThat(instances.get(0).getRoutingEntry()).isEqualTo(routingEntry5);
+    assertThat(instances).extracting(routingEntry).containsExactly(routingEntry5);
 
     instances = ModuleCache.lookup("/perms/users1", HttpMethod.GET, map, true, null);
-    assertThat(instances.size()).isEqualTo(1);
-    assertThat(instances.get(0).getRoutingEntry()).isEqualTo(routingEntry5);
+    assertThat(instances).extracting(routingEntry).containsExactly(routingEntry5);
 
     ModuleCache.lookup("/perms/user", HttpMethod.GET, map, true, null).isEmpty();
 
     assertThat(ModuleCache.lookup("/old/foo", HttpMethod.GET, map, true, null)).isEmpty();
     instances = ModuleCache.lookup("/old/type", HttpMethod.GET, map, true, null);
-    assertThat(instances.size()).isEqualTo(1);
-    assertThat(instances.get(0).getRoutingEntry()).isEqualTo(routingEntry6);
+    assertThat(instances).extracting(routingEntry).containsExactly(routingEntry6);
   }
 
   @Test
@@ -169,26 +163,23 @@ class ModuleCacheTest {
     assertThat(moduleCache.getModules()).isEqualTo(modules);
 
     List<ModuleInstance> instances = moduleCache.lookup("/a/id", HttpMethod.GET, null);
-    assertThat(instances.size()).isEqualTo(1);
-    assertThat(instances.get(0).getRoutingEntry()).isEqualTo(routingEntry2);
+    assertThat(instances).extracting(routingEntry).containsExactly(routingEntry2);
 
     instances = moduleCache.lookup("/a/id#a", HttpMethod.GET, null);
-    assertThat(instances.size()).isEqualTo(1);
-    assertThat(instances.get(0).getRoutingEntry()).isEqualTo(routingEntry2);
+    assertThat(instances).extracting(routingEntry).containsExactly(routingEntry2);
 
     instances = moduleCache.lookup("/a/id?a", HttpMethod.GET, null);
-    assertThat(instances.size()).isEqualTo(1);
-    assertThat(instances.get(0).getRoutingEntry()).isEqualTo(routingEntry2);
+    assertThat(instances).extracting(routingEntry).containsExactly(routingEntry2);
 
     assertThat(moduleCache.lookup("/a/id", HttpMethod.GET, "module-id")).isEmpty();
 
     instances = moduleCache.lookup("/a/client_id", HttpMethod.GET, null);
-    assertThat(instances.size()).isEqualTo(1);
-    assertThat(instances.get(0).getRoutingEntry()).isEqualTo(routingEntry1);
+    assertThat(instances).extracting(routingEntry).containsExactly(routingEntry1);
   }
 
   @Test
   void testModuleMulti() {
+
     RoutingEntry[] routingEntries = new RoutingEntry[1];
     RoutingEntry routingEntry1 = routingEntries[0] = new RoutingEntry();
     routingEntry1.setPathPattern("/a/{id}");
@@ -209,8 +200,7 @@ class ModuleCacheTest {
     ModuleCache moduleCache = new ModuleCache(modules);
 
     List<ModuleInstance> instances = moduleCache.lookup("/a/id", HttpMethod.GET, "module-1.0.0");
-    assertThat(instances.size()).isEqualTo(1);
-    assertThat(instances.get(0).getRoutingEntry()).isEqualTo(routingEntry1);
+    assertThat(instances).extracting(routingEntry).containsExactly(routingEntry1);
 
     assertThat(moduleCache.lookup("/a/id", HttpMethod.GET, "other-1.0.0")).isEmpty();
     assertThat(moduleCache.lookup("/a/id", HttpMethod.GET, null)).isEmpty();
@@ -244,17 +234,13 @@ class ModuleCacheTest {
     ModuleCache moduleCache = new ModuleCache(modules);
 
     List<ModuleInstance> instances = moduleCache.lookup("/a/id", HttpMethod.GET, null);
-    assertThat(instances.size()).isEqualTo(1);
-    assertThat(instances.get(0).getRoutingEntry()).isEqualTo(routingEntry2);
+    assertThat(instances).extracting(routingEntry).containsExactly(routingEntry2);
 
     instances = moduleCache.lookup("/token", HttpMethod.POST, null);
-    assertThat(instances.size()).isEqualTo(1);
-    assertThat(instances.get(0).getRoutingEntry()).isEqualTo(routingEntry2);
+    assertThat(instances).extracting(routingEntry).containsExactly(routingEntry2);
 
     instances = moduleCache.lookup("/token", HttpMethod.GET, null);
-    assertThat(instances.size()).isEqualTo(2);
-    assertThat(instances.get(0).getRoutingEntry()).isEqualTo(routingEntry2);
-    assertThat(instances.get(1).getRoutingEntry()).isEqualTo(routingEntry1);
+    assertThat(instances).extracting(routingEntry).containsExactly(routingEntry2, routingEntry1);
   }
 
   @Test
@@ -331,15 +317,10 @@ class ModuleCacheTest {
     ModuleCache moduleCache2 = new ModuleCache(modules);
 
     List<ModuleInstance> instances = moduleCache2.lookup("/second", HttpMethod.GET, null);
-    assertThat(instances.size()).isEqualTo(2);
-    assertThat(instances.get(0).getRoutingEntry()).isEqualTo(routingEntry2);
-    assertThat(instances.get(1).getRoutingEntry()).isEqualTo(routingEntry1);
+    assertThat(instances).extracting(routingEntry).containsExactly(routingEntry2, routingEntry1);
 
     instances = moduleCache2.lookup("/third", HttpMethod.GET, null);
-    assertThat(instances.size()).isEqualTo(3);
-    assertThat(instances.get(0).getRoutingEntry()).isEqualTo(routingEntry3);
-    assertThat(instances.get(1).getRoutingEntry()).isEqualTo(routingEntry2);
-    assertThat(instances.get(2).getRoutingEntry()).isEqualTo(routingEntry1);
+    assertThat(instances).extracting(routingEntry).containsExactly(routingEntry3, routingEntry2, routingEntry1);
   }
 
 

--- a/okapi-core/src/test/java/org/folio/okapi/util/ModuleUtilTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/ModuleUtilTest.java
@@ -1,0 +1,27 @@
+package org.folio.okapi.util;
+
+import java.util.LinkedList;
+import java.util.List;
+import org.folio.okapi.bean.ModuleDescriptor;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ModuleUtilTest {
+
+  @Test
+  void testModuleList() {
+    List<ModuleDescriptor> list = new LinkedList<>();
+    assertThat(ModuleUtil.moduleList(list)).isEqualTo("");
+
+    ModuleDescriptor md = new ModuleDescriptor();
+    md.setId("foo-1.0.0");
+    list.add(md);
+    assertThat(ModuleUtil.moduleList(list)).isEqualTo("foo-1.0.0");
+
+    md = new ModuleDescriptor();
+    md.setId("bar-2.0.0");
+    list.add(md);
+    assertThat(ModuleUtil.moduleList(list)).isEqualTo("foo-1.0.0, bar-2.0.0");
+  }
+}

--- a/okapi-core/src/test/java/org/folio/okapi/util/ModuleUtilTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/ModuleUtilTest.java
@@ -7,12 +7,12 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ModuleUtilTest {
+class ModuleUtilTest {
 
   @Test
   void testModuleList() {
     List<ModuleDescriptor> list = new LinkedList<>();
-    assertThat(ModuleUtil.moduleList(list)).isEqualTo("");
+    assertThat(ModuleUtil.moduleList(list)).isEmpty();
 
     ModuleDescriptor md = new ModuleDescriptor();
     md.setId("foo-1.0.0");

--- a/okapi-core/src/test/resources/install2.json
+++ b/okapi-core/src/test/resources/install2.json
@@ -1,0 +1,313 @@
+[ {
+  "id" : "mod-orders-storage-11.0.3",
+  "action" : "enable"
+}, {
+  "id" : "mod-configuration-5.4.4",
+  "action" : "enable"
+}, {
+  "id" : "mod-inventory-storage-19.3.6",
+  "action" : "enable"
+}, {
+  "id" : "mod-users-17.1.2",
+  "action" : "enable"
+}, {
+  "id" : "mod-login-7.0.1",
+  "action" : "enable"
+}, {
+  "id" : "mod-permissions-5.11.4",
+  "action" : "enable"
+}, {
+  "id" : "mod-pubsub-1.2.5",
+  "action" : "enable"
+}, {
+  "id" : "mod-circulation-storage-12.0.3",
+  "action" : "enable"
+}, {
+  "id" : "mod-source-record-storage-4.0.4",
+  "action" : "enable"
+}, {
+  "id" : "mod-inventory-16.0.3",
+  "action" : "enable"
+}, {
+  "id" : "mod-organizations-storage-3.1.1",
+  "action" : "enable"
+}, {
+  "id" : "mod-finance-storage-5.0.2",
+  "action" : "enable"
+}, {
+  "id" : "mod-finance-3.0.1",
+  "action" : "enable"
+}, {
+  "id" : "mod-calendar-1.9.1",
+  "action" : "enable"
+}, {
+  "id" : "mod-event-config-1.5.0",
+  "action" : "enable"
+}, {
+  "id" : "mod-template-engine-1.9.0",
+  "action" : "enable"
+}, {
+  "id" : "mod-email-1.8.0",
+  "action" : "enable"
+}, {
+  "id" : "mod-sender-1.3.1",
+  "action" : "enable"
+}, {
+  "id" : "mod-notify-2.6.0",
+  "action" : "enable"
+}, {
+  "id" : "mod-feesfines-15.8.3",
+  "action" : "enable"
+}, {
+  "id" : "mod-patron-blocks-1.0.7",
+  "action" : "enable"
+}, {
+  "id" : "mod-circulation-19.0.16",
+  "action" : "enable"
+}, {
+  "id" : "mod-orders-11.0.6",
+  "action" : "enable"
+}, {
+  "id" : "folio_acquisition-units-2.1.0",
+  "action" : "enable"
+}, {
+  "id" : "mod-agreements-2.3.1",
+  "action" : "enable"
+}, {
+  "id" : "mod-licenses-2.2.3",
+  "action" : "enable"
+}, {
+  "id" : "folio_agreements-4.0.4",
+  "action" : "enable"
+}, {
+  "id" : "folio_calendar-4.0.1",
+  "action" : "enable"
+}, {
+  "id" : "folio_checkin-3.0.2",
+  "action" : "enable"
+}, {
+  "id" : "folio_checkout-4.0.3",
+  "action" : "enable"
+}, {
+  "id" : "folio_circulation-3.0.2",
+  "action" : "enable"
+}, {
+  "id" : "mod-courses-1.0.7",
+  "action" : "enable"
+}, {
+  "id" : "folio_courses-2.0.0",
+  "action" : "enable"
+}, {
+  "id" : "mod-data-export-2.1.4",
+  "action" : "enable"
+}, {
+  "id" : "folio_data-export-2.0.1",
+  "action" : "enable"
+}, {
+  "id" : "mod-data-import-converter-storage-1.8.3",
+  "action" : "enable"
+}, {
+  "id" : "mod-source-record-manager-2.3.4",
+  "action" : "enable"
+}, {
+  "id" : "mod-data-import-1.10.2",
+  "action" : "enable"
+}, {
+  "id" : "folio_data-import-2.1.4",
+  "action" : "enable"
+}, {
+  "id" : "folio_developer-3.0.0",
+  "action" : "enable"
+}, {
+  "id" : "mod-kb-ebsco-java-3.5.3",
+  "action" : "enable"
+}, {
+  "id" : "mod-tags-0.6.0",
+  "action" : "enable"
+}, {
+  "id" : "folio_eholdings-4.0.1",
+  "action" : "enable"
+}, {
+  "id" : "mod-erm-usage-2.9.0",
+  "action" : "enable"
+}, {
+  "id" : "folio_erm-usage-3.0.0",
+  "action" : "enable"
+}, {
+  "id" : "folio_finance-2.1.2",
+  "action" : "enable"
+}, {
+  "id" : "folio_inventory-4.0.3",
+  "action" : "enable"
+}, {
+  "id" : "mod-invoice-storage-4.0.1",
+  "action" : "enable"
+}, {
+  "id" : "mod-invoice-4.0.3",
+  "action" : "enable"
+}, {
+  "id" : "mod-organizations-1.0.0",
+  "action" : "enable"
+}, {
+  "id" : "folio_invoice-2.1.3",
+  "action" : "enable"
+}, {
+  "id" : "folio_licenses-4.0.1",
+  "action" : "enable"
+}, {
+  "id" : "folio_local-kb-admin-2.0.0",
+  "action" : "enable"
+}, {
+  "id" : "folio_myprofile-3.0.0",
+  "action" : "enable"
+}, {
+  "id" : "mod-notes-2.9.0",
+  "action" : "enable"
+}, {
+  "id" : "folio_notes-3.0.0",
+  "action" : "enable"
+}, {
+  "id" : "folio_oai-pmh-1.2.0",
+  "action" : "enable"
+}, {
+  "id" : "folio_orders-2.1.1",
+  "action" : "enable"
+}, {
+  "id" : "folio_organizations-2.1.2",
+  "action" : "enable"
+}, {
+  "id" : "folio_plugin-create-item-2.1.0",
+  "action" : "enable"
+}, {
+  "id" : "folio_plugin-find-agreement-4.0.0",
+  "action" : "enable"
+}, {
+  "id" : "folio_plugin-find-contact-2.1.0",
+  "action" : "enable"
+}, {
+  "id" : "folio_plugin-find-erm-usage-data-provider-1.4.0",
+  "action" : "enable"
+}, {
+  "id" : "folio_plugin-find-import-profile-2.0.1",
+  "action" : "enable"
+}, {
+  "id" : "folio_plugin-find-instance-3.0.0",
+  "action" : "enable"
+}, {
+  "id" : "folio_plugin-find-interface-2.1.0",
+  "action" : "enable"
+}, {
+  "id" : "folio_plugin-find-license-4.0.0",
+  "action" : "enable"
+}, {
+  "id" : "folio_plugin-find-organization-2.1.0",
+  "action" : "enable"
+}, {
+  "id" : "folio_plugin-find-package-title-1.0.1",
+  "action" : "enable"
+}, {
+  "id" : "folio_plugin-find-po-line-2.1.0",
+  "action" : "enable"
+}, {
+  "id" : "folio_plugin-find-user-3.0.1",
+  "action" : "enable"
+}, {
+  "id" : "mod-quick-marc-1.1.1",
+  "action" : "enable"
+}, {
+  "id" : "folio_quick-marc-1.1.1",
+  "action" : "enable"
+}, {
+  "id" : "folio_receiving-1.1.0",
+  "action" : "enable"
+}, {
+  "id" : "folio_requests-3.0.7",
+  "action" : "enable"
+}, {
+  "id" : "mod-codex-mux-2.8.0",
+  "action" : "enable"
+}, {
+  "id" : "folio_search-3.0.0",
+  "action" : "enable"
+}, {
+  "id" : "folio_servicepoints-3.0.0",
+  "action" : "enable"
+}, {
+  "id" : "folio_stripes-acq-components-2.1.2",
+  "action" : "enable"
+}, {
+  "id" : "mod-password-validator-1.7.0",
+  "action" : "enable"
+}, {
+  "id" : "mod-authtoken-2.5.1",
+  "action" : "enable"
+}, {
+  "id" : "mod-users-bl-6.0.0",
+  "action" : "enable"
+}, {
+  "id" : "folio_stripes-core-5.0.3",
+  "action" : "enable"
+}, {
+  "id" : "folio_stripes-data-transfer-components-2.0.1",
+  "action" : "enable"
+}, {
+  "id" : "folio_stripes-smart-components-4.1.5",
+  "action" : "enable"
+}, {
+  "id" : "folio_tags-3.0.0",
+  "action" : "enable"
+}, {
+  "id" : "mod-login-saml-2.0.1",
+  "action" : "enable"
+}, {
+  "id" : "folio_tenant-settings-4.0.0",
+  "action" : "enable"
+}, {
+  "id" : "folio_users-4.0.7",
+  "action" : "enable"
+}, {
+  "id" : "mod-ncip-1.4.2",
+  "action" : "enable"
+}, {
+  "id" : "edge-ncip-1.4.0",
+  "action" : "enable"
+}, {
+  "id" : "mod-gobi-1.10.0",
+  "action" : "enable"
+}, {
+  "id" : "edge-orders-2.2.1",
+  "action" : "enable"
+}, {
+  "id" : "mod-oai-pmh-3.1.3",
+  "action" : "enable"
+}, {
+  "id" : "edge-oai-pmh-2.2.2",
+  "action" : "enable"
+}, {
+  "id" : "mod-patron-4.2.0",
+  "action" : "enable"
+}, {
+  "id" : "edge-patron-4.2.0",
+  "action" : "enable"
+}, {
+  "id" : "mod-rtac-1.5.0",
+  "action" : "enable"
+}, {
+  "id" : "edge-rtac-2.0.2",
+  "action" : "enable"
+}, {
+  "id" : "edge-sip2-1.3.1",
+  "action" : "enable"
+}, {
+  "id" : "mod-codex-inventory-1.7.0",
+  "action" : "enable"
+}, {
+  "id" : "mod-codex-ekb-1.6.0",
+  "action" : "enable"
+}, {
+  "id" : "mod-erm-usage-harvester-1.7.2",
+  "action" : "enable"
+}, {
+  "id" : "mod-user-import-3.2.1",
+  "action" : "enable"
+} ]

--- a/okapi-core/src/test/resources/modules2.json
+++ b/okapi-core/src/test/resources/modules2.json
@@ -1,0 +1,17994 @@
+[ {
+  "id" : "edge-ncip-1.4.0",
+  "name" : "Edge NCIP",
+  "requires" : [ {
+    "id" : "ncip",
+    "version" : "1.0"
+  }, {
+    "id" : "login",
+    "version" : "5.0 6.0 7.0"
+  } ],
+  "provides" : [ ],
+  "permissionSets" : [ ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/edge-ncip:1.4.0",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "edge-oai-pmh-2.2.2",
+  "name" : "OAI-PMH Edge API",
+  "requires" : [ {
+    "id" : "oai-pmh",
+    "version" : "3.0"
+  }, {
+    "id" : "login",
+    "version" : "5.0 6.0 7.0"
+  }, {
+    "id" : "configuration",
+    "version" : "2.0"
+  } ],
+  "provides" : [ ],
+  "permissionSets" : [ ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/edge-oai-pmh:2.2.2",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0 -Drequest_timeout_ms=7200000"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 268435456,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "edge-orders-2.2.1",
+  "name" : "Acquisitions - Orders Edge API",
+  "requires" : [ {
+    "id" : "gobi",
+    "version" : "1.9"
+  }, {
+    "id" : "login",
+    "version" : "5.0 6.0 7.0"
+  } ],
+  "provides" : [ ],
+  "permissionSets" : [ ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/edge-orders:2.2.1",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 268435456,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "edge-patron-4.2.0",
+  "name" : "Patron Services Edge API",
+  "requires" : [ {
+    "id" : "patron",
+    "version" : "4.0"
+  }, {
+    "id" : "login",
+    "version" : "5.0 6.0 7.0"
+  } ],
+  "provides" : [ ],
+  "permissionSets" : [ ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/edge-patron:4.2.0",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 268435456,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "edge-rtac-2.0.2",
+  "name" : "Real Time Availability Check Edge API",
+  "requires" : [ {
+    "id" : "rtac",
+    "version" : "1.3"
+  }, {
+    "id" : "login",
+    "version" : "5.0 6.0 7.0"
+  } ],
+  "provides" : [ ],
+  "permissionSets" : [ ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/edge-rtac:2.0.2",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 268435456,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "edge-sip2-1.3.1",
+  "name" : "SIP2 Module",
+  "requires" : [ {
+    "id" : "login",
+    "version" : "5.0 6.0 7.0"
+  }, {
+    "id" : "circulation",
+    "version" : "7.0 8.0 9.0"
+  }, {
+    "id" : "users",
+    "version" : "15.0"
+  }, {
+    "id" : "configuration",
+    "version" : "2.0"
+  }, {
+    "id" : "feesfines",
+    "version" : "15.0"
+  } ],
+  "provides" : [ ],
+  "permissionSets" : [ ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/edge-sip2:1.3.1",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 268435456,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "folio_acquisition-units-2.1.0",
+  "name" : "Acquisition units",
+  "requires" : [ {
+    "id" : "acquisitions-units",
+    "version" : "1.1"
+  }, {
+    "id" : "users",
+    "version" : "15.1"
+  } ],
+  "optional" : [ ],
+  "permissionSets" : [ {
+    "permissionName" : "settings.acquisition-units.enabled",
+    "displayName" : "Settings (acquisition units): display list of settings pages",
+    "subPermissions" : [ "settings.enabled", "users.collection.get", "usergroups.collection.get", "acquisitions-units.units.all", "acquisitions-units.memberships.all" ],
+    "visible" : true
+  } ]
+}, {
+  "id" : "folio_agreements-4.0.4",
+  "name" : "ERM agreement functionality for Stripes",
+  "requires" : [ {
+    "id" : "configuration",
+    "version" : "2.0 3.0 4.0 5.0"
+  }, {
+    "id" : "erm",
+    "version" : "2.0"
+  }, {
+    "id" : "licenses",
+    "version" : "1.0 2.0"
+  }, {
+    "id" : "order-lines",
+    "version" : "1.0"
+  }, {
+    "id" : "organizations-storage.interfaces",
+    "version" : "2.0"
+  }, {
+    "id" : "users",
+    "version" : "13.0 14.0 15.0"
+  } ],
+  "optional" : [ ],
+  "permissionSets" : [ {
+    "permissionName" : "module.agreements.enabled",
+    "displayName" : "UI: ui-agreements module is enabled",
+    "subPermissions" : [ "configuration.entries.collection.get", "tags.collection.get", "erm.refdata.view", "note.types.collection.get" ]
+  }, {
+    "permissionName" : "ui-agreements.resources.view",
+    "displayName" : "Agreements: Search & view e-resources",
+    "subPermissions" : [ "module.agreements.enabled", "erm.packages.view", "erm.titles.view", "erm.resources.view", "erm.pci.view" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-agreements.resources.edit",
+    "displayName" : "Agreements: Edit e-resources",
+    "subPermissions" : [ "erm.pci.edit", "erm.pti.edit", "erm.titles.edit", "ui-agreements.resources.view" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-agreements.agreements.view",
+    "displayName" : "Agreements: Search & view agreements",
+    "subPermissions" : [ "module.agreements.enabled", "erm.agreements.view", "erm.contacts.view", "erm.custprops.view", "erm.files.view", "erm.orgs.view", "licenses.custprops.view" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-agreements.agreements.edit",
+    "displayName" : "Agreements: Edit agreements",
+    "subPermissions" : [ "ui-agreements.agreements.view", "erm.agreements.edit", "erm.entitlements.edit", "erm.files.edit", "tags.item.post" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-agreements.agreements.delete",
+    "displayName" : "Agreements: Delete agreements",
+    "subPermissions" : [ "ui-agreements.agreements.view", "erm.agreements.item.delete" ],
+    "visible" : true
+  }, {
+    "permissionName" : "settings.agreements.enabled",
+    "displayName" : "Settings (Agreements): Can view and edit settings",
+    "subPermissions" : [ "module.agreements.enabled", "settings.enabled", "configuration.all" ]
+  }, {
+    "permissionName" : "ui-agreements.generalSettings.manage",
+    "displayName" : "Settings (Agreements): Can view and edit general settings",
+    "subPermissions" : [ "settings.agreements.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-agreements.picklists.manage",
+    "displayName" : "Settings (Agreements): Manage pick lists and values",
+    "subPermissions" : [ "settings.agreements.enabled", "erm.refdata.manage" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-agreements.supplementaryProperties.manage",
+    "displayName" : "Settings (Agreements): Manage agreement supplementary properties",
+    "subPermissions" : [ "settings.agreements.enabled", "erm.custprops.manage" ],
+    "visible" : true
+  } ]
+}, {
+  "id" : "folio_calendar-4.0.1",
+  "name" : "Opening hours",
+  "requires" : [ {
+    "id" : "calendar",
+    "version" : "4.0"
+  }, {
+    "id" : "service-points",
+    "version" : "3.0"
+  } ],
+  "optional" : [ ],
+  "permissionSets" : [ {
+    "permissionName" : "module.calendar.enabled",
+    "displayName" : "UI: Calendar module is enabled"
+  }, {
+    "permissionName" : "ui-calendar.all",
+    "displayName" : "Settings (Calendar): Can create, view, edit, and remove calendar events.",
+    "description" : "User can create,edit, view, and remove calendar events",
+    "subPermissions" : [ "ui-calendar.edit", "calendar.periods.item.delete" ],
+    "visible" : true
+  }, {
+    "permissionName" : "settings.calendar.enabled",
+    "displayName" : "Settings (Calendar): display list of settings pages",
+    "subPermissions" : [ "settings.enabled" ]
+  }, {
+    "permissionName" : "ui-calendar.view",
+    "displayName" : "Settings (Calendar): Can view calendar events",
+    "description" : "Can view calendar events",
+    "subPermissions" : [ "configuration.entries.collection.get", "inventory-storage.service-points.collection.get", "calendar.opening-hours.collection.get", "calendar.periods.collection.get", "calendar.periods.item.get", "module.calendar.enabled", "settings.calendar.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-calendar.edit",
+    "displayName" : "Settings (Calendar): Can create, view, and edit calendar events",
+    "description" : "Can edit calendar events. User cannot remove any calendar event.",
+    "subPermissions" : [ "settings.calendar.enabled", "ui-calendar.view", "calendar.periods.item.post", "calendar.periods.item.put" ],
+    "visible" : true
+  } ]
+}, {
+  "id" : "folio_checkin-3.0.2",
+  "name" : "Item Check-in",
+  "requires" : [ {
+    "id" : "circulation",
+    "version" : "9.0"
+  }, {
+    "id" : "configuration",
+    "version" : "2.0"
+  }, {
+    "id" : "item-storage",
+    "version" : "8.0"
+  }, {
+    "id" : "loan-policy-storage",
+    "version" : "1.0 2.0"
+  }, {
+    "id" : "users",
+    "version" : "15.0"
+  } ],
+  "optional" : [ ],
+  "permissionSets" : [ {
+    "permissionName" : "module.checkin.enabled",
+    "displayName" : "UI: Check in module is enabled"
+  }, {
+    "permissionName" : "ui-checkin.all",
+    "displayName" : "Check in: All permissions",
+    "description" : "Entire set of permissions needed to use Checkin",
+    "subPermissions" : [ "circulation.all", "circulation-storage.all", "configuration.all", "users.collection.get", "usergroups.collection.get", "module.checkin.enabled", "inventory.items.collection.get", "inventory-storage.service-points.collection.get" ],
+    "visible" : true
+  } ]
+}, {
+  "id" : "folio_checkout-4.0.3",
+  "name" : "Item Check-out",
+  "requires" : [ {
+    "id" : "circulation",
+    "version" : "9.0"
+  }, {
+    "id" : "configuration",
+    "version" : "2.0"
+  }, {
+    "id" : "item-storage",
+    "version" : "8.0"
+  }, {
+    "id" : "loan-policy-storage",
+    "version" : "1.0 2.0"
+  }, {
+    "id" : "users",
+    "version" : "15.0"
+  }, {
+    "id" : "inventory",
+    "version" : "10.0"
+  }, {
+    "id" : "automated-patron-blocks",
+    "version" : "0.1"
+  } ],
+  "optional" : [ ],
+  "permissionSets" : [ {
+    "permissionName" : "module.checkout.enabled",
+    "displayName" : "UI: Check out module is enabled"
+  }, {
+    "permissionName" : "ui-checkout.overrideCheckOutByBarcode",
+    "displayName" : "Check out: Override loans policy on check out by barcode",
+    "subPermissions" : [ "circulation.override-check-out-by-barcode.post" ]
+  }, {
+    "permissionName" : "ui-checkout.circulation",
+    "displayName" : "Check out: Check out circulating items",
+    "description" : "Set of permissions needed to check out circulation items",
+    "subPermissions" : [ "circulation.all", "circulation-storage.all", "configuration.all", "users.collection.get", "usergroups.collection.get", "proxiesfor.collection.get", "accounts.collection.get", "manualblocks.collection.get", "automated-patron-blocks.collection.get", "module.checkout.enabled", "inventory.items.collection.get", "circulation.end-patron-action-session.post" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-checkout.all",
+    "displayName" : "Check out: All permissions",
+    "description" : "Entire set of permissions needed to use Check out",
+    "subPermissions" : [ "ui-checkout.circulation", "ui-checkout.overrideCheckOutByBarcode" ],
+    "visible" : true
+  } ]
+}, {
+  "id" : "folio_circulation-3.0.2",
+  "name" : "Circulation manager",
+  "requires" : [ {
+    "id" : "circulation",
+    "version" : "9.0"
+  }, {
+    "id" : "configuration",
+    "version" : "2.0"
+  }, {
+    "id" : "fixed-due-date-schedules-storage",
+    "version" : "2.0"
+  }, {
+    "id" : "loan-policy-storage",
+    "version" : "1.0 2.0"
+  }, {
+    "id" : "template-engine",
+    "version" : "2.0"
+  }, {
+    "id" : "patron-notice-policy-storage",
+    "version" : "0.11"
+  }, {
+    "id" : "location-units",
+    "version" : "2.0"
+  }, {
+    "id" : "locations",
+    "version" : "3.0"
+  }, {
+    "id" : "feesfines",
+    "version" : "15.0"
+  } ],
+  "optional" : [ ],
+  "permissionSets" : [ {
+    "permissionName" : "settings.circulation.enabled",
+    "displayName" : "Settings (Circ): display list of settings pages",
+    "subPermissions" : [ "settings.enabled" ]
+  }, {
+    "permissionName" : "ui-circulation.settings.cancellation-reasons",
+    "displayName" : "Settings (Circ): Can create, edit and remove cancellation reasons",
+    "subPermissions" : [ "circulation-storage.cancellation-reasons.item.get", "circulation-storage.cancellation-reasons.item.post", "circulation-storage.cancellation-reasons.item.put", "circulation-storage.cancellation-reasons.item.delete", "circulation-storage.cancellation-reasons.collection.get", "circulation-storage.cancellation-reasons.collection.delete", "users.collection.get", "users.item.get", "settings.circulation.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-circulation.settings.loan-history",
+    "displayName" : "Settings (Circ): Can view loan history",
+    "subPermissions" : [ "settings.circulation.enabled", "payments.collection.get" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-circulation.settings.loan-policies",
+    "displayName" : "Settings (Circ): Can create, edit and remove loan policies",
+    "subPermissions" : [ "circulation-storage.loan-policies.collection.get", "circulation-storage.loan-policies.item.get", "circulation-storage.loan-policies.item.post", "circulation-storage.loan-policies.item.put", "circulation-storage.loan-policies.item.delete", "circulation-storage.loan-policies.collection.delete", "circulation-storage.fixed-due-date-schedules.collection.get", "circulation-storage.fixed-due-date-schedules.item.get", "users.collection.get", "users.item.get", "settings.circulation.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-circulation.settings.notice-policies",
+    "displayName" : "Settings (Circ): Can create, edit and remove notice policies",
+    "subPermissions" : [ "circulation-storage.patron-notice-policies.item.post", "circulation-storage.patron-notice-policies.item.put", "circulation-storage.patron-notice-policies.item.delete", "circulation-storage.patron-notice-policies.collection.get", "circulation-storage.patron-notice-policies.item.get", "templates.collection.get", "templates.item.get", "users.collection.get", "users.item.get", "settings.circulation.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "settings.loan-policies.all",
+    "displayName" : "Settings (Circ): Can create, edit and remove loan policies [LEGACY]",
+    "subPermissions" : [ "ui-circulation.settings.loan-policies" ]
+  }, {
+    "permissionName" : "ui-circulation.settings.circulation-rules",
+    "displayName" : "Settings (Circ): Can create, edit and remove circulation rules",
+    "subPermissions" : [ "circulation-storage.circulation-rules.get", "circulation-storage.circulation-rules.put", "circulation.rules.get", "circulation.rules.put", "usergroups.collection.get", "circulation-storage.loan-policies.collection.get", "circulation-storage.request-policies.collection.get", "circulation-storage.patron-notice-policies.collection.get", "inventory-storage.material-types.collection.get", "inventory-storage.loan-types.collection.get", "circulation-storage.loan-policies.item.get", "circulation-storage.request-policies.item.get", "circulation-storage.patron-notice-policies.item.get", "inventory-storage.material-types.item.get", "inventory-storage.loan-types.item.get", "settings.circulation.enabled", "inventory-storage.location-units.institutions.collection.get", "inventory-storage.location-units.campuses.collection.get", "inventory-storage.location-units.libraries.collection.get", "inventory-storage.locations.collection.get" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-circulation.settings.fixed-due-date-schedules",
+    "displayName" : "Settings (Circ): Can create, edit and remove fixed due date schedules",
+    "subPermissions" : [ "circulation-storage.fixed-due-date-schedules.collection.get", "circulation-storage.fixed-due-date-schedules.item.get", "circulation-storage.fixed-due-date-schedules.item.post", "circulation-storage.fixed-due-date-schedules.item.put", "circulation-storage.fixed-due-date-schedules.item.delete", "circulation-storage.fixed-due-date-schedules.collection.delete", "users.collection.get", "users.item.get", "settings.circulation.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "settings.loan-rules.all",
+    "displayName" : "Settings (Circ): Can create, edit and remove loan rules [LEGACY]",
+    "subPermissions" : [ "ui-circulation.settings.circulation-rules" ]
+  }, {
+    "permissionName" : "ui-circulation.settings.staff-slips",
+    "displayName" : "Settings (Circ): Can create, edit and remove staff slips",
+    "subPermissions" : [ "circulation-storage.staff-slips.item.delete", "circulation-storage.staff-slips.collection.delete", "circulation-storage.staff-slips.collection.get", "circulation-storage.staff-slips.item.post", "circulation-storage.staff-slips.item.put", "circulation-storage.staff-slips.item.get", "settings.circulation.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-circulation.settings.request-policies",
+    "displayName" : "Settings (Circ): Can create, edit and remove request policies",
+    "subPermissions" : [ "circulation-storage.request-policies.collection.get", "circulation-storage.request-policies.item.get", "circulation-storage.request-policies.collection.delete", "circulation-storage.request-policies.item.delete", "circulation-storage.request-policies.item.post", "circulation-storage.request-policies.item.put", "users.collection.get", "users.item.get", "settings.circulation.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-circulation.settings.other-settings",
+    "displayName" : "Settings (Circ): Can create, edit and remove other settings",
+    "subPermissions" : [ "configuration.all", "settings.circulation.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-circulation.settings.notice-templates",
+    "displayName" : "Settings (Circ): Can create, edit and remove patron notice templates",
+    "subPermissions" : [ "templates.collection.get", "templates.item.get", "templates.item.post", "templates.item.put", "templates.item.delete", "template-request.post", "settings.circulation.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-circulation.settings.overdue-fines-policies",
+    "displayName" : "Settings (Circ): Can create, edit and remove overdue fine policies",
+    "subPermissions" : [ "overdue-fines-policies.item.post", "overdue-fines-policies.item.put", "overdue-fines-policies.item.delete", "overdue-fines-policies.collection.get", "overdue-fines-policies.item.get", "users.collection.get", "users.item.get", "settings.circulation.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-circulation.settings.lost-item-fees-policies",
+    "displayName" : "Settings (Circ): Can create, edit and remove lost item fee policies",
+    "subPermissions" : [ "lost-item-fees-policies.item.post", "lost-item-fees-policies.item.put", "lost-item-fees-policies.item.delete", "lost-item-fees-policies.collection.get", "lost-item-fees-policies.item.get", "users.collection.get", "users.item.get", "settings.circulation.enabled" ],
+    "visible" : true
+  } ]
+}, {
+  "id" : "folio_courses-2.0.0",
+  "name" : "Maintain courses and reserve items for them",
+  "requires" : [ {
+    "id" : "course-reserves-storage",
+    "version" : "0.2"
+  }, {
+    "id" : "term-storage",
+    "version" : "0.1"
+  }, {
+    "id" : "department-storage",
+    "version" : "0.1"
+  }, {
+    "id" : "course-type-storage",
+    "version" : "0.1"
+  }, {
+    "id" : "processing-status-storage",
+    "version" : "0.1"
+  }, {
+    "id" : "copyright-status-storage",
+    "version" : "0.1"
+  }, {
+    "id" : "role-storage",
+    "version" : "0.1"
+  }, {
+    "id" : "locations",
+    "version" : "3.0"
+  }, {
+    "id" : "item-storage",
+    "version" : "7.1 8.0"
+  }, {
+    "id" : "loan-types",
+    "version" : "2.2"
+  } ],
+  "optional" : [ ],
+  "permissionSets" : [ {
+    "permissionName" : "module.courses.enabled",
+    "displayName" : "UI: courses module is enabled",
+    "visible" : true
+  }, {
+    "permissionName" : "settings.courses.enabled",
+    "displayName" : "Settings (courses): display list of settings pages",
+    "subPermissions" : [ "settings.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "course-reserves.all",
+    "displayName" : "Courses: All Permissions",
+    "description" : "The highest level is CRUD Course Reserves which allows the user to maintain courses, items, instructors, cross listed courses, etc.",
+    "subPermissions" : [ "module.courses.enabled", "course-reserves.maintain-settings", "course-reserves-storage.all", "inventory-storage.locations.collection.get", "inventory.items.collection.get", "inventory-storage.loan-types.collection.get", "inventory-storage.items.item.get" ],
+    "visible" : true
+  }, {
+    "permissionName" : "course-reserves.read-all",
+    "displayName" : "Courses: Read All",
+    "description" : "Allows user read only access to Courses and Reserves",
+    "subPermissions" : [ "module.courses.enabled", "course-reserves-storage.courses.read", "course-reserves-storage.courselistings.read", "course-reserves-storage.reserves.read", "course-reserves-storage.terms.read", "course-reserves-storage.course-types.read", "course-reserves-storage.departments.read", "course-reserves-storage.processing-statuses.read", "course-reserves-storage.copyright-statuses.read", "course-reserves-storage.roles.read", "inventory-storage.locations.collection.get", "inventory.items.collection.get" ],
+    "visible" : true
+  }, {
+    "permissionName" : "course-reserves.read-add-edit",
+    "displayName" : "Courses: Read, Add, edit",
+    "description" : "Allows user the ability to read, add and edit Course Records - but not to delete. (Does not include item add, edit and remove)",
+    "subPermissions" : [ "module.courses.enabled", "course-reserves-storage.courselistings.write", "course-reserves-storage.courses.write", "inventory-storage.locations.collection.get", "inventory.items.collection.get" ],
+    "visible" : true
+  }, {
+    "permissionName" : "course-reserves.maintain-items",
+    "displayName" : "Courses: Add, edit, and remove items",
+    "description" : "This permission allows a user to add and edit items to a course",
+    "subPermissions" : [ "course-reserves.read-all", "course-reserves-storage.reserves.write", "course-reserves-storage.courselistings.reserves.item.put", "course-reserves-storage.courselistings.reserves.item.post", "course-reserves-storage.courselistings.reserves.item.delete", "inventory-storage.locations.collection.get", "inventory.items.collection.get", "inventory-storage.loan-types.collection.get", "inventory-storage.items.item.get", "inventory-storage.items.item.put" ],
+    "visible" : true
+  }, {
+    "permissionName" : "course-reserves.maintain-settings",
+    "displayName" : "Settings (Courses): Can create, edit and delete Course Settings",
+    "description" : "This permission allows the user to Create, edit and delete all Course Settings",
+    "subPermissions" : [ "settings.courses.enabled", "course-reserves-storage.terms.write", "course-reserves-storage.course-types.write", "course-reserves-storage.departments.write", "course-reserves-storage.processing-statuses.write", "course-reserves-storage.copyright-statuses.write", "course-reserves-storage.roles.write" ],
+    "visible" : true
+  } ]
+}, {
+  "id" : "folio_data-export-2.0.1",
+  "name" : "Data export manager",
+  "requires" : [ {
+    "id" : "data-export",
+    "version" : "2.0"
+  } ],
+  "optional" : [ ],
+  "permissionSets" : [ {
+    "permissionName" : "module.data-export.enabled",
+    "displayName" : "UI: Data export module is enabled",
+    "subPermissions" : [ "data-export.file-definitions.item.post", "data-export.file-definitions.upload.post", "data-export.mapping-profiles.item.post", "data-export.mapping-profiles.item.get", "data-export.export.post", "data-export.mapping-profiles.collection.get", "data-export.job-executions.items.get", "data-export.job-executions.items.download.get", "data-export.job-profiles.collection.get", "data-export.job-profiles.item.post", "data-export.job-profiles.item.get" ],
+    "visible" : true
+  }, {
+    "permissionName" : "settings.data-export.enabled",
+    "displayName" : "Settings (data-export): display list of settings pages",
+    "subPermissions" : [ "settings.enabled" ],
+    "visible" : true
+  } ]
+}, {
+  "id" : "folio_data-import-2.1.4",
+  "name" : "Data Import manager",
+  "requires" : [ {
+    "id" : "data-import",
+    "version" : "3.0"
+  }, {
+    "id" : "source-manager-job-executions",
+    "version" : "1.0"
+  }, {
+    "id" : "data-import-converter-storage",
+    "version" : "1.2"
+  } ],
+  "optional" : [ ],
+  "permissionSets" : [ {
+    "permissionName" : "module.data-import.enabled",
+    "displayName" : "UI: ui-data-import module is enabled",
+    "subPermissions" : [ "metadata-provider.log.get", "metadata-provider.jobexecutions.get", "data-import.uploaddefinitions.get", "data-import.uploaddefinitions.post", "data-import.uploaddefinitions.delete", "data-import.uploaddefinitions.files.delete", "data-import.upload.file.post", "source-storage.records.get", "data-import.uploaddefinitions.files.post" ],
+    "visible" : true
+  }, {
+    "permissionName" : "settings.data-import.enabled",
+    "displayName" : "Settings (data-import): display list of settings pages",
+    "subPermissions" : [ "settings.enabled", "data-import.fileExtensions.get", "data-import.fileExtensions.post", "data-import.fileExtensions.put", "data-import.fileExtensions.delete", "data-import.fileExtensions.default", "converter-storage.profileSnapshots.get", "converter-storage.jobprofile.get", "converter-storage.jobprofile.post", "converter-storage.jobprofile.put", "converter-storage.jobprofile.delete", "converter-storage.matchprofile.get", "converter-storage.matchprofile.post", "converter-storage.matchprofile.put", "converter-storage.matchprofile.delete", "converter-storage.jobprofile.delete", "converter-storage.actionprofile.get", "converter-storage.actionprofile.post", "converter-storage.actionprofile.put", "converter-storage.actionprofile.delete", "converter-storage.mappingprofile.get", "converter-storage.mappingprofile.post", "converter-storage.mappingprofile.put", "converter-storage.mappingprofile.delete", "converter-storage.profileassociation.get" ],
+    "visible" : true
+  } ]
+}, {
+  "id" : "folio_developer-3.0.0",
+  "name" : "Developer settings",
+  "requires" : [ ],
+  "optional" : [ ],
+  "permissionSets" : [ {
+    "permissionName" : "module.developer.enabled",
+    "displayName" : "UI: Developer module is enabled"
+  }, {
+    "permissionName" : "settings.developer.enabled",
+    "displayName" : "Settings (Developer): display list of settings pages",
+    "subPermissions" : [ "settings.enabled" ]
+  }, {
+    "permissionName" : "ui-developer.settings.configuration",
+    "displayName" : "Settings (Developer): configuration",
+    "subPermissions" : [ "settings.developer.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-developer.settings.hotkeys",
+    "displayName" : "Settings (Developer): hot keys test",
+    "subPermissions" : [ "settings.developer.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-developer.settings.token",
+    "displayName" : "Settings (Developer): manage JWT authentication token",
+    "subPermissions" : [ "settings.developer.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-developer.settings.locale",
+    "displayName" : "Settings (Developer): set session locale",
+    "subPermissions" : [ "settings.developer.enabled" ],
+    "visible" : true
+  } ]
+}, {
+  "id" : "folio_eholdings-4.0.1",
+  "name" : "FOLIO UI module for eHoldings",
+  "requires" : [ {
+    "id" : "eholdings",
+    "version" : "2.0"
+  }, {
+    "id" : "tags",
+    "version" : "1.0"
+  }, {
+    "id" : "erm",
+    "version" : "1.0 2.0"
+  } ],
+  "optional" : [ ],
+  "permissionSets" : [ {
+    "permissionName" : "module.eholdings.enabled",
+    "displayName" : "UI: eHoldings module is enabled",
+    "subPermissions" : [ "kb-ebsco.all", "tags.all" ],
+    "visible" : true
+  }, {
+    "permissionName" : "settings.eholdings.enabled",
+    "displayName" : "Settings (eHoldings): display list of settings pages",
+    "subPermissions" : [ "module.eholdings.enabled", "settings.enabled" ]
+  }, {
+    "permissionName" : "ui-eholdings.settings.kb",
+    "displayName" : "Settings (eHoldings): configure EBSCO RM API credentials",
+    "subPermissions" : [ "settings.eholdings.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-eholdings.settings.root-proxy",
+    "displayName" : "Settings (eHoldings): configure root proxy setting",
+    "subPermissions" : [ "settings.eholdings.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-eholdings.package-title.select-unselect",
+    "displayName" : "eHoldings: Can select/unselect packages and titles to/from your holdings",
+    "subPermissions" : [ "module.eholdings.enabled", "kb-ebsco.packages.item.put", "kb-ebsco.resources.item.put" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-eholdings.records.edit",
+    "displayName" : "eHoldings: Can edit providers, packages, titles detail records",
+    "subPermissions" : [ "module.eholdings.enabled", "kb-ebsco.packages.item.put", "kb-ebsco.resources.item.put", "kb-ebsco.providers.item.put" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-eholdings.titles-packages.create-delete",
+    "displayName" : "eHoldings: Can create and delete custom packages and titles",
+    "subPermissions" : [ "module.eholdings.enabled", "kb-ebsco.packages.collection.post", "kb-ebsco.resources.collection.post", "kb-ebsco.titles.collection.post", "kb-ebsco.packages.item.delete", "kb-ebsco.resources.item.delete" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-eholdings.settings.access-types.view",
+    "displayName" : "Settings (eholdings): Can view access status types",
+    "subPermissions" : [ "settings.eholdings.enabled", "kb-ebsco.kb-credentials.access-types.collection.get", "kb-ebsco.kb-credentials.access-types.item.get" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-eholdings.settings.access-types.create-edit",
+    "displayName" : "Settings (eholdings): Can create, edit, and view access status types",
+    "subPermissions" : [ "settings.eholdings.enabled", "ui-eholdings.settings.access-types.view", "kb-ebsco.kb-credentials.access-types.collection.post", "kb-ebsco.kb-credentials.access-types.item.put" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-eholdings.settings.access-types.all",
+    "displayName" : "Settings (eholdings): Can create, edit, view, and delete access status types",
+    "subPermissions" : [ "settings.eholdings.enabled", "ui-eholdings.settings.access-types.view", "ui-eholdings.settings.access-types.create-edit", "kb-ebsco.kb-credentials.access-types.item.delete" ],
+    "visible" : true
+  } ]
+}, {
+  "id" : "folio_erm-usage-3.0.0",
+  "name" : "eUsage Module",
+  "requires" : [ {
+    "id" : "usage-data-providers",
+    "version" : "2.4"
+  }, {
+    "id" : "aggregator-settings",
+    "version" : "1.2"
+  }, {
+    "id" : "counter-reports",
+    "version" : "1.5"
+  } ],
+  "optional" : [ ],
+  "permissionSets" : [ {
+    "permissionName" : "module.erm-usage.enabled",
+    "displayName" : "UI: eUsage module is enabled",
+    "subPermissions" : [ "configuration.entries.collection.get", "configuration.entries.item.get", "tags.collection.get", "note.types.collection.get" ],
+    "visible" : true
+  }, {
+    "permissionName" : "settings.erm-usage.enabled",
+    "displayName" : "Settings (eUsage): Can view and edit settings",
+    "subPermissions" : [ "module.erm-usage.enabled", "settings.enabled", "aggregatorsettings.collection.get", "aggregatorsettings.item.get", "aggregatorsettings.item.post", "aggregatorsettings.item.put", "aggregatorsettings.item.delete", "configuration.entries.collection.get", "configuration.entries.item.get", "configuration.entries.item.post" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-erm-usage.all",
+    "displayName" : "eUsage: All permissions",
+    "description" : "All permissions of eUsage module",
+    "subPermissions" : [ "module.erm-usage.enabled", "eusage.all" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-erm-usage.view",
+    "displayName" : "eUsage: Can view usage data providers and COUNTER reports",
+    "description" : "Can view usage data providers and COUNTER reports",
+    "subPermissions" : [ "module.erm-usage.enabled", "usagedataproviders.collection.get", "usagedataproviders.item.get", "counterreports.collection.get", "counterreports.item.get", "aggregatorsettings.collection.get", "aggregatorsettings.item.get" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-erm-usage.view-create",
+    "displayName" : "eUsage: Can view and create usage data providers and COUNTER reports",
+    "description" : "Can view and create usage data providers and COUNTER reports",
+    "subPermissions" : [ "module.erm-usage.enabled", "usagedataproviders.collection.get", "usagedataproviders.item.get", "usagedataproviders.item.post", "counterreports.collection.get", "counterreports.item.get", "counterreports.item.post", "aggregatorsettings.collection.get", "aggregatorsettings.item.get" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-erm-usage.view-edit",
+    "displayName" : "eUsage: Can view and edit usage data providers and COUNTER reports",
+    "description" : "Can view and edit usage data providers and COUNTER reports",
+    "subPermissions" : [ "module.erm-usage.enabled", "usagedataproviders.collection.get", "usagedataproviders.item.get", "usagedataproviders.item.put", "counterreports.collection.get", "counterreports.item.get", "counterreports.item.put", "aggregatorsettings.collection.get", "aggregatorsettings.item.get" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-erm-usage.view-create-edit",
+    "displayName" : "eUsage: Can view, create and edit usage data providers and COUNTER reports",
+    "description" : "Can view, create and edit usage data providers and COUNTER reports",
+    "subPermissions" : [ "module.erm-usage.enabled", "usagedataproviders.collection.get", "usagedataproviders.item.get", "usagedataproviders.item.post", "usagedataproviders.item.put", "counterreports.collection.get", "counterreports.item.get", "counterreports.item.post", "counterreports.item.put", "aggregatorsettings.collection.get", "aggregatorsettings.item.get" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-erm-usage.view-create-edit-delete",
+    "displayName" : "eUsage: Can view, create, edit and delete usage data providers and COUNTER reports",
+    "description" : "Can view, create, edit and delete usage data providers and COUNTER reports",
+    "subPermissions" : [ "module.erm-usage.enabled", "usagedataproviders.collection.get", "usagedataproviders.item.get", "usagedataproviders.item.post", "usagedataproviders.item.put", "usagedataproviders.item.delete", "counterreports.collection.get", "counterreports.item.get", "counterreports.item.post", "counterreports.item.put", "counterreports.item.delete", "aggregatorsettings.collection.get", "aggregatorsettings.item.get" ],
+    "visible" : true
+  } ]
+}, {
+  "id" : "folio_finance-2.1.2",
+  "name" : "Description for ui-finance",
+  "requires" : [ {
+    "id" : "acquisitions-units",
+    "version" : "1.1"
+  }, {
+    "id" : "configuration",
+    "version" : "2.0"
+  }, {
+    "id" : "finance.budgets",
+    "version" : "1.0"
+  }, {
+    "id" : "finance.fiscal-years",
+    "version" : "1.0"
+  }, {
+    "id" : "finance.fund-types",
+    "version" : "1.0"
+  }, {
+    "id" : "finance.funds",
+    "version" : "1.0"
+  }, {
+    "id" : "finance.group-fiscal-year-summaries",
+    "version" : "1.0"
+  }, {
+    "id" : "finance.group-fund-fiscal-years",
+    "version" : "1.0"
+  }, {
+    "id" : "finance.groups",
+    "version" : "1.0"
+  }, {
+    "id" : "finance.ledgers",
+    "version" : "1.0"
+  }, {
+    "id" : "finance.order-transaction-summaries",
+    "version" : "1.0"
+  }, {
+    "id" : "finance.transactions",
+    "version" : "2.0 3.0"
+  }, {
+    "id" : "tags",
+    "version" : "1.0"
+  }, {
+    "id" : "users",
+    "version" : "15.0"
+  } ],
+  "optional" : [ ],
+  "permissionSets" : [ {
+    "permissionName" : "module.finance.enabled",
+    "displayName" : "UI: Finance module is enabled",
+    "visible" : true
+  }, {
+    "permissionName" : "settings.finance.enabled",
+    "displayName" : "Settings (Finance): Can view and edit settings",
+    "subPermissions" : [ "settings.enabled", "finance.fund-types.all" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-finance.third-party-services",
+    "displayName" : "Finance: Permissions required to call services apart from mod-finance",
+    "description" : "",
+    "subPermissions" : [ "acquisitions-units.memberships.collection.get", "acquisitions-units.units.collection.get", "configuration.entries.collection.get", "tags.collection.get", "users.collection.get" ]
+  }, {
+    "permissionName" : "ui-finance.view",
+    "displayName" : "Finance: View groups, ledgers, funds, budgets and fiscal years",
+    "description" : "",
+    "subPermissions" : [ "finance.budgets.collection.get", "finance.budgets.item.get", "finance.fiscal-years.collection.get", "finance.fiscal-years.item.get", "finance.fund-types.collection.get", "finance.fund-types.item.get", "finance.funds.collection.get", "finance.funds.item.get", "finance.group-fiscal-year-summaries.collection.get", "finance.group-fund-fiscal-years.collection.get", "finance.groups.collection.get", "finance.groups.item.get", "finance.ledgers.collection.get", "finance.ledgers.current-fiscal-year.item.get", "finance.ledgers.item.get", "finance.transactions.collection.get", "finance.transactions.item.get", "ui-finance.third-party-services" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-finance.all",
+    "displayName" : "Finance: all permissions for View and Edit ledgers, funds, budgets and fiscal years",
+    "description" : "",
+    "subPermissions" : [ "finance.budgets.all", "finance.encumbrances.item.post", "finance.exchange-rate.item.get", "finance.fiscal-years.all", "finance.fund-types.all", "finance.funds.all", "finance.group-fiscal-year-summaries.collection.get", "finance.group-fund-fiscal-years.all", "finance.groups.all", "finance.invoice-transaction-summaries.item.post", "finance.ledgers.all", "finance.order-transaction-summaries.item.post", "finance.order-transaction-summaries.item.put", "finance.transactions.collection.get", "finance.transactions.item.get", "ui-finance.third-party-services" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-finance.acq.unit.assignment.assign",
+    "displayName" : "Finance: Assign acquisition units to new record",
+    "description" : "",
+    "subPermissions" : [ "finance.acquisitions-units-assignments.assign" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-finance.acq.unit.assignment.manage",
+    "displayName" : "Finance: Manage acquisition units",
+    "description" : "",
+    "subPermissions" : [ "finance.acquisitions-units-assignments.manage" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-finance.allocations.create",
+    "displayName" : "Finance: Create allocations",
+    "description" : "",
+    "subPermissions" : [ "finance.allocations.item.post" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-finance.transfers.create",
+    "displayName" : "Finance: Create transfers",
+    "description" : "",
+    "subPermissions" : [ "finance.transfers.item.post" ],
+    "visible" : true
+  } ]
+}, {
+  "id" : "folio_inventory-4.0.3",
+  "name" : "Inventory manager",
+  "requires" : [ {
+    "id" : "inventory",
+    "version" : "10.0"
+  }, {
+    "id" : "source-storage-records",
+    "version" : "2.0"
+  }, {
+    "id" : "instance-storage",
+    "version" : "7.0"
+  }, {
+    "id" : "holdings-storage",
+    "version" : "3.0 4.0"
+  }, {
+    "id" : "item-storage",
+    "version" : "8.0"
+  }, {
+    "id" : "loan-types",
+    "version" : "2.0"
+  }, {
+    "id" : "material-types",
+    "version" : "2.0"
+  }, {
+    "id" : "item-note-types",
+    "version" : "1.0"
+  }, {
+    "id" : "locations",
+    "version" : "3.0"
+  }, {
+    "id" : "identifier-types",
+    "version" : "1.1"
+  }, {
+    "id" : "contributor-types",
+    "version" : "2.0"
+  }, {
+    "id" : "contributor-name-types",
+    "version" : "1.2"
+  }, {
+    "id" : "instance-types",
+    "version" : "2.0"
+  }, {
+    "id" : "nature-of-content-terms",
+    "version" : "1.0"
+  }, {
+    "id" : "instance-formats",
+    "version" : "2.0"
+  }, {
+    "id" : "classification-types",
+    "version" : "1.1"
+  }, {
+    "id" : "statistical-code-types",
+    "version" : "1.0"
+  }, {
+    "id" : "statistical-codes",
+    "version" : "1.0"
+  }, {
+    "id" : "modes-of-issuance",
+    "version" : "1.0"
+  }, {
+    "id" : "instance-statuses",
+    "version" : "1.0"
+  }, {
+    "id" : "instance-relationship-types",
+    "version" : "1.0"
+  }, {
+    "id" : "instance-note-types",
+    "version" : "1.0"
+  }, {
+    "id" : "alternative-title-types",
+    "version" : "1.0"
+  }, {
+    "id" : "holdings-types",
+    "version" : "1.0"
+  }, {
+    "id" : "call-number-types",
+    "version" : "1.0"
+  }, {
+    "id" : "electronic-access-relationships",
+    "version" : "1.0"
+  }, {
+    "id" : "ill-policies",
+    "version" : "1.0"
+  }, {
+    "id" : "holdings-note-types",
+    "version" : "1.0"
+  }, {
+    "id" : "users",
+    "version" : "15.0"
+  }, {
+    "id" : "location-units",
+    "version" : "2.0"
+  }, {
+    "id" : "circulation",
+    "version" : "9.0"
+  } ],
+  "optional" : [ ],
+  "permissionSets" : [ {
+    "permissionName" : "module.inventory.enabled",
+    "displayName" : "Inventory: Module is enabled"
+  }, {
+    "permissionName" : "ui-inventory.all-permissions.TEMPORARY",
+    "displayName" : "Inventory: All permissions",
+    "description" : "Some subperms to support enabling/using the Inventory app",
+    "subPermissions" : [ "ui-inventory.instance.view", "ui-inventory.instance.create", "ui-inventory.holdings.create", "ui-inventory.item.create", "ui-inventory.instance.edit", "ui-inventory.item.edit", "ui-inventory.holdings.edit", "ui-inventory.item.markasmissing", "ui-inventory.item.delete", "ui-inventory.holdings.delete", "ui-inventory.instance.view-staff-suppressed-records" ],
+    "visible" : true
+  }, {
+    "permissionName" : "settings.inventory.enabled",
+    "displayName" : "Settings (Inventory): Module is enabled.",
+    "subPermissions" : [ "settings.enabled" ],
+    "visible" : false
+  }, {
+    "permissionName" : "ui-inventory.settings.materialtypes",
+    "displayName" : "Settings (Inventory): Create, edit, delete material types",
+    "subPermissions" : [ "inventory-storage.material-types.collection.get", "inventory-storage.material-types.item.delete", "inventory-storage.material-types.item.get", "inventory-storage.material-types.item.post", "inventory-storage.material-types.item.put", "settings.inventory.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-inventory.settings.loantypes",
+    "displayName" : "Settings (Inventory): Create, edit, delete loan types",
+    "subPermissions" : [ "inventory-storage.loan-types.collection.get", "inventory-storage.loan-types.item.delete", "inventory-storage.loan-types.item.get", "inventory-storage.loan-types.item.post", "inventory-storage.loan-types.item.put", "settings.inventory.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-inventory.settings.statistical-code-types",
+    "displayName" : "Settings (Inventory): Create, edit, delete statistical code types",
+    "subPermissions" : [ "inventory-storage.statistical-code-types.collection.get", "inventory-storage.statistical-code-types.item.delete", "inventory-storage.statistical-code-types.item.get", "inventory-storage.statistical-code-types.item.post", "inventory-storage.statistical-code-types.item.put", "settings.inventory.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-inventory.settings.instance-formats",
+    "displayName" : "Settings (Inventory): Create, edit, delete formats",
+    "subPermissions" : [ "inventory-storage.instance-formats.collection.get", "inventory-storage.instance-formats.item.delete", "inventory-storage.instance-formats.item.get", "inventory-storage.instance-formats.item.post", "inventory-storage.instance-formats.item.put", "settings.inventory.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-inventory.settings.electronic-access-relationships",
+    "displayName" : "Settings (Inventory): Create, edit, delete URL relationships",
+    "subPermissions" : [ "inventory-storage.electronic-access-relationships.collection.get", "inventory-storage.electronic-access-relationships.item.delete", "inventory-storage.electronic-access-relationships.item.get", "inventory-storage.electronic-access-relationships.item.post", "inventory-storage.electronic-access-relationships.item.put", "settings.inventory.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-inventory.settings.holdings-types",
+    "displayName" : "Settings (Inventory): Create, edit, delete holdings types",
+    "subPermissions" : [ "inventory-storage.holdings-types.collection.get", "inventory-storage.holdings-types.item.delete", "inventory-storage.holdings-types.item.get", "inventory-storage.holdings-types.item.post", "inventory-storage.holdings-types.item.put", "settings.inventory.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-inventory.settings.classification-types",
+    "displayName" : "Settings (Inventory): Create, edit, delete classification identifier types",
+    "subPermissions" : [ "inventory-storage.classification-types.collection.get", "inventory-storage.classification-types.item.delete", "inventory-storage.classification-types.item.get", "inventory-storage.classification-types.item.post", "inventory-storage.classification-types.item.put", "settings.inventory.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-inventory.settings.identifier-types",
+    "displayName" : "Settings (Inventory): Create, edit, delete resource identifier types",
+    "subPermissions" : [ "inventory-storage.identifier-types.collection.get", "inventory-storage.identifier-types.item.delete", "inventory-storage.identifier-types.item.get", "inventory-storage.identifier-types.item.post", "inventory-storage.identifier-types.item.put", "settings.inventory.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-inventory.settings.instance-statuses",
+    "displayName" : "Settings (Inventory): Create, edit, delete instance status types",
+    "subPermissions" : [ "inventory-storage.instance-statuses.collection.get", "inventory-storage.instance-statuses.item.delete", "inventory-storage.instance-statuses.item.get", "inventory-storage.instance-statuses.item.post", "inventory-storage.instance-statuses.item.put", "settings.inventory.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-inventory.settings.statistical-codes",
+    "displayName" : "Settings (Inventory): Create, edit, delete statistical codes",
+    "subPermissions" : [ "inventory-storage.statistical-codes.collection.get", "inventory-storage.statistical-codes.item.delete", "inventory-storage.statistical-codes.item.get", "inventory-storage.statistical-codes.item.post", "inventory-storage.statistical-codes.item.put", "settings.inventory.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-inventory.settings.alternative-title-types",
+    "displayName" : "Settings (Inventory): Create, edit, delete alternative title types",
+    "subPermissions" : [ "inventory-storage.alternative-title-types.collection.get", "inventory-storage.alternative-title-types.item.delete", "inventory-storage.alternative-title-types.item.get", "inventory-storage.alternative-title-types.item.post", "inventory-storage.alternative-title-types.item.put", "settings.inventory.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-inventory.settings.instance-types",
+    "displayName" : "Settings (Inventory): Create, edit, delete locally defined resource types",
+    "subPermissions" : [ "inventory-storage.instance-types.collection.get", "inventory-storage.instance-types.item.delete", "inventory-storage.instance-types.item.get", "inventory-storage.instance-types.item.post", "inventory-storage.instance-types.item.put", "settings.inventory.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-inventory.settings.nature-of-content-terms",
+    "displayName" : "Settings (Inventory): Create, edit, delete nature of content",
+    "subPermissions" : [ "inventory-storage.nature-of-content-terms.collection.get", "inventory-storage.nature-of-content-terms.item.delete", "inventory-storage.nature-of-content-terms.item.get", "inventory-storage.nature-of-content-terms.item.post", "inventory-storage.nature-of-content-terms.item.put", "settings.inventory.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-inventory.settings.modes-of-issuance",
+    "displayName" : "Settings (Inventory): Create, edit, delete locally defined modes of issuance",
+    "subPermissions" : [ "inventory-storage.modes-of-issuance.collection.get", "inventory-storage.modes-of-issuance.item.delete", "inventory-storage.modes-of-issuance.item.get", "inventory-storage.modes-of-issuance.item.post", "inventory-storage.modes-of-issuance.item.put", "settings.inventory.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-inventory.settings.instance-note-types",
+    "displayName" : "Settings (Inventory): Create, edit, delete instance note types",
+    "subPermissions" : [ "inventory-storage.instance-note-types.collection.get", "inventory-storage.instance-note-types.item.delete", "inventory-storage.instance-note-types.item.get", "inventory-storage.instance-note-types.item.post", "inventory-storage.instance-note-types.item.put", "settings.inventory.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-inventory.settings.ill-policies",
+    "displayName" : "Settings (Inventory): Create, edit, delete ILL policies",
+    "subPermissions" : [ "inventory-storage.ill-policies.collection.get", "inventory-storage.ill-policies.item.delete", "inventory-storage.ill-policies.item.get", "inventory-storage.ill-policies.item.post", "inventory-storage.ill-policies.item.put", "settings.inventory.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-inventory.settings.contributor-types",
+    "displayName" : "Settings (Inventory): Create, edit, delete contributor types",
+    "subPermissions" : [ "inventory-storage.contributor-types.collection.get", "inventory-storage.contributor-types.item.delete", "inventory-storage.contributor-types.item.get", "inventory-storage.contributor-types.item.post", "inventory-storage.contributor-types.item.put", "settings.inventory.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-inventory.settings.call-number-types",
+    "displayName" : "Settings (Inventory): Create, edit, delete call number types",
+    "subPermissions" : [ "inventory-storage.call-number-types.collection.get", "inventory-storage.call-number-types.item.delete", "inventory-storage.call-number-types.item.get", "inventory-storage.call-number-types.item.post", "inventory-storage.call-number-types.item.put", "settings.inventory.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-inventory.settings.holdings-note-types",
+    "displayName" : "Settings (Inventory): Create, edit, delete holdings note types",
+    "subPermissions" : [ "inventory-storage.holdings-note-types.collection.get", "inventory-storage.holdings-note-types.item.delete", "inventory-storage.holdings-note-types.item.get", "inventory-storage.holdings-note-types.item.post", "inventory-storage.holdings-note-types.item.put", "settings.inventory.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-inventory.settings.item-note-types",
+    "displayName" : "Settings (Inventory): Create, edit, delete item note types",
+    "subPermissions" : [ "inventory-storage.item-note-types.collection.get", "inventory-storage.item-note-types.item.delete", "inventory-storage.item-note-types.item.get", "inventory-storage.item-note-types.item.post", "inventory-storage.item-note-types.item.put", "settings.inventory.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-inventory.settings.hrid-handling",
+    "displayName" : "Settings (Inventory): Create, edit and delete HRID handling",
+    "subPermissions" : [ "configuration.entries.collection.get", "inventory-storage.hrid-settings.item.get", "inventory-storage.hrid-settings.item.put", "settings.inventory.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-inventory.instance.view",
+    "displayName" : "Inventory: View instances, holdings, and items",
+    "subPermissions" : [ "module.inventory.enabled", "users.collection.get", "source-storage.records.get", "circulation.loans.collection.get", "circulation.loans.collection.get", "circulation.requests.collection.get", "configuration.entries.collection.get", "inventory.config.instances.blocked-fields.get", "inventory.instances.collection.get", "inventory.instances.item.get", "inventory.items.collection.get", "inventory.items.item.get", "inventory-storage.items.item.get", "inventory-storage.items.collection.get", "inventory-storage.identifier-types.collection.get", "inventory-storage.contributor-types.collection.get", "inventory-storage.contributor-name-types.collection.get", "inventory-storage.call-number-types.collection.get", "inventory-storage.item-note-types.collection.get", "inventory-storage.item-damaged-statuses.collection.get", "inventory-storage.nature-of-content-terms.collection.get", "inventory-storage.classification-types.collection.get", "inventory-storage.alternative-title-types.collection.get", "inventory-storage.locations.collection.get", "inventory-storage.locations.item.get", "inventory-storage.location-units.institutions.collection.get", "inventory-storage.location-units.institutions.item.get", "inventory-storage.location-units.campuses.collection.get", "inventory-storage.location-units.campuses.item.get", "inventory-storage.location-units.libraries.collection.get", "inventory-storage.location-units.libraries.item.get", "inventory-storage.modes-of-issuance.collection.get", "inventory-storage.instance-formats.collection.get", "inventory-storage.instance-statuses.collection.get", "inventory-storage.instance-types.collection.get", "inventory-storage.instance-relationship-types.collection.get", "inventory-storage.instance-note-types.collection.get", "inventory-storage.instances.item.get", "inventory-storage.electronic-access-relationships.collection.get", "inventory-storage.statistical-code-types.collection.get", "inventory-storage.statistical-codes.collection.get", "inventory-storage.ill-policies.collection.get", "inventory-storage.holdings-note-types.collection.get", "inventory-storage.holdings-types.collection.get", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.material-types.collection.get", "inventory-storage.loan-types.collection.get", "inventory-storage.service-points.get", "inventory-storage.service-points.collection.get", "inventory-storage.hrid-settings.item.get", "inventory-storage.instance-bulk.ids.get" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-inventory.instance.create",
+    "displayName" : "Inventory: View, create instances",
+    "subPermissions" : [ "ui-inventory.instance.view", "inventory.instances.item.post", "inventory-storage.instances.item.post" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-inventory.instance.edit",
+    "displayName" : "Inventory: View, create, edit instances",
+    "subPermissions" : [ "ui-inventory.instance.create", "inventory.instances.item.put", "inventory-storage.instances.item.put" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-inventory.item.create",
+    "displayName" : "Inventory: View, create items",
+    "subPermissions" : [ "ui-inventory.instance.view", "inventory.items.item.post", "inventory.instances.item.put", "inventory-storage.instances.item.put" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-inventory.item.edit",
+    "displayName" : "Inventory: View, create, edit items",
+    "subPermissions" : [ "ui-inventory.item.create", "inventory.items.item.put" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-inventory.item.markasmissing",
+    "displayName" : "Inventory: View, create, edit, mark missing items",
+    "subPermissions" : [ "ui-inventory.item.edit" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-inventory.item.delete",
+    "displayName" : "Inventory: View, create, edit, delete items",
+    "subPermissions" : [ "ui-inventory.item.edit", "inventory.items.item.delete" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-inventory.holdings.create",
+    "displayName" : "Inventory: View, create holdings",
+    "subPermissions" : [ "ui-inventory.instance.view", "inventory-storage.holdings.item.post" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-inventory.holdings.edit",
+    "displayName" : "Inventory: View, create, edit holdings",
+    "subPermissions" : [ "ui-inventory.holdings.create", "inventory-storage.holdings.item.put" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-inventory.holdings.delete",
+    "displayName" : "Inventory: View, create, edit, delete holdings",
+    "subPermissions" : [ "ui-inventory.holdings.edit", "inventory-storage.holdings.item.delete" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-inventory.instance.view-staff-suppressed-records",
+    "displayName" : "Inventory: View instance records being suppressed for staff",
+    "subPermissions" : [ "ui-inventory.instance.view" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-inventory.settings.list.view",
+    "displayName" : "Settings (Inventory): Display list of settings pages",
+    "subPermissions" : [ "settings.inventory.enabled", "users.collection.get", "source-storage.records.get", "inventory-storage.material-types.collection.get", "inventory-storage.material-types.item.get", "inventory-storage.loan-types.collection.get", "inventory-storage.loan-types.item.get", "inventory-storage.statistical-code-types.collection.get", "inventory-storage.statistical-code-types.item.get", "inventory-storage.instance-formats.collection.get", "inventory-storage.instance-formats.item.get", "inventory-storage.electronic-access-relationships.collection.get", "inventory-storage.electronic-access-relationships.item.get", "inventory-storage.holdings-types.collection.get", "inventory-storage.holdings-types.item.get", "inventory-storage.classification-types.collection.get", "inventory-storage.classification-types.item.get", "inventory-storage.identifier-types.collection.get", "inventory-storage.identifier-types.item.get", "inventory-storage.instance-statuses.collection.get", "inventory-storage.instance-statuses.item.get", "inventory-storage.statistical-codes.collection.get", "inventory-storage.statistical-codes.item.get", "inventory-storage.alternative-title-types.collection.get", "inventory-storage.alternative-title-types.item.get", "inventory-storage.instance-types.collection.get", "inventory-storage.instance-types.item.get", "inventory-storage.nature-of-content-terms.collection.get", "inventory-storage.nature-of-content-terms.item.get", "inventory-storage.modes-of-issuance.collection.get", "inventory-storage.modes-of-issuance.item.get", "inventory-storage.instance-note-types.collection.get", "inventory-storage.instance-note-types.item.get", "inventory-storage.ill-policies.collection.get", "inventory-storage.ill-policies.item.get", "inventory-storage.contributor-types.collection.get", "inventory-storage.contributor-types.item.get", "inventory-storage.call-number-types.collection.get", "inventory-storage.call-number-types.item.get", "inventory-storage.holdings-note-types.collection.get", "inventory-storage.holdings-note-types.item.get", "inventory-storage.item-note-types.collection.get", "inventory-storage.item-note-types.item.get", "inventory-storage.hrid-settings.item.get" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-inventory.instance.view-staff-suppressed-records",
+    "displayName" : "Inventory: View instance records being suppressed for staff",
+    "subPermissions" : [ "ui-inventory.instance.view" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-inventory.items.mark-items-withdrawn",
+    "displayName" : "Inventory: Mark items withdrawn",
+    "subPermissions" : [ "inventory.items.item.mark-withdrawn.post" ],
+    "visible" : true
+  } ]
+}, {
+  "id" : "folio_invoice-2.1.3",
+  "name" : "Invoice",
+  "requires" : [ {
+    "id" : "acquisitions-units",
+    "version" : "1.1"
+  }, {
+    "id" : "batch-group",
+    "version" : "1.0"
+  }, {
+    "id" : "batch-voucher.batch-voucher-exports",
+    "version" : "1.0"
+  }, {
+    "id" : "batch-voucher.export-configurations",
+    "version" : "1.0"
+  }, {
+    "id" : "configuration",
+    "version" : "2.0"
+  }, {
+    "id" : "finance.funds",
+    "version" : "1.0"
+  }, {
+    "id" : "contributor-name-types",
+    "version" : "1.2"
+  }, {
+    "id" : "identifier-types",
+    "version" : "1.2"
+  }, {
+    "id" : "invoice",
+    "version" : "5.0"
+  }, {
+    "id" : "order-lines",
+    "version" : "1.0"
+  }, {
+    "id" : "organizations.organizations",
+    "version" : "1.0"
+  }, {
+    "id" : "tags",
+    "version" : "1.0"
+  }, {
+    "id" : "users",
+    "version" : "15.1"
+  }, {
+    "id" : "voucher-number",
+    "version" : "1.0"
+  }, {
+    "id" : "voucher",
+    "version" : "2.1"
+  } ],
+  "optional" : [ ],
+  "permissionSets" : [ {
+    "permissionName" : "module.invoice.enabled",
+    "displayName" : "UI: invoice module is enabled",
+    "visible" : true
+  }, {
+    "permissionName" : "settings.invoice.enabled",
+    "displayName" : "Settings (Invoice): Can view and edit settings",
+    "subPermissions" : [ "batch-groups.all", "batch-voucher.batch-voucher-exports.collection.get", "batch-voucher.export-configurations.all", "configuration.all", "settings.enabled", "ui-invoice.third-party-services" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-invoice.third-party-services",
+    "displayName" : "Invoice: Permissions required to call services apart from mod-invoice",
+    "description" : "",
+    "subPermissions" : [ "acquisitions-units.memberships.collection.get", "acquisitions-units.units.collection.get", "configuration.entries.collection.get", "finance.funds.collection.get", "finance.transactions.collection.get", "inventory-storage.contributor-name-types.collection.get", "inventory-storage.identifier-types.collection.get", "orders.po-lines.collection.get", "orders.po-lines.item.get", "organizations.organizations.collection.get", "organizations.organizations.item.get", "tags.collection.get", "tags.item.post", "users.collection.get", "users.item.get" ]
+  }, {
+    "permissionName" : "ui-invoice.all",
+    "displayName" : "Invoice: all permissions for Create, View, Edit and Delete invoice",
+    "description" : "",
+    "subPermissions" : [ "ui-invoice.third-party-services", "invoice.all" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-invoice.approve",
+    "displayName" : "Invoice: Approve invoice",
+    "description" : "",
+    "subPermissions" : [ "invoice.item.approve" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-invoice.pay",
+    "displayName" : "Invoice: Pay invoice",
+    "description" : "",
+    "subPermissions" : [ "invoice.item.pay" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-invoice.acq.unit.assignment.assign",
+    "displayName" : "Invoice: Assign acquisition units to new invoice",
+    "description" : "",
+    "subPermissions" : [ "invoice.acquisitions-units-assignments.assign" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-invoice.acq.unit.assignment.manage",
+    "displayName" : "Invoice: Manage acquisition units",
+    "description" : "",
+    "subPermissions" : [ "invoice.acquisitions-units-assignments.manage" ],
+    "visible" : true
+  } ]
+}, {
+  "id" : "folio_licenses-4.0.1",
+  "name" : "ERM License functionality for Stripes",
+  "requires" : [ {
+    "id" : "licenses",
+    "version" : "1.0 2.0"
+  }, {
+    "id" : "organizations-storage.interfaces",
+    "version" : "2.0"
+  }, {
+    "id" : "users",
+    "version" : "13.0 14.0 15.0"
+  } ],
+  "optional" : [ ],
+  "permissionSets" : [ {
+    "permissionName" : "module.licenses.enabled",
+    "displayName" : "UI: ui-licenses module is enabled",
+    "subPermissions" : [ "configuration.entries.collection.get", "tags.collection.get", "licenses.refdata.view", "note.types.collection.get" ]
+  }, {
+    "permissionName" : "ui-licenses.licenses.view",
+    "displayName" : "Licenses: Search & view licenses",
+    "subPermissions" : [ "module.licenses.enabled", "tags.item.post", "licenses.licenses.view", "licenses.files.view", "licenses.contacts.view", "licenses.custprops.view", "licenses.orgs.view" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-licenses.licenses.edit",
+    "displayName" : "Licenses: Edit licenses",
+    "subPermissions" : [ "ui-licenses.licenses.view", "licenses.licenses.edit", "licenses.files.edit" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-licenses.licenses.delete",
+    "displayName" : "Licenses: Delete licenses",
+    "subPermissions" : [ "ui-licenses.licenses.view", "licenses.licenses.item.delete" ],
+    "visible" : true
+  }, {
+    "permissionName" : "settings.licenses.enabled",
+    "displayName" : "Settings (Licenses): display list of settings pages",
+    "subPermissions" : [ "settings.enabled" ]
+  }, {
+    "permissionName" : "ui-licenses.picklists.manage",
+    "displayName" : "Settings (Licenses): Manage pick lists and values",
+    "subPermissions" : [ "settings.licenses.enabled", "licenses.refdata.manage" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-licenses.terms.manage",
+    "displayName" : "Settings (Licenses): Manage license terms",
+    "subPermissions" : [ "settings.licenses.enabled", "licenses.custprops.manage" ],
+    "visible" : true
+  } ]
+}, {
+  "id" : "folio_local-kb-admin-2.0.0",
+  "name" : "ERM KB Administration for FOLIO with Stripes",
+  "requires" : [ {
+    "id" : "erm",
+    "version" : "1.0 2.0"
+  } ],
+  "optional" : [ ],
+  "permissionSets" : [ {
+    "permissionName" : "module.local-kb-admin.enabled",
+    "displayName" : "UI: ui-local-kb-admin module is enabled"
+  }, {
+    "permissionName" : "ui-local-kb-admin.jobs.view",
+    "displayName" : "Local KB admin: View jobs",
+    "subPermissions" : [ "module.local-kb-admin.enabled", "erm.jobs.view", "erm.refdata.view" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-local-kb-admin.jobs.edit",
+    "displayName" : "Local KB admin: Create jobs",
+    "subPermissions" : [ "ui-local-kb-admin.jobs.view", "erm.jobs.edit" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-local-kb-admin.jobs.delete",
+    "displayName" : "Local KB admin: Delete jobs",
+    "subPermissions" : [ "ui-local-kb-admin.jobs.view", "erm.jobs.item.delete" ],
+    "visible" : true
+  }, {
+    "permissionName" : "settings.local-kb-admin.enabled",
+    "displayName" : "Settings (Local KB admin): display list of settings pages",
+    "subPermissions" : [ "settings.enabled" ]
+  }, {
+    "permissionName" : "ui-local-kb-admin.kbs.manage",
+    "displayName" : "Local KB admin: Manage remote KB configuration",
+    "subPermissions" : [ "settings.local-kb-admin.enabled", "erm.kbs.manage", "settings.enabled" ],
+    "visible" : true
+  } ]
+}, {
+  "id" : "folio_myprofile-3.0.0",
+  "name" : "My profile",
+  "requires" : [ ],
+  "optional" : [ ],
+  "permissionSets" : [ {
+    "permissionName" : "module.myprofile.enabled",
+    "displayName" : "UI: My-profile module is enabled"
+  }, {
+    "permissionName" : "settings.myprofile.enabled",
+    "displayName" : "Settings (My profile): display list of settings pages",
+    "subPermissions" : [ "settings.enabled" ]
+  }, {
+    "permissionName" : "ui-myprofile.settings.change-password",
+    "displayName" : "Settings (My profile): Can change your local password",
+    "description" : "Some subperms can be deleted later when submodules use modern permission names",
+    "subPermissions" : [ "settings.myprofile.enabled", "validation.rules.collection.get", "users.collection.get", "users-bl.item.get", "users.item.get", "login.item.get" ],
+    "visible" : true
+  } ]
+}, {
+  "id" : "folio_notes-3.0.0",
+  "name" : "Note types manager",
+  "requires" : [ {
+    "id" : "notes",
+    "version" : "1.0"
+  } ],
+  "optional" : [ ],
+  "permissionSets" : [ {
+    "permissionName" : "module.notes.enabled",
+    "displayName" : "UI: ui-notes module is enabled",
+    "visible" : true
+  }, {
+    "permissionName" : "settings.notes.enabled",
+    "displayName" : "Settings (notes): display list of settings pages",
+    "subPermissions" : [ "settings.enabled", "note.types.allops" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-notes.item.view",
+    "displayName" : "Notes: Can view a note",
+    "subPermissions" : [ "note.types.collection.get", "notes.item.get", "notes.collection.get", "notes.collection.get.by.status", "notes.domain.all", "module.notes.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-notes.item.create",
+    "displayName" : "Notes: Can create a note",
+    "subPermissions" : [ "notes.item.post", "notes.domain.all", "ui-notes.item.view" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-notes.item.edit",
+    "displayName" : "Notes: Can edit a note",
+    "subPermissions" : [ "notes.item.put", "notes.domain.all", "ui-notes.item.view" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-notes.item.delete",
+    "displayName" : "Notes: Can delete a note",
+    "subPermissions" : [ "notes.item.delete", "notes.domain.all", "ui-notes.item.view" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-notes.item.assign-unassign",
+    "displayName" : "Notes: Can assign and unassign a note",
+    "subPermissions" : [ "note.links.collection.put", "ui-notes.item.view" ],
+    "visible" : true
+  } ]
+}, {
+  "id" : "folio_oai-pmh-1.2.0",
+  "name" : "OAI-PMH manager",
+  "requires" : [ ],
+  "optional" : [ ],
+  "permissionSets" : [ {
+    "permissionName" : "settings.oai-pmh.enabled",
+    "displayName" : "Settings (oai-pmh): display list of settings pages",
+    "subPermissions" : [ "settings.enabled" ],
+    "visible" : false
+  }, {
+    "permissionName" : "ui-oai-pmh.view",
+    "displayName" : "Settings (OAI-PMH): Display list of settings pages",
+    "subPermissions" : [ "settings.oai-pmh.enabled", "configuration.entries.collection.get" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-oai-pmh.edit",
+    "displayName" : "Settings (OAI-PMH): Can view and edit settings",
+    "subPermissions" : [ "ui-oai-pmh.view", "configuration.entries.item.put" ],
+    "visible" : true
+  } ]
+}, {
+  "id" : "folio_orders-2.1.1",
+  "name" : "Description for orders",
+  "requires" : [ {
+    "id" : "acquisitions-units",
+    "version" : "1.1"
+  }, {
+    "id" : "configuration.prefixes",
+    "version" : "1.0"
+  }, {
+    "id" : "configuration.reasons-for-closure",
+    "version" : "1.0"
+  }, {
+    "id" : "configuration.suffixes",
+    "version" : "1.0"
+  }, {
+    "id" : "configuration",
+    "version" : "2.0"
+  }, {
+    "id" : "contributor-name-types",
+    "version" : "1.2"
+  }, {
+    "id" : "finance.funds",
+    "version" : "1.0"
+  }, {
+    "id" : "identifier-types",
+    "version" : "1.2"
+  }, {
+    "id" : "instance-statuses",
+    "version" : "1.0"
+  }, {
+    "id" : "instance-types",
+    "version" : "2.0"
+  }, {
+    "id" : "invoice",
+    "version" : "5.0"
+  }, {
+    "id" : "loan-types",
+    "version" : "2.2"
+  }, {
+    "id" : "location-units",
+    "version" : "2.0"
+  }, {
+    "id" : "locations",
+    "version" : "3.0"
+  }, {
+    "id" : "material-types",
+    "version" : "2.2"
+  }, {
+    "id" : "order-lines",
+    "version" : "1.0"
+  }, {
+    "id" : "orders-storage.pieces",
+    "version" : "4.0"
+  }, {
+    "id" : "orders",
+    "version" : "10.0"
+  }, {
+    "id" : "organizations.organizations",
+    "version" : "1.0"
+  }, {
+    "id" : "pieces",
+    "version" : "2.0"
+  }, {
+    "id" : "po-number",
+    "version" : "1.0"
+  }, {
+    "id" : "receiving",
+    "version" : "1.0"
+  }, {
+    "id" : "tags",
+    "version" : "1.0"
+  }, {
+    "id" : "users",
+    "version" : "15.0"
+  } ],
+  "optional" : [ ],
+  "permissionSets" : [ {
+    "permissionName" : "module.orders.enabled",
+    "displayName" : "UI: Orders module is enabled",
+    "visible" : true
+  }, {
+    "permissionName" : "ui-orders.third-party-services",
+    "displayName" : "Orders: Permissions required to call services apart from mod-orders",
+    "description" : "",
+    "subPermissions" : [ "acquisitions-units.memberships.collection.get", "acquisitions-units.units.collection.get", "configuration.entries.collection.get", "finance.funds.collection.get", "finance.transactions.collection.get", "inventory-storage.contributor-name-types.collection.get", "inventory-storage.identifier-types.collection.get", "inventory-storage.instance-statuses.collection.get", "inventory-storage.instance-types.collection.get", "inventory-storage.loan-types.collection.get", "inventory-storage.location-units.campuses.collection.get", "inventory-storage.location-units.institutions.collection.get", "inventory-storage.location-units.libraries.collection.get", "inventory-storage.locations.collection.get", "inventory-storage.locations.item.get", "inventory-storage.material-types.collection.get", "inventory.items.collection.get", "invoice.invoice-lines.collection.get", "invoice.invoices.collection.get", "isbn-utils.validator.get", "organizations.organizations.collection.get", "organizations.organizations.item.get", "tags.collection.get", "tags.item.post", "users.collection.get" ]
+  }, {
+    "permissionName" : "ui-orders.order.view",
+    "displayName" : "Orders: View orders",
+    "description" : "",
+    "subPermissions" : [ "orders-storage.order-invoice-relationships.collection.get", "orders.collection.get", "orders.configuration.prefixes.collection.get", "orders.configuration.suffixes.collection.get", "orders.configuration.reasons-for-closure.collection.get", "orders.item.get", "orders.receiving-history.collection.get", "ui-orders.third-party-services" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-orders.order.create",
+    "displayName" : "Orders: Create orders",
+    "description" : "",
+    "subPermissions" : [ "orders.configuration.prefixes.collection.get", "orders.configuration.suffixes.collection.get", "orders.configuration.reasons-for-closure.collection.get", "orders.item.post", "orders.order-templates.collection.get", "orders.order-templates.item.get", "orders.po-number.item.get", "orders.po-number.item.post", "ui-orders.third-party-services" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-orders.order.edit",
+    "displayName" : "Orders: Edit orders",
+    "description" : "",
+    "subPermissions" : [ "orders.configuration.prefixes.collection.get", "orders.configuration.suffixes.collection.get", "orders.configuration.reasons-for-closure.collection.get", "orders.order-templates.collection.get", "orders.order-templates.item.get", "orders.item.put", "orders.item.approve", "orders.po-number.item.post", "orders.po-number.item.get" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-orders.order.delete",
+    "displayName" : "Orders: Remove orders",
+    "description" : "",
+    "subPermissions" : [ "orders.item.delete" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-orders.order-lines.view",
+    "displayName" : "Orders: View order lines",
+    "description" : "",
+    "subPermissions" : [ "orders-storage.order-invoice-relationships.collection.get", "orders.po-lines.collection.get", "orders.po-lines.item.get", "orders.receiving-history.collection.get", "ui-orders.third-party-services" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-orders.order-lines.create",
+    "displayName" : "Orders: Create order lines",
+    "description" : "",
+    "subPermissions" : [ "orders.order-templates.collection.get", "orders.order-templates.item.get", "orders.po-lines.item.post" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-orders.order-lines.edit",
+    "displayName" : "Orders: Edit order lines",
+    "description" : "",
+    "subPermissions" : [ "orders-storage.pieces.collection.get", "orders.order-templates.collection.get", "orders.order-templates.item.get", "orders.pieces.item.delete", "orders.po-lines.item.put" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-orders.order-lines.delete",
+    "displayName" : "Orders: Delete order lines",
+    "description" : "",
+    "subPermissions" : [ "orders.po-lines.item.delete" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-orders.acq.unit.assignment.assign",
+    "displayName" : "Orders: Assign acquisition units to new order",
+    "description" : "",
+    "subPermissions" : [ "orders.acquisitions-units-assignments.assign" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-orders.acq.unit.assignment.manage",
+    "displayName" : "Orders: Manage acquisition units",
+    "description" : "",
+    "subPermissions" : [ "orders.acquisitions-units-assignments.manage" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-orders.order.reopen",
+    "displayName" : "Orders: Reopen purchase orders",
+    "description" : "",
+    "subPermissions" : [ "orders.item.put" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-orders.order.unopen",
+    "displayName" : "Orders: Unopen purchase orders",
+    "description" : "",
+    "subPermissions" : [ "orders.item.put", "orders.item.unopen" ],
+    "visible" : true
+  }, {
+    "permissionName" : "settings.orders.enabled",
+    "displayName" : "Settings (Orders): Can view and edit settings",
+    "subPermissions" : [ "configuration.all", "orders.configuration.prefixes.all", "orders.configuration.reasons-for-closure.all", "orders.configuration.suffixes.all", "orders.order-templates.all", "settings.enabled", "ui-orders.third-party-services" ],
+    "visible" : true
+  } ]
+}, {
+  "id" : "folio_organizations-2.1.2",
+  "name" : "Organizations",
+  "requires" : [ {
+    "id" : "configuration",
+    "version" : "2.0"
+  }, {
+    "id" : "organizations.organizations",
+    "version" : "1.0"
+  }, {
+    "id" : "organizations-storage.addresses",
+    "version" : "1.1"
+  }, {
+    "id" : "organizations-storage.categories",
+    "version" : "1.1"
+  }, {
+    "id" : "organizations-storage.contacts",
+    "version" : "2.0"
+  }, {
+    "id" : "organizations-storage.emails",
+    "version" : "1.1"
+  }, {
+    "id" : "organizations-storage.interfaces",
+    "version" : "2.1"
+  }, {
+    "id" : "organizations-storage.phone-numbers",
+    "version" : "2.0"
+  }, {
+    "id" : "organizations-storage.urls",
+    "version" : "1.1"
+  }, {
+    "id" : "tags",
+    "version" : "1.0"
+  }, {
+    "id" : "users",
+    "version" : "15.1"
+  } ],
+  "optional" : [ ],
+  "permissionSets" : [ {
+    "permissionName" : "module.organizations.enabled",
+    "displayName" : "UI: Organizations module is enabled"
+  }, {
+    "permissionName" : "settings.organizations.enabled",
+    "displayName" : "Settings (Organization): Display list of settings for Organization",
+    "subPermissions" : [ "settings.enabled" ],
+    "visible" : false
+  }, {
+    "permissionName" : "ui-organizations.third-party-services",
+    "displayName" : "Organizations: Permissions required to call services apart from mod-organizations-storage",
+    "subPermissions" : [ "acquisitions-units.memberships.collection.get", "acquisitions-units.units.collection.get", "configuration.entries.collection.get", "tags.collection.get", "users.collection.get" ],
+    "visible" : false
+  }, {
+    "permissionName" : "ui-organizations.basic.view",
+    "displayName" : "Organizations: Basic view",
+    "subPermissions" : [ "module.organizations.enabled", "organizations.organizations.collection.get", "organizations.organizations.item.get", "organizations-storage.accounts.collection.get", "organizations-storage.accounts.item.get", "organizations-storage.addresses.collection.get", "organizations-storage.addresses.item.get", "organizations-storage.agreements.collection.get", "organizations-storage.agreements.item.get", "organizations-storage.aliases.collection.get", "organizations-storage.aliases.item.get", "organizations-storage.categories.collection.get", "organizations-storage.categories.item.get", "organizations-storage.contacts.all", "organizations-storage.emails.collection.get", "organizations-storage.emails.item.get", "organizations-storage.interfaces.all", "organizations-storage.phone-numbers.collection.get", "organizations-storage.phone-numbers.item.get", "organizations-storage.urls.collection.get", "organizations-storage.urls.item.get", "ui-organizations.third-party-services" ],
+    "visible" : false
+  }, {
+    "permissionName" : "ui-organizations.view",
+    "displayName" : "Organizations: View",
+    "subPermissions" : [ "ui-organizations.basic.view", "settings.organizations.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-organizations.edit",
+    "displayName" : "Organizations: View, edit",
+    "subPermissions" : [ "organizations.organizations.item.put", "organizations-storage.accounts.item.put", "organizations-storage.addresses.item.put", "organizations-storage.agreements.item.put", "organizations-storage.aliases.item.put", "organizations-storage.emails.item.put", "organizations-storage.phone-numbers.item.put", "organizations-storage.urls.item.put", "ui-organizations.view" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-organizations.create",
+    "displayName" : "Organizations: View, edit, create",
+    "subPermissions" : [ "organizations.organizations.item.post", "organizations-storage.accounts.item.post", "organizations-storage.addresses.item.post", "organizations-storage.agreements.item.post", "organizations-storage.aliases.item.post", "organizations-storage.emails.item.post", "organizations-storage.phone-numbers.item.post", "organizations-storage.urls.item.post", "ui-organizations.edit" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-organizations.delete",
+    "displayName" : "Organizations: View, edit, delete",
+    "subPermissions" : [ "organizations.organizations.item.delete", "organizations-storage.accounts.item.delete", "organizations-storage.addresses.item.delete", "organizations-storage.agreements.item.delete", "organizations-storage.aliases.item.delete", "organizations-storage.emails.item.delete", "organizations-storage.phone-numbers.item.delete", "organizations-storage.urls.item.delete", "ui-organizations.edit" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-organizations.creds.view",
+    "displayName" : "Organizations: Interface usernames and passwords: view",
+    "subPermissions" : [ "organizations-storage.interfaces.credentials.item.get", "ui-organizations.basic.view" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-organizations.creds.manage",
+    "displayName" : "Organizations: Interface usernames and passwords: view, edit, create, delete",
+    "subPermissions" : [ "organizations-storage.interfaces.credentials.item.put", "organizations-storage.interfaces.credentials.item.post", "organizations-storage.interfaces.credentials.item.delete", "ui-organizations.creds.view" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-organizations.acqUnits.assign",
+    "displayName" : "Organizations: Assign acquisition units to new organization",
+    "description" : "",
+    "subPermissions" : [ "organizations.acquisitions-units-assignments.assign" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-organizations.acqUnits.manage",
+    "displayName" : "Organizations: Manage acquisition units",
+    "description" : "",
+    "subPermissions" : [ "organizations.acquisitions-units-assignments.manage" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-organizations.settings",
+    "displayName" : "Settings (Organizations): Can view and edit settings",
+    "subPermissions" : [ "configuration.all", "organizations-storage.categories.all", "ui-organizations.view" ],
+    "visible" : true
+  } ]
+}, {
+  "id" : "folio_plugin-create-item-2.1.0",
+  "name" : "Instance-create-item for Stripes",
+  "requires" : [ {
+    "id" : "inventory",
+    "version" : "10.0"
+  }, {
+    "id" : "instance-storage",
+    "version" : "7.2"
+  }, {
+    "id" : "holdings-storage",
+    "version" : "4.0"
+  }, {
+    "id" : "loan-types",
+    "version" : "2.2"
+  }, {
+    "id" : "material-types",
+    "version" : "2.2"
+  }, {
+    "id" : "item-note-types",
+    "version" : "1.0"
+  }, {
+    "id" : "locations",
+    "version" : "3.0"
+  }, {
+    "id" : "identifier-types",
+    "version" : "1.2"
+  }, {
+    "id" : "contributor-types",
+    "version" : "2.0"
+  }, {
+    "id" : "contributor-name-types",
+    "version" : "1.2"
+  }, {
+    "id" : "instance-types",
+    "version" : "2.0"
+  }, {
+    "id" : "instance-formats",
+    "version" : "2.0"
+  }, {
+    "id" : "classification-types",
+    "version" : "1.2"
+  }, {
+    "id" : "statistical-code-types",
+    "version" : "1.0"
+  }, {
+    "id" : "statistical-codes",
+    "version" : "1.0"
+  }, {
+    "id" : "modes-of-issuance",
+    "version" : "1.1"
+  }, {
+    "id" : "instance-statuses",
+    "version" : "1.0"
+  }, {
+    "id" : "instance-relationship-types",
+    "version" : "1.0"
+  }, {
+    "id" : "alternative-title-types",
+    "version" : "1.0"
+  }, {
+    "id" : "holdings-types",
+    "version" : "1.0"
+  }, {
+    "id" : "call-number-types",
+    "version" : "1.0"
+  }, {
+    "id" : "electronic-access-relationships",
+    "version" : "1.0"
+  }, {
+    "id" : "ill-policies",
+    "version" : "1.0"
+  }, {
+    "id" : "holdings-note-types",
+    "version" : "1.0"
+  }, {
+    "id" : "item-damaged-statuses",
+    "version" : "1.0"
+  } ],
+  "optional" : [ ],
+  "permissionSets" : [ ]
+}, {
+  "id" : "folio_plugin-find-agreement-4.0.0",
+  "name" : "ERM-agreement-finder for Stripes",
+  "requires" : [ {
+    "id" : "erm",
+    "version" : "1.0 2.0"
+  } ],
+  "optional" : [ ],
+  "permissionSets" : [ {
+    "permissionName" : "ui-plugin-find-agreement.search",
+    "displayName" : "Find Agreement Plugin: Search agreements",
+    "subPermissions" : [ "erm.agreements.view", "erm.orgs.view", "erm.refdata.view" ],
+    "visible" : true
+  } ]
+}, {
+  "id" : "folio_plugin-find-contact-2.1.0",
+  "name" : "Find and select contacts plugin for Stripes",
+  "requires" : [ {
+    "id" : "organizations-storage.categories",
+    "version" : "1.1"
+  }, {
+    "id" : "organizations-storage.contacts",
+    "version" : "2.0"
+  } ],
+  "optional" : [ ],
+  "permissionSets" : [ ]
+}, {
+  "id" : "folio_plugin-find-erm-usage-data-provider-1.4.0",
+  "name" : "ERM-Usage-data-provider-finder for Stripes",
+  "requires" : [ ],
+  "optional" : [ ],
+  "permissionSets" : [ ]
+}, {
+  "id" : "folio_plugin-find-import-profile-2.0.1",
+  "name" : "Find and select Data Import Profiles plugin for Stripes",
+  "requires" : [ {
+    "id" : "data-import",
+    "version" : "3.0"
+  }, {
+    "id" : "source-manager-job-executions",
+    "version" : "1.0"
+  }, {
+    "id" : "data-import-converter-storage",
+    "version" : "1.2"
+  } ],
+  "optional" : [ ],
+  "permissionSets" : [ ]
+}, {
+  "id" : "folio_plugin-find-instance-3.0.0",
+  "name" : "Instance-finder for Stripes",
+  "requires" : [ {
+    "id" : "contributor-types",
+    "version" : "2.0"
+  }, {
+    "id" : "instance-types",
+    "version" : "2.0"
+  }, {
+    "id" : "locations",
+    "version" : "3.0"
+  } ],
+  "optional" : [ ],
+  "permissionSets" : [ ]
+}, {
+  "id" : "folio_plugin-find-interface-2.1.0",
+  "name" : "Find and select interfaces plugin for Stripes",
+  "requires" : [ {
+    "id" : "organizations-storage.interfaces",
+    "version" : "2.1"
+  } ],
+  "optional" : [ ],
+  "permissionSets" : [ ]
+}, {
+  "id" : "folio_plugin-find-license-4.0.0",
+  "name" : "License-finder for Stripes",
+  "requires" : [ {
+    "id" : "licenses",
+    "version" : "1.0 2.0"
+  } ],
+  "optional" : [ ],
+  "permissionSets" : [ {
+    "permissionName" : "ui-plugin-find-license.search",
+    "displayName" : "Find License Plugin: Search licenses",
+    "subPermissions" : [ "licenses.licenses.view", "licenses.orgs.view", "licenses.refdata.view" ],
+    "visible" : true
+  } ]
+}, {
+  "id" : "folio_plugin-find-organization-2.1.0",
+  "name" : "Organization-finder for Stripes",
+  "requires" : [ {
+    "id" : "configuration",
+    "version" : "2.0"
+  }, {
+    "id" : "organizations.organizations",
+    "version" : "1.0"
+  }, {
+    "id" : "tags",
+    "version" : "1.0"
+  } ],
+  "optional" : [ ],
+  "permissionSets" : [ ]
+}, {
+  "id" : "folio_plugin-find-package-title-1.0.1",
+  "name" : "Stripes plugin to find packages and titles",
+  "requires" : [ ],
+  "optional" : [ ],
+  "permissionSets" : [ {
+    "permissionName" : "module.ui-plugin-find-package-title.enabled",
+    "displayName" : "UI: find packages and titles plugin is enabled"
+  } ]
+}, {
+  "id" : "folio_plugin-find-po-line-2.1.0",
+  "name" : "Find and select PO lines plugin for Stripes",
+  "requires" : [ {
+    "id" : "contributor-name-types",
+    "version" : "1.2"
+  }, {
+    "id" : "finance.funds",
+    "version" : "1.0"
+  }, {
+    "id" : "identifier-types",
+    "version" : "1.2"
+  }, {
+    "id" : "inventory",
+    "version" : "10.0"
+  }, {
+    "id" : "locations",
+    "version" : "3.0"
+  }, {
+    "id" : "material-types",
+    "version" : "2.2"
+  }, {
+    "id" : "order-lines",
+    "version" : "1.3"
+  }, {
+    "id" : "organizations.organizations",
+    "version" : "1.0"
+  } ],
+  "optional" : [ ],
+  "permissionSets" : [ ]
+}, {
+  "id" : "folio_plugin-find-user-3.0.1",
+  "name" : "User-finder for Stripes",
+  "requires" : [ ],
+  "optional" : [ ],
+  "permissionSets" : [ {
+    "permissionName" : "module.ui-plugin-find-user.enabled",
+    "displayName" : "UI: find-user plugin is enabled"
+  } ]
+}, {
+  "id" : "folio_quick-marc-1.1.1",
+  "name" : "Quick MARC editor",
+  "requires" : [ {
+    "id" : "inventory",
+    "version" : "10.0"
+  }, {
+    "id" : "records-editor.records",
+    "version" : "1.0"
+  } ],
+  "optional" : [ ],
+  "permissionSets" : [ {
+    "permissionName" : "ui-quick-marc.quick-marc-editor.all",
+    "displayName" : "quickMARC: View, edit",
+    "subPermissions" : [ "records-editor.records.item.get", "records-editor.records.item.put", "inventory.instances.item.get" ],
+    "visible" : true
+  } ]
+}, {
+  "id" : "folio_receiving-1.1.0",
+  "name" : "Description for receiving",
+  "requires" : [ {
+    "id" : "acquisitions-units",
+    "version" : "1.1"
+  }, {
+    "id" : "circulation",
+    "version" : "9.0"
+  }, {
+    "id" : "configuration",
+    "version" : "2.0"
+  }, {
+    "id" : "holdings-storage",
+    "version" : "4.2"
+  }, {
+    "id" : "identifier-types",
+    "version" : "1.2"
+  }, {
+    "id" : "inventory",
+    "version" : "10.0"
+  }, {
+    "id" : "location-units",
+    "version" : "2.0"
+  }, {
+    "id" : "locations",
+    "version" : "3.0"
+  }, {
+    "id" : "material-types",
+    "version" : "2.2"
+  }, {
+    "id" : "order-lines",
+    "version" : "1.0"
+  }, {
+    "id" : "orders-storage.pieces",
+    "version" : "4.0"
+  }, {
+    "id" : "orders",
+    "version" : "10.0"
+  }, {
+    "id" : "pieces",
+    "version" : "2.0"
+  }, {
+    "id" : "receiving",
+    "version" : "1.0"
+  }, {
+    "id" : "tags",
+    "version" : "1.0"
+  }, {
+    "id" : "titles",
+    "version" : "1.2"
+  } ],
+  "optional" : [ ],
+  "permissionSets" : [ {
+    "permissionName" : "module.receiving.enabled",
+    "displayName" : "UI: Receiving module is enabled"
+  }, {
+    "permissionName" : "settings.receiving.enabled",
+    "displayName" : "Settings (Receiving): Display list of settings for Receiving",
+    "subPermissions" : [ "settings.enabled" ],
+    "visible" : false
+  }, {
+    "permissionName" : "ui-receiving.third-party-services",
+    "displayName" : "Receiving: Permissions required to call services",
+    "subPermissions" : [ "acquisitions-units.memberships.collection.get", "acquisitions-units.units.collection.get", "circulation.requests.collection.get", "configuration.entries.collection.get", "inventory-storage.contributor-name-types.collection.get", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.post", "inventory-storage.identifier-types.collection.get", "inventory-storage.location-units.campuses.collection.get", "inventory-storage.location-units.institutions.collection.get", "inventory-storage.location-units.libraries.collection.get", "inventory-storage.locations.collection.get", "inventory-storage.locations.item.get", "inventory-storage.material-types.collection.get", "inventory.items.collection.get", "orders-storage.pieces.collection.get", "orders.pieces.all", "orders.po-lines.item.get", "orders.titles.all", "tags.collection.get" ],
+    "visible" : false
+  }, {
+    "permissionName" : "ui-receiving.basic.view",
+    "displayName" : "Receiving: Basic view",
+    "subPermissions" : [ "module.receiving.enabled", "orders.item.get", "orders.pieces.item.post", "orders.pieces.item.put", "orders.po-lines.collection.get", "orders.titles.collection.get", "orders.titles.item.get", "ui-receiving.third-party-services" ],
+    "visible" : false
+  }, {
+    "permissionName" : "ui-receiving.view",
+    "displayName" : "Receiving: View",
+    "subPermissions" : [ "orders.check-in.collection.post", "orders.receiving.collection.post", "settings.receiving.enabled", "ui-receiving.basic.view" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-receiving.edit",
+    "displayName" : "Receiving: View, edit",
+    "subPermissions" : [ "orders.titles.item.put", "ui-receiving.view" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-receiving.create",
+    "displayName" : "Receiving: View, edit, create",
+    "subPermissions" : [ "orders.titles.item.post", "ui-receiving.edit" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-receiving.delete",
+    "displayName" : "Receiving: View, edit, delete",
+    "subPermissions" : [ "orders.titles.item.delete", "ui-receiving.edit" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-receiving.settings",
+    "displayName" : "Settings (Receiving): Can view and edit settings",
+    "subPermissions" : [ "configuration.all", "module.receiving.enabled", "settings.receiving.enabled" ],
+    "visible" : true
+  } ]
+}, {
+  "id" : "folio_requests-3.0.7",
+  "name" : "Requests manager",
+  "requires" : [ {
+    "id" : "cancellation-reason-storage",
+    "version" : "1.1"
+  }, {
+    "id" : "circulation",
+    "version" : "9.0"
+  }, {
+    "id" : "inventory",
+    "version" : "10.0"
+  }, {
+    "id" : "request-storage",
+    "version" : "3.0"
+  }, {
+    "id" : "pick-slips",
+    "version" : "0.1"
+  }, {
+    "id" : "automated-patron-blocks",
+    "version" : "0.1"
+  } ],
+  "optional" : [ ],
+  "permissionSets" : [ {
+    "permissionName" : "module.requests.enabled",
+    "displayName" : "UI: Requests module is enabled"
+  }, {
+    "permissionName" : "ui-requests.moveRequest",
+    "displayName" : "Requests: Move to new item, reorder queue",
+    "subPermissions" : [ "circulation.requests.item.move.post", "circulation.rules.request-policy.get", "ui-requests.reorderQueue" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-requests.reorderQueue",
+    "displayName" : "Requests: Reorder queue",
+    "subPermissions" : [ "circulation.requests.queue.reorder.collection.post", "circulation.rules.request-policy.get" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-requests.all",
+    "displayName" : "Requests: All permissions",
+    "description" : "All permissions for the Requests app",
+    "subPermissions" : [ "ui-requests.view", "ui-requests.create", "ui-requests.edit", "ui-requests.moveRequest", "ui-requests.reorderQueue" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-requests.view",
+    "displayName" : "Requests: View",
+    "subPermissions" : [ "module.requests.enabled", "circulation.loans.collection.get", "circulation.requests.collection.get", "circulation.requests.item.get", "circulation-storage.cancellation-reasons.collection.get", "circulation-storage.loans.collection.get", "circulation-storage.loans.item.get", "circulation-storage.requests.collection.get", "circulation-storage.requests.item.get", "users.collection.get", "users.item.get", "proxiesfor.collection.get", "inventory-storage.service-points.collection.get", "inventory-storage.service-points.item.get", "addresstypes.collection.get", "usergroups.collection.get", "configuration.entries.collection.get", "inventory.items.collection.get", "inventory.items.item.get", "inventory.instances.item.get", "inventory.instances.collection.get", "inventory-storage.items.collection.get", "inventory-storage.items.item.get", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.instances.item.get", "inventory-storage.instances.collection.get", "manualblocks.collection.get", "circulation.requests.hold-shelf-clearance-report.get", "tags.collection.get" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-requests.create",
+    "displayName" : "Requests: View, create",
+    "subPermissions" : [ "ui-requests.view", "automated-patron-blocks.collection.get", "circulation.requests.item.post", "circulation-storage.requests.item.post", "circulation.pick-slips.get", "inventory-storage.locations.item.get" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-requests.edit",
+    "displayName" : "Requests: View, edit, cancel",
+    "subPermissions" : [ "ui-requests.view", "circulation.requests.item.put", "circulation-storage.requests.collection.delete", "circulation-storage.requests.item.put", "circulation-storage.requests.item.delete", "tags.collection.get", "tags.item.post" ],
+    "visible" : true
+  } ]
+}, {
+  "id" : "folio_search-3.0.0",
+  "name" : "Search across the Codex",
+  "requires" : [ {
+    "id" : "codex",
+    "version" : "3.0"
+  } ],
+  "optional" : [ ],
+  "permissionSets" : [ {
+    "permissionName" : "module.search.enabled",
+    "displayName" : "UI: Codex Search module is enabled",
+    "visible" : true
+  }, {
+    "permissionName" : "ui-search.codex-mux.instances",
+    "subPermissions" : [ "codex-mux.instances.collection.get", "codex-mux.instances.item.get", "codex-mux.instances-sources.collection.get" ],
+    "visible" : false
+  }, {
+    "permissionName" : "ui-search.codex-mux.packages",
+    "subPermissions" : [ "codex-mux.packages.collection.get", "codex-mux.packages.item.get", "codex-mux.packages-sources.collection.get" ],
+    "visible" : false
+  }, {
+    "permissionName" : "ui-search.codex-ekb.instances",
+    "subPermissions" : [ "codex-ekb.instances.collection.get", "codex-ekb.instances.item.get", "codex-ekb.instances-sources.collection.get" ],
+    "visible" : false
+  }, {
+    "permissionName" : "ui-search.codex-ekb.packages",
+    "subPermissions" : [ "codex-ekb.packages.collection.get", "codex-ekb.packages.item.get", "codex-ekb.packages-sources.collection.get" ],
+    "visible" : false
+  }, {
+    "permissionName" : "ui-search.codexsearch",
+    "displayName" : "Search: Can search using the Codex with all back-ends",
+    "subPermissions" : [ "ui-search.codex-mux.instances", "ui-search.codex-mux.packages", "ui-search.codex-ekb.instances", "ui-search.codex-ekb.packages" ],
+    "visible" : true
+  } ]
+}, {
+  "id" : "folio_servicepoints-3.0.0",
+  "name" : "Service Points handler for Stripes",
+  "requires" : [ ],
+  "optional" : [ ],
+  "permissionSets" : [ ]
+}, {
+  "id" : "folio_stripes-acq-components-2.1.2",
+  "name" : "Component library for Stripes Acquisitions modules",
+  "requires" : [ ],
+  "optional" : [ ],
+  "permissionSets" : [ ]
+}, {
+  "id" : "folio_stripes-core-5.0.3",
+  "name" : "The starting point for Stripes applications",
+  "requires" : [ {
+    "id" : "users-bl",
+    "version" : "5.0 6.0"
+  }, {
+    "id" : "authtoken",
+    "version" : "1.0 2.0"
+  }, {
+    "id" : "configuration",
+    "version" : "2.0"
+  } ],
+  "optional" : [ ],
+  "permissionSets" : [ {
+    "permissionName" : "settings.enabled",
+    "displayName" : "UI: settings area is enabled"
+  } ]
+}, {
+  "id" : "folio_stripes-data-transfer-components-2.0.1",
+  "name" : "Shared components for ui-data-import and ui-data-export projects",
+  "requires" : [ ],
+  "optional" : [ ],
+  "permissionSets" : [ ]
+}, {
+  "id" : "folio_stripes-smart-components-4.1.5",
+  "name" : "Connected Stripes components",
+  "requires" : [ {
+    "id" : "notes",
+    "version" : "1.0"
+  }, {
+    "id" : "tags",
+    "version" : "1.0"
+  }, {
+    "id" : "password-validator",
+    "version" : "1.0"
+  } ],
+  "optional" : [ ],
+  "permissionSets" : [ ]
+}, {
+  "id" : "folio_tags-3.0.0",
+  "name" : "Tags manager",
+  "requires" : [ {
+    "id" : "tags",
+    "version" : "1.0"
+  } ],
+  "optional" : [ ],
+  "permissionSets" : [ {
+    "permissionName" : "module.tags.enabled",
+    "displayName" : "UI: Tags module is enabled"
+  }, {
+    "permissionName" : "settings.tags.enabled",
+    "displayName" : "Settings (Tags): display list of settings pages",
+    "subPermissions" : [ "settings.enabled" ],
+    "visible" : true
+  } ]
+}, {
+  "id" : "folio_tenant-settings-4.0.0",
+  "name" : "Tenant settings",
+  "requires" : [ {
+    "id" : "configuration",
+    "version" : "2.0"
+  }, {
+    "id" : "location-units",
+    "version" : "2.0"
+  }, {
+    "id" : "locations",
+    "version" : "3.0"
+  }, {
+    "id" : "login-saml",
+    "version" : "2.0"
+  }, {
+    "id" : "service-points",
+    "version" : "3.0"
+  }, {
+    "id" : "users",
+    "version" : "15.0"
+  } ],
+  "optional" : [ {
+    "id" : "course-reserves-storage",
+    "version" : "0.2"
+  }, {
+    "id" : "reserves-storage",
+    "version" : "0.1"
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "module.tenant-settings.enabled",
+    "displayName" : "UI: Tenant-settings module is enabled"
+  }, {
+    "permissionName" : "settings.tenant-settings.enabled",
+    "displayName" : "Settings (tenant): display list of settings pages",
+    "subPermissions" : [ "settings.enabled" ]
+  }, {
+    "permissionName" : "ui-tenant-settings.settings.addresses",
+    "displayName" : "Settings (tenant): Can manage tenant addresses",
+    "subPermissions" : [ "configuration.all", "users.collection.get", "settings.tenant-settings.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-tenant-settings.settings.key-bindings",
+    "displayName" : "Settings (tenant): Can maintain key bindings",
+    "subPermissions" : [ "configuration.all", "settings.tenant-settings.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-tenant-settings.settings.locale",
+    "displayName" : "Settings (tenant): Can edit language, localization, and currency",
+    "subPermissions" : [ "configuration.all", "settings.tenant-settings.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-tenant-settings.settings.plugins",
+    "displayName" : "Settings (tenant): Can maintain preferred plugins",
+    "subPermissions" : [ "configuration.all", "settings.tenant-settings.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-tenant-settings.settings.sso",
+    "displayName" : "Settings (tenant): Can maintain SSO settings",
+    "subPermissions" : [ "login-saml.configuration.get", "login-saml.configuration.put", "settings.tenant-settings.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-tenant-settings.settings.location",
+    "displayName" : "Settings (tenant): Can create, edit and remove locations",
+    "subPermissions" : [ "configuration.all", "settings.tenant-settings.enabled", "users.item.get", "users.collection.get", "inventory-storage.location-units.institutions.collection.get", "inventory-storage.location-units.institutions.item.get", "inventory-storage.location-units.institutions.item.post", "inventory-storage.location-units.institutions.item.put", "inventory-storage.location-units.institutions.item.delete", "inventory-storage.location-units.campuses.collection.get", "inventory-storage.location-units.campuses.item.get", "inventory-storage.location-units.campuses.item.post", "inventory-storage.location-units.campuses.item.put", "inventory-storage.location-units.campuses.item.delete", "inventory-storage.location-units.libraries.collection.get", "inventory-storage.location-units.libraries.item.get", "inventory-storage.location-units.libraries.item.post", "inventory-storage.location-units.libraries.item.put", "inventory-storage.location-units.libraries.item.delete", "inventory-storage.locations.collection.get", "inventory-storage.locations.item.get", "inventory-storage.locations.item.post", "inventory-storage.locations.item.put", "inventory-storage.locations.item.delete" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-tenant-settings.settings.servicepoints",
+    "displayName" : "Settings (tenant):  Can create, edit and remove service points",
+    "subPermissions" : [ "configuration.all", "settings.tenant-settings.enabled", "users.item.get", "users.collection.get", "inventory-storage.locations.collection.get", "inventory-storage.location-units.institutions.collection.get", "inventory-storage.location-units.campuses.collection.get", "inventory-storage.location-units.libraries.collection.get", "inventory-storage.service-points.collection.get", "inventory-storage.service-points.item.get", "inventory-storage.service-points.item.post", "inventory-storage.service-points.item.put", "inventory-storage.service-points.item.delete" ],
+    "visible" : true
+  } ]
+}, {
+  "id" : "folio_users-4.0.7",
+  "name" : "User management",
+  "requires" : [ {
+    "id" : "users",
+    "version" : "15.0"
+  }, {
+    "id" : "configuration",
+    "version" : "2.0"
+  }, {
+    "id" : "permissions",
+    "version" : "5.0"
+  }, {
+    "id" : "loan-policy-storage",
+    "version" : "1.0 2.0"
+  }, {
+    "id" : "loan-storage",
+    "version" : "4.0 5.0 6.0 7.0"
+  }, {
+    "id" : "login",
+    "version" : "6.0 7.0"
+  }, {
+    "id" : "request-storage",
+    "version" : "2.5 3.0"
+  }, {
+    "id" : "users-bl",
+    "version" : "5.0 6.0"
+  }, {
+    "id" : "automated-patron-blocks",
+    "version" : "0.1"
+  } ],
+  "optional" : [ {
+    "id" : "circulation",
+    "version" : "9.0"
+  }, {
+    "id" : "feesfines",
+    "version" : "15.0"
+  }, {
+    "id" : "notes",
+    "version" : "1.0"
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "module.users.enabled",
+    "displayName" : "UI: Users module is enabled"
+  }, {
+    "permissionName" : "settings.users.enabled",
+    "displayName" : "Settings (Users): display list of settings pages",
+    "subPermissions" : [ "settings.enabled" ]
+  }, {
+    "permissionName" : "ui-users.view",
+    "displayName" : "Users: Can view user profile",
+    "description" : "Some subperms can be deleted later when submodules use modern permission names",
+    "subPermissions" : [ "module.users.enabled", "users-bl.collection.get", "users-bl.item.get", "addresstypes.collection.get", "users.collection.get", "users.item.get", "usergroups.collection.get", "login.item.get", "configuration.entries.collection.get", "user-settings.custom-fields.collection.get", "user-settings.custom-fields.item.get", "user-settings.custom-fields.item.stats.get", "tags.collection.get" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.edit",
+    "displayName" : "Users: Can edit user profile",
+    "description" : "Some subperms can be deleted later when bl does updates and ModulePermissions can be used",
+    "subPermissions" : [ "ui-users.view", "users-bl.item.put", "users.item.put", "login.item.put", "tags.collection.get", "tags.item.post" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.create",
+    "displayName" : "Users: Can create new user",
+    "description" : "Some subperms can be deleted later when bl does updates and ModulePermissions can be used",
+    "subPermissions" : [ "ui-users.edit", "users-bl.item.post", "users.item.post", "perms.users.item.post", "login.item.post" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.viewperms",
+    "displayName" : "Users: Can view permissions assigned to users",
+    "description" : "Also includes basic permissions to view users",
+    "subPermissions" : [ "ui-users.view", "perms.users.get", "perms.permissions.get" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.editperms",
+    "displayName" : "Users: Can assign and unassign permissions to users",
+    "description" : "",
+    "subPermissions" : [ "ui-users.edit", "ui-users.viewperms", "perms.users.item.put", "perms.users.item.post", "perms.users.item.delete" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.viewuserservicepoints",
+    "displayName" : "Users: Can view service points assigned to users",
+    "description" : "Also includes basic permissions to view users",
+    "subPermissions" : [ "ui-users.view", "inventory-storage.service-points.collection.get", "inventory-storage.service-points-users.collection.get" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.edituserservicepoints",
+    "displayName" : "Users: Can assign and unassign service points to users",
+    "description" : "",
+    "subPermissions" : [ "ui-users.edit", "ui-users.viewuserservicepoints", "inventory-storage.service-points-users.item.post", "inventory-storage.service-points-users.item.put" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.settings.permsets",
+    "displayName" : "Settings (Users): Can create, edit and remove permission sets",
+    "description" : "",
+    "subPermissions" : [ "perms.permissions.get", "perms.permissions.item.put", "perms.permissions.item.post", "perms.permissions.item.delete", "settings.users.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.settings.usergroups",
+    "displayName" : "Settings (Users): Can create, edit and remove patron groups",
+    "subPermissions" : [ "usergroups.collection.get", "usergroups.item.delete", "usergroups.item.get", "usergroups.item.post", "usergroups.item.put", "settings.users.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.settings.addresstypes",
+    "displayName" : "Settings (Users): Can create, edit and remove address types",
+    "subPermissions" : [ "addresstypes.collection.get", "addresstypes.item.get", "addresstypes.item.post", "addresstypes.item.put", "addresstypes.item.delete", "settings.users.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.viewproxies",
+    "displayName" : "Users: Can view proxies assigned to users",
+    "subPermissions" : [ "ui-users.view", "proxiesfor.collection.get" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.editproxies",
+    "displayName" : "Users: Can create, edit and remove proxies",
+    "description" : "",
+    "subPermissions" : [ "ui-users.edit", "ui-users.viewproxies", "proxiesfor.item.get", "proxiesfor.item.post", "proxiesfor.item.put", "proxiesfor.item.delete" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.settings.comments",
+    "displayName" : "Settings (Users): Can create, edit and remove comments",
+    "subPermissions" : [ "comments.collection.get", "comments.item.delete", "comments.item.get", "comments.item.post", "comments.item.put", "settings.users.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.settings.feefines.all",
+    "displayName" : "Settings (Users): Can create, edit and remove all feefines-related entries",
+    "subPermissions" : [ "settings.users.enabled", "ui-users.settings.owners", "ui-users.settings.feefines", "ui-users.settings.waives", "ui-users.settings.payments", "ui-users.settings.refunds", "ui-users.settings.comments", "ui-users.settings.transfers", "ui-users.settings.transfertypes" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.settings.feefines",
+    "displayName" : "Settings (Users): Can create, edit and remove feefines",
+    "subPermissions" : [ "feefines.collection.get", "feefines.item.delete", "feefines.item.get", "feefines.item.post", "feefines.item.put", "settings.users.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.settings.customfields.view",
+    "displayName" : "Settings (Users): Can view custom fields",
+    "subPermissions" : [ "settings.users.enabled", "configuration.entries.collection.get" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.settings.customfields.edit",
+    "displayName" : "Settings (Users): Can create, edit, and view custom fields",
+    "subPermissions" : [ "ui-users.settings.customfields.view", "user-settings.custom-fields.collection.put", "user-settings.custom-fields.item.post", "user-settings.custom-fields.item.put", "configuration.entries.item.post", "configuration.entries.item.put" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.settings.customfields.all",
+    "displayName" : "Settings (Users): Can create, edit, view and delete custom fields",
+    "subPermissions" : [ "ui-users.settings.customfields.view", "ui-users.settings.customfields.edit", "user-settings.custom-fields.item.delete" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.settings.owners",
+    "displayName" : "Settings (Users): Can create, edit and remove owners",
+    "subPermissions" : [ "owners.collection.get", "owners.item.delete", "owners.item.get", "owners.item.post", "owners.item.put", "settings.users.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.settings.payments",
+    "displayName" : "Settings (Users): Can create, edit and remove payments",
+    "subPermissions" : [ "payments.collection.get", "payments.item.delete", "payments.item.get", "payments.item.post", "payments.item.put", "settings.users.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.settings.refunds",
+    "displayName" : "Settings (Users): Can create, edit and remove refunds",
+    "subPermissions" : [ "refunds.collection.get", "refunds.item.delete", "refunds.item.get", "refunds.item.post", "refunds.item.put", "settings.users.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.settings.waives",
+    "displayName" : "Settings (Users): Can create, edit and remove waives",
+    "subPermissions" : [ "waives.collection.get", "waives.item.delete", "waives.item.get", "waives.item.post", "waives.item.put", "settings.users.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.accounts",
+    "displayName" : "Fee/Fine History: Can create, edit and remove accounts",
+    "subPermissions" : [ "accounts.collection.get", "accounts.item.delete", "accounts.item.get", "accounts.item.post", "accounts.item.put", "feefineactions.collection.get", "payments.collection.get", "waives.collection.get", "owners.collection.get", "feefines.collection.get", "transfers.collection.get", "inventory-storage.service-points-users.collection.get" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.feefineactions",
+    "displayName" : "Fee/Fine Details: Can create, edit and remove fee/fine actions",
+    "subPermissions" : [ "feefineactions.collection.get", "feefineactions.item.delete", "feefineactions.item.get", "feefineactions.item.post", "feefineactions.item.put" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.settings.transfers",
+    "displayName" : "Settings (Users): Can create, edit and remove transfer accounts ",
+    "subPermissions" : [ "transfers.collection.get", "transfers.item.delete", "transfers.item.get", "transfers.item.post", "transfers.item.put", "settings.users.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.settings.transfertypes",
+    "displayName" : "Settings (Users): Can create, edit and remove transfer criteria",
+    "subPermissions" : [ "transfertypes.collection.get", "transfertypes.item.delete", "transfertypes.item.get", "transfertypes.item.post", "transfertypes.item.put", "settings.users.enabled" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.manual_pay",
+    "displayName" : "Fees/Fines: Can pay",
+    "subPermissions" : [ "ui-users.accounts", "ui-users.feefineactions", "comments.collection.get", "comments.item.get", "payments.collection.get", "payments.item.get" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.manual_waive",
+    "displayName" : "Fees/Fines: Can waive",
+    "subPermissions" : [ "ui-users.accounts", "ui-users.feefineactions", "comments.collection.get", "comments.item.get", "waives.collection.get", "waives.item.get" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.manual_charge",
+    "displayName" : "Fees/Fines: Can charge",
+    "subPermissions" : [ "owners.collection.get", "owners.item.get", "feefines.collection.get", "feefines.item.get", "ui-users.manual_pay" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.patron_blocks",
+    "displayName" : "Users: Can create, edit and remove patron blocks",
+    "subPermissions" : [ "manualblocks.collection.get", "manualblocks.item.delete", "manualblocks.item.get", "manualblocks.item.post", "manualblocks.item.put" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.settings.conditions",
+    "displayName" : "Settings (Users): Can create, edit and remove patron blocks conditions",
+    "subPermissions" : [ "patron-block-conditions.collection.get", "patron-block-conditions.item.get", "patron-block-conditions.item.post", "patron-block-conditions.item.put", "patron-block-conditions.item.delete" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.settings.limits",
+    "displayName" : "Settings (Users): Can create, edit and remove patron blocks limits",
+    "subPermissions" : [ "ui-users.settings.conditions", "patron-block-limits.collection.get", "patron-block-limits.item.get", "patron-block-limits.item.post", "patron-block-limits.item.put", "patron-block-limits.item.delete" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.feesfines.actions.all",
+    "displayName" : "Users: Can create, edit and remove fees/fines",
+    "subPermissions" : [ "ui-users.manual_charge", "ui-users.manual_pay", "ui-users.manual_waive" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.loans.renew",
+    "displayName" : "Users: User loans renew",
+    "description" : "Also includes backend permissions to perform loans renew",
+    "subPermissions" : [ "circulation.renew-by-barcode.post", "inventory-storage.location-units.libraries.collection.get" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.loans.renew-override",
+    "displayName" : "Users: User loans renew through override",
+    "description" : "Also includes backend permissions to perform loans renew through override",
+    "subPermissions" : [ "circulation.override-renewal-by-barcode.post" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.loans.declare-item-lost",
+    "displayName" : "Users: User loans declare lost",
+    "description" : "Also includes backend permissions to declare items lost",
+    "subPermissions" : [ "circulation.loans.declare-item-lost.post", "circulation-storage.loans.item.get", "inventory-storage.items.item.get", "inventory-storage.holdings.item.get", "inventory-storage.instances.item.get" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.loans.declare-claimed-returned-item-as-missing",
+    "displayName" : "Users: User loans mark claimed returned missing",
+    "description" : "Also includes backend permission to declare claimed returned item as missing",
+    "subPermissions" : [ "circulation.loans.declare-claimed-returned-item-as-missing.post", "circulation-storage.loans.item.get", "inventory-storage.items.item.get", "inventory-storage.holdings.item.get", "inventory-storage.instances.item.get" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.loans.claim-item-returned",
+    "displayName" : "Users: User loans claim returned",
+    "description" : "Also includes backend permissions to claim items returned",
+    "subPermissions" : [ "circulation.loans.claim-item-returned.post", "circulation-storage.loans.item.get", "inventory-storage.items.item.get", "inventory-storage.holdings.item.get", "inventory-storage.instances.item.get" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.loans.view",
+    "displayName" : "Users: User loans view",
+    "description" : "Also includes basic permissions to view users",
+    "subPermissions" : [ "ui-users.view", "circulation.loans.collection.get", "circulation.requests.collection.get", "circulation-storage.loan-policies.collection.get", "circulation-storage.loans-history.collection.get", "accounts.collection.get", "comments.collection.get" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.loans.edit",
+    "displayName" : "Users: User loan edit",
+    "description" : "Also includes backend permissions to perform loan edit",
+    "subPermissions" : [ "circulation.loans.item.put", "circulation.renew-by-barcode.post", "circulation-storage.loans.item.get" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.loans.all",
+    "displayName" : "Users: User loans view, edit, renew (all)",
+    "description" : "Also includes requests, loan-policies and accounts permissions",
+    "subPermissions" : [ "ui-users.view", "ui-users.loans.view", "ui-users.loans.edit", "ui-users.loans.renew", "circulation.loans.declare-item-lost.post", "circulation.loans.claim-item-returned.post", "circulation.loans.declare-claimed-returned-item-as-missing.post", "circulation.loans.collection.anonymize.user.post", "ui-users.loans.renew-override", "circulation.loans.item.put", "circulation.renew-by-barcode.post", "circulation-storage.loans-history.collection.get", "circulation-storage.loans.collection.anonymize.user.post", "circulation-storage.loan-policies.collection.get", "circulation-storage.loan-policies.item.get", "circulation-storage.loans.item.get", "accounts.collection.get", "feefineactions.collection.get", "owners.collection.get", "payments.collection.get", "comments.collection.get", "waives.collection.get", "inventory-storage.locations.collection.get", "inventory-storage.location-units.libraries.collection.get", "inventory-storage.material-types.collection.get" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.requests.all",
+    "displayName" : "Users: View requests",
+    "description" : "Also includes basic permissions to view users and loans",
+    "subPermissions" : [ "ui-users.view", "circulation.loans.collection.get", "circulation.requests.collection.get", "circulation.requests.item.get", "circulation-storage.cancellation-reasons.collection.get", "circulation-storage.loans.collection.get", "circulation-storage.loans.item.get", "circulation-storage.requests.collection.get", "circulation-storage.requests.collection.delete", "circulation-storage.requests.item.get", "circulation-storage.requests.item.delete", "inventory.items.collection.get", "inventory.items.item.get", "inventory.instances.item.get", "inventory.instances.collection.get", "inventory-storage.items.collection.get", "inventory-storage.items.item.get", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.instances.item.get", "inventory-storage.instances.collection.get", "inventory-storage.locations.collection.get", "inventory-storage.location-units.libraries.collection.get", "inventory-storage.material-types.collection.get", "circulation-storage.loan-policies.collection.get" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.reset.password",
+    "displayName" : "Users: Create/reset password",
+    "subPermissions" : [ "login.credentials-existence.get", "login.collection.get", "ui-users.view", "ui-users.edit", "users-bl.password-reset-link.generate" ],
+    "visible" : true
+  }, {
+    "permissionName" : "ui-users.settings.profilePictures",
+    "displayName" : "Settings (Users): Can create, edit and remove permission sets",
+    "description" : "",
+    "subPermissions" : [ "settings.users.enabled", "configuration.entries.collection.get", "configuration.entries.item.get", "configuration.entries.item.post", "configuration.entries.item.put" ],
+    "visible" : true
+  } ]
+}, {
+  "id" : "mod-agreements-2.3.1",
+  "name" : "mod-agreements",
+  "provides" : [ {
+    "id" : "erm",
+    "version" : "2.3",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/sas",
+      "permissionsRequired" : [ "erm.agreements.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/sas/publicLookup",
+      "permissionsRequired" : [ ],
+      "modulePermissions" : [ "licenses.licenses.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/sas/{id}",
+      "permissionsRequired" : [ "erm.agreements.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/sas/{id}/export",
+      "permissionsRequired" : [ "erm.agreements.export" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/sas/{id}/export/*",
+      "permissionsRequired" : [ "erm.agreements.export" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/sas/linkedLicenses",
+      "permissionsRequired" : [ "erm.agreements.linkedLicenses.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/sas/{id}/linkedLicenses",
+      "permissionsRequired" : [ "erm.agreements.linkedLicenses.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/sas/usageDataProviders",
+      "permissionsRequired" : [ "erm.agreements.usageDataProviders.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/sas/{id}/usageDataProviders",
+      "permissionsRequired" : [ "erm.agreements.usageDataProviders.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/sas/{id}/resources",
+      "permissionsRequired" : [ "erm.agreements.item.resources.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/sas/{id}/resources/*",
+      "permissionsRequired" : [ "erm.agreements.item.resources.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/sas/{id}/resources/export",
+      "permissionsRequired" : [ "erm.agreements.export" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/sas/{id}/resources/export/*",
+      "permissionsRequired" : [ "erm.agreements.export" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/erm/sas",
+      "permissionsRequired" : [ "erm.agreements.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/erm/sas/{id}",
+      "permissionsRequired" : [ "erm.agreements.item.put" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/erm/sas/{id}/clone",
+      "permissionsRequired" : [ "erm.agreements.item.clone" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/erm/sas/{id}",
+      "permissionsRequired" : [ "erm.agreements.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/export",
+      "permissionsRequired" : [ "erm.agreements.export" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/export/*",
+      "permissionsRequired" : [ "erm.agreements.export" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/entitlements",
+      "permissionsRequired" : [ "erm.entitlements.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/entitlements/{id}",
+      "permissionsRequired" : [ "erm.entitlements.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/erm/entitlements/{id}",
+      "permissionsRequired" : [ "erm.entitlements.item.put" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/files",
+      "permissionsRequired" : [ "erm.files.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/files/{id}",
+      "permissionsRequired" : [ "erm.files.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/files/{id}/*",
+      "permissionsRequired" : [ "erm.files.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/erm/files",
+      "permissionsRequired" : [ "erm.files.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/erm/files/{id}",
+      "permissionsRequired" : [ "erm.files.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/erm/files/{id}",
+      "permissionsRequired" : [ "erm.files.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/contacts",
+      "permissionsRequired" : [ "erm.contacts.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/contacts/{id}",
+      "permissionsRequired" : [ "erm.contacts.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/org",
+      "permissionsRequired" : [ "erm.orgs.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/org/{id}",
+      "permissionsRequired" : [ "erm.orgs.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/packages",
+      "permissionsRequired" : [ "erm.packages.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/packages/{id}",
+      "permissionsRequired" : [ "erm.packages.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/packages/{id}/content",
+      "permissionsRequired" : [ "erm.packages.item.content.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/packages/{id}/content/*",
+      "permissionsRequired" : [ "erm.packages.item.content.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/jobs",
+      "permissionsRequired" : [ "erm.jobs.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/jobs/{id}",
+      "permissionsRequired" : [ "erm.jobs.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/jobs/{id}/fullLog",
+      "permissionsRequired" : [ "erm.jobs.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/jobs/{id}/errorLog",
+      "permissionsRequired" : [ "erm.jobs.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/jobs/{id}/infoLog",
+      "permissionsRequired" : [ "erm.jobs.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/erm/jobs/{type}",
+      "permissionsRequired" : [ "erm.jobs.item.post" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/erm/jobs/{id}",
+      "permissionsRequired" : [ "erm.jobs.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/refdata",
+      "permissionsRequired" : [ "erm.refdata.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/refdata/{domain}/{property}",
+      "permissionsRequired" : [ "erm.refdata.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/refdata/{id}",
+      "permissionsRequired" : [ "erm.refdata.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/erm/refdata",
+      "permissionsRequired" : [ "erm.refdata.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/erm/refdata/{id}",
+      "permissionsRequired" : [ "erm.refdata.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/erm/refdata/{id}",
+      "permissionsRequired" : [ "erm.refdata.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/kbs",
+      "permissionsRequired" : [ "erm.kbs.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/kbs/{id}",
+      "permissionsRequired" : [ "erm.kbs.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/erm/kbs",
+      "permissionsRequired" : [ "erm.kbs.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/erm/kbs/{id}",
+      "permissionsRequired" : [ "erm.kbs.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/erm/kbs/{id}",
+      "permissionsRequired" : [ "erm.kbs.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/resource",
+      "permissionsRequired" : [ "erm.resources.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/resource/electronic",
+      "permissionsRequired" : [ "erm.resources.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/resource/{id}",
+      "permissionsRequired" : [ "erm.resources.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/resource/{id}/entitlements",
+      "permissionsRequired" : [ "erm.resources.item.entitlement.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/resource/{id}/entitlements/related",
+      "permissionsRequired" : [ "erm.resources.item.entitlement.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/resource/{id}/entitlementOptions",
+      "permissionsRequired" : [ "erm.resources.item.entitlementOptions.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/titles",
+      "permissionsRequired" : [ "erm.titles.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/titles/entitled",
+      "permissionsRequired" : [ "erm.titles.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/titles/{id}",
+      "permissionsRequired" : [ "erm.titles.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/erm/titles/{id}",
+      "permissionsRequired" : [ "erm.titles.item.put" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/pci",
+      "permissionsRequired" : [ "erm.pci.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/pci/{id}",
+      "permissionsRequired" : [ "erm.pci.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/erm/pci/{id}",
+      "permissionsRequired" : [ "erm.pci.item.put" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/pti",
+      "permissionsRequired" : [ "erm.pti.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/pti/{id}",
+      "permissionsRequired" : [ "erm.pti.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/erm/pti/{id}",
+      "permissionsRequired" : [ "erm.pti.item.put" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/custprops",
+      "permissionsRequired" : [ "erm.custprops.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm/custprops/{id}",
+      "permissionsRequired" : [ "erm.custprops.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/erm/custprops",
+      "permissionsRequired" : [ "erm.custprops.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/erm/custprops/{id}",
+      "permissionsRequired" : [ "erm.custprops.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/erm/custprops/{id}",
+      "permissionsRequired" : [ "erm.custprops.item.delete" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/erm/packages/import",
+      "permissionsRequired" : [ "erm.packages.collection.import" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/erm/validate/subscriptionAgreement",
+      "permissionsRequired" : [ "erm.agreements.item.post", "erm.agreements.item.put" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/erm/validate/subscriptionAgreement/*",
+      "permissionsRequired" : [ "erm.agreements.item.post", "erm.agreements.item.put" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/erm/validate/remoteKB",
+      "permissionsRequired" : [ "erm.kbs.item.post", "erm.kbs.item.put" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/erm/validate/remoteKB/*",
+      "permissionsRequired" : [ "erm.kbs.item.post", "erm.kbs.item.put" ]
+    } ]
+  }, {
+    "id" : "_tenant",
+    "version" : "1.2",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST", "DELETE" ],
+      "pathPattern" : "/_/tenant"
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/_/tenant/disable"
+    } ]
+  }, {
+    "id" : "codex",
+    "version" : "3.0",
+    "interfaceType" : "multiple",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/codex-instances",
+      "permissionsRequired" : [ "codex.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/codex-instances/{id}",
+      "permissionsRequired" : [ "codex.item.get" ]
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "erm.agreements.view",
+    "subPermissions" : [ "erm.agreements.collection.get", "erm.agreements.item.get", "erm.agreements.item.resources.get", "erm.agreements.export", "erm.agreements.linkedLicenses.get", "erm.agreements.usageDataProviders.get", "erm.resources.view" ]
+  }, {
+    "permissionName" : "erm.agreements.edit",
+    "subPermissions" : [ "erm.agreements.view", "erm.agreements.item.post", "erm.agreements.item.put", "erm.agreements.item.clone" ]
+  }, {
+    "permissionName" : "erm.agreements.manage",
+    "subPermissions" : [ "erm.agreements.edit", "erm.agreements.item.delete" ]
+  }, {
+    "permissionName" : "erm.files.view",
+    "subPermissions" : [ "erm.files.collection.get", "erm.files.item.get" ]
+  }, {
+    "permissionName" : "erm.files.edit",
+    "subPermissions" : [ "erm.files.view", "erm.files.item.post", "erm.files.item.put" ]
+  }, {
+    "permissionName" : "erm.files.manage",
+    "subPermissions" : [ "erm.files.edit", "erm.files.item.delete" ]
+  }, {
+    "permissionName" : "erm.contacts.view",
+    "subPermissions" : [ "erm.contacts.collection.get", "erm.contacts.item.get" ]
+  }, {
+    "permissionName" : "erm.orgs.view",
+    "subPermissions" : [ "erm.orgs.collection.get", "erm.orgs.item.get" ]
+  }, {
+    "permissionName" : "erm.packages.view",
+    "subPermissions" : [ "erm.packages.collection.get", "erm.packages.item.get", "erm.packages.item.content.get" ]
+  }, {
+    "permissionName" : "erm.jobs.view",
+    "subPermissions" : [ "erm.jobs.collection.get", "erm.jobs.item.get" ]
+  }, {
+    "permissionName" : "erm.jobs.edit",
+    "subPermissions" : [ "erm.jobs.item.post" ]
+  }, {
+    "permissionName" : "erm.jobs.manage",
+    "subPermissions" : [ "erm.jobs.edit", "erm.jobs.item.delete" ]
+  }, {
+    "permissionName" : "erm.refdata.view",
+    "subPermissions" : [ "erm.refdata.collection.get", "erm.refdata.item.get" ]
+  }, {
+    "permissionName" : "erm.refdata.edit",
+    "subPermissions" : [ "erm.refdata.view", "erm.refdata.item.post", "erm.refdata.item.put" ]
+  }, {
+    "permissionName" : "erm.refdata.manage",
+    "subPermissions" : [ "erm.refdata.edit", "erm.refdata.item.delete" ]
+  }, {
+    "permissionName" : "erm.kbs.view",
+    "subPermissions" : [ "erm.kbs.collection.get", "erm.kbs.item.get" ]
+  }, {
+    "permissionName" : "erm.kbs.edit",
+    "subPermissions" : [ "erm.kbs.view", "erm.kbs.item.post", "erm.kbs.item.put" ]
+  }, {
+    "permissionName" : "erm.kbs.manage",
+    "subPermissions" : [ "erm.kbs.edit", "erm.kbs.item.delete" ]
+  }, {
+    "permissionName" : "erm.pci.view",
+    "subPermissions" : [ "erm.pci.collection.get", "erm.pci.item.get" ]
+  }, {
+    "permissionName" : "erm.pci.edit",
+    "subPermissions" : [ "erm.pci.view", "erm.pci.item.put" ]
+  }, {
+    "permissionName" : "erm.pti.view",
+    "subPermissions" : [ "erm.pti.collection.get", "erm.pti.item.get" ]
+  }, {
+    "permissionName" : "erm.pti.edit",
+    "subPermissions" : [ "erm.pti.view", "erm.pti.item.put" ]
+  }, {
+    "permissionName" : "erm.resources.view",
+    "subPermissions" : [ "erm.resources.collection.get", "erm.resources.item.get", "erm.resources.item.entitlement.get", "erm.resources.item.entitlementOptions.get", "erm.entitlements.view", "erm.kbs.collection.get" ]
+  }, {
+    "permissionName" : "erm.entitlements.view",
+    "subPermissions" : [ "erm.entitlements.collection.get", "erm.entitlements.item.get" ]
+  }, {
+    "permissionName" : "erm.entitlements.edit",
+    "subPermissions" : [ "erm.entitlements.view", "erm.entitlements.item.put" ]
+  }, {
+    "permissionName" : "erm.titles.view",
+    "subPermissions" : [ "erm.titles.collection.get", "erm.titles.item.get" ]
+  }, {
+    "permissionName" : "erm.titles.edit",
+    "subPermissions" : [ "erm.titles.view", "erm.titles.item.put" ]
+  }, {
+    "permissionName" : "erm.custprops.view",
+    "subPermissions" : [ "erm.custprops.collection.get", "erm.custprops.item.get" ]
+  }, {
+    "permissionName" : "erm.custprops.edit",
+    "subPermissions" : [ "erm.custprops.view", "erm.custprops.item.post", "erm.custprops.item.put" ]
+  }, {
+    "permissionName" : "erm.custprops.manage",
+    "subPermissions" : [ "erm.custprops.edit", "erm.custprops.item.delete" ]
+  }, {
+    "permissionName" : "erm.packages.collection.import"
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-agreements:2.3.1",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-server -XX:+UseContainerSupport -XX:MaxRAMPercentage=50.0 -XX:+PrintFlagsFinal"
+    }, {
+      "name" : "DB_HOST",
+      "value" : "postgres"
+    }, {
+      "name" : "DB_PORT",
+      "value" : "5432"
+    }, {
+      "name" : "DB_USERNAME",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_PASSWORD",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_DATABASE",
+      "value" : "okapi_modules"
+    }, {
+      "name" : "DB_MAXPOOLSIZE",
+      "value" : "50"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 872415232,
+        "PortBindings" : {
+          "8080/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-authtoken-2.5.1",
+  "name" : "authtoken",
+  "requires" : [ {
+    "id" : "permissions",
+    "version" : "5.3"
+  }, {
+    "id" : "users",
+    "version" : "15.0"
+  } ],
+  "provides" : [ {
+    "id" : "authtoken",
+    "version" : "2.0",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/token",
+      "permissionsRequired" : [ ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/refreshtoken",
+      "permissionsRequired" : [ ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/refresh",
+      "permissionsRequired" : [ ]
+    } ]
+  } ],
+  "filters" : [ {
+    "methods" : [ "*" ],
+    "pathPattern" : "/*",
+    "phase" : "auth",
+    "type" : "headers"
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-authtoken:2.5.1",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0 -Dcache.permissions=true"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-calendar-1.9.1",
+  "name" : "Calendar module",
+  "requires" : [ ],
+  "provides" : [ {
+    "id" : "calendar",
+    "version" : "4.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/calendar/periods",
+      "permissionsRequired" : [ "calendar.opening-hours.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/calendar/periods/{servicePointId}/period",
+      "permissionsRequired" : [ "calendar.periods.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/calendar/periods/{servicePointId}/period",
+      "permissionsRequired" : [ "calendar.periods.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/calendar/periods/{servicePointId}/period/{periodId}",
+      "permissionsRequired" : [ "calendar.periods.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/calendar/periods/{servicePointId}/period/{periodId}",
+      "permissionsRequired" : [ "calendar.periods.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/calendar/periods/{servicePointId}/period/{periodId}",
+      "permissionsRequired" : [ "calendar.periods.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/calendar/periods/{servicePointId}/calculateopening",
+      "permissionsRequired" : [ "calendar.opening-hours.collection.get" ]
+    } ]
+  }, {
+    "id" : "_tenant",
+    "version" : "1.0",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST", "DELETE" ],
+      "pathPattern" : "/_/tenant"
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "calendar.opening-hours.collection.get",
+    "displayName" : "List calendar opening hours",
+    "description" : ""
+  }, {
+    "permissionName" : "calendar.periods.collection.get",
+    "displayName" : "List calendar periods descriptions",
+    "description" : ""
+  }, {
+    "permissionName" : "calendar.periods.item.get",
+    "displayName" : "Get period description",
+    "description" : ""
+  }, {
+    "permissionName" : "calendar.periods.item.post",
+    "displayName" : "Add new calendar period description",
+    "description" : ""
+  }, {
+    "permissionName" : "calendar.periods.item.put",
+    "displayName" : "Update existing calendar period description",
+    "description" : ""
+  }, {
+    "permissionName" : "calendar.periods.item.delete",
+    "displayName" : "Remove calendar period description",
+    "description" : ""
+  }, {
+    "permissionName" : "calendar.all",
+    "displayName" : "Calendar - all permissions",
+    "description" : "All permission for mod-calendar module",
+    "subPermissions" : [ "calendar.opening-hours.collection.get", "calendar.periods.collection.get", "calendar.periods.item.post", "calendar.periods.item.get", "calendar.periods.item.put", "calendar.periods.item.delete" ],
+    "visible" : false
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-calendar:1.9.1",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    }, {
+      "name" : "DB_HOST",
+      "value" : "postgres"
+    }, {
+      "name" : "DB_PORT",
+      "value" : "5432"
+    }, {
+      "name" : "DB_USERNAME",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_PASSWORD",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_DATABASE",
+      "value" : "okapi_modules"
+    }, {
+      "name" : "DB_QUERYTIMEOUT",
+      "value" : "60000"
+    }, {
+      "name" : "DB_CHARSET",
+      "value" : "UTF-8"
+    }, {
+      "name" : "DB_MAXPOOLSIZE",
+      "value" : "5"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-circulation-19.0.16",
+  "name" : "Circulation Module",
+  "requires" : [ {
+    "id" : "loan-storage",
+    "version" : "7.0"
+  }, {
+    "id" : "circulation-rules-storage",
+    "version" : "1.0"
+  }, {
+    "id" : "item-storage",
+    "version" : "8.4"
+  }, {
+    "id" : "instance-storage",
+    "version" : "4.0 5.0 6.0 7.0"
+  }, {
+    "id" : "holdings-storage",
+    "version" : "1.3 2.0 3.0 4.0"
+  }, {
+    "id" : "request-storage",
+    "version" : "3.3"
+  }, {
+    "id" : "request-storage-batch",
+    "version" : "0.3"
+  }, {
+    "id" : "users",
+    "version" : "14.2 15.0"
+  }, {
+    "id" : "locations",
+    "version" : "3.0"
+  }, {
+    "id" : "material-types",
+    "version" : "2.0"
+  }, {
+    "id" : "loan-policy-storage",
+    "version" : "1.2 2.0"
+  }, {
+    "id" : "request-policy-storage",
+    "version" : "1.0"
+  }, {
+    "id" : "fixed-due-date-schedules-storage",
+    "version" : "2.0"
+  }, {
+    "id" : "service-points",
+    "version" : "3.0"
+  }, {
+    "id" : "calendar",
+    "version" : "3.0 4.0"
+  }, {
+    "id" : "patron-notice-policy-storage",
+    "version" : "0.11"
+  }, {
+    "id" : "patron-notice",
+    "version" : "1.0"
+  }, {
+    "id" : "configuration",
+    "version" : "2.0"
+  }, {
+    "id" : "cancellation-reason-storage",
+    "version" : "1.1"
+  }, {
+    "id" : "loan-types",
+    "version" : "2.2"
+  }, {
+    "id" : "scheduled-notice-storage",
+    "version" : "0.1"
+  }, {
+    "id" : "feesfines",
+    "version" : "15.0"
+  }, {
+    "id" : "location-units",
+    "version" : "2.0"
+  }, {
+    "id" : "patron-action-session-storage",
+    "version" : "0.1"
+  }, {
+    "id" : "check-in-storage",
+    "version" : "0.2"
+  }, {
+    "id" : "pubsub-event-types",
+    "version" : "0.1"
+  }, {
+    "id" : "pubsub-publishers",
+    "version" : "0.1"
+  }, {
+    "id" : "pubsub-subscribers",
+    "version" : "0.1"
+  }, {
+    "id" : "pubsub-publish",
+    "version" : "0.1"
+  }, {
+    "id" : "automated-patron-blocks",
+    "version" : "0.1"
+  } ],
+  "provides" : [ {
+    "id" : "requests-reports",
+    "version" : "0.7",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/circulation/requests-reports/hold-shelf-clearance/{id}",
+      "permissionsRequired" : [ "circulation.requests.hold-shelf-clearance-report.get" ],
+      "modulePermissions" : [ "modperms.circulation.requests.hold-shelf-clearance-report.get" ]
+    } ]
+  }, {
+    "id" : "inventory-reports",
+    "version" : "0.4",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/inventory-reports/items-in-transit",
+      "permissionsRequired" : [ "circulation.inventory.items-in-transit-report.get" ],
+      "modulePermissions" : [ "modperms.inventory.items-in-transit-report.get" ]
+    } ]
+  }, {
+    "id" : "pick-slips",
+    "version" : "0.2",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/circulation/pick-slips/{servicePointId}",
+      "permissionsRequired" : [ "circulation.pick-slips.get" ],
+      "modulePermissions" : [ "modperms.circulation.pick-slips.get" ]
+    } ]
+  }, {
+    "id" : "request-move",
+    "version" : "0.7",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/circulation/requests/{id}/move",
+      "permissionsRequired" : [ "circulation.requests.item.move.post" ],
+      "modulePermissions" : [ "modperms.circulation.requests.item.move.post" ]
+    } ]
+  }, {
+    "id" : "loan-anonymization",
+    "version" : "0.1",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/loan-anonymization/by-user/{userId}",
+      "permissionsRequired" : [ "circulation.loans.collection.anonymize.user.post" ],
+      "modulePermissions" : [ "modperms.circulation.loans.anonymize" ]
+    } ]
+  }, {
+    "id" : "declare-item-lost",
+    "version" : "0.2",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/circulation/loans/{id}/declare-item-lost",
+      "permissionsRequired" : [ "circulation.loans.declare-item-lost.post" ],
+      "modulePermissions" : [ "modperms.circulation.loans.declare-item-lost.post" ]
+    } ]
+  }, {
+    "id" : "change-due-date",
+    "version" : "0.1",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/circulation/loans/{id}/change-due-date",
+      "permissionsRequired" : [ "circulation.loans.change-due-date.post" ],
+      "modulePermissions" : [ "modperms.circulation.loans.change-due-date.post" ]
+    } ]
+  }, {
+    "id" : "claim-item-returned",
+    "version" : "0.2",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/circulation/loans/{id}/claim-item-returned",
+      "permissionsRequired" : [ "circulation.loans.claim-item-returned.post" ],
+      "modulePermissions" : [ "modperms.circulation.loans.claim-item-returned.post" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/circulation/loans/{id}/declare-claimed-returned-item-as-missing",
+      "permissionsRequired" : [ "circulation.loans.declare-claimed-returned-item-as-missing.post" ],
+      "modulePermissions" : [ "modperms.circulation.loans.declare-claimed-returned-item-as-missing.post" ]
+    } ]
+  }, {
+    "id" : "circulation",
+    "version" : "9.3",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/circulation/check-out-by-barcode",
+      "permissionsRequired" : [ "circulation.check-out-by-barcode.post" ],
+      "modulePermissions" : [ "modperms.circulation.check-out-by-barcode.post" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/circulation/override-check-out-by-barcode",
+      "permissionsRequired" : [ "circulation.override-check-out-by-barcode.post" ],
+      "modulePermissions" : [ "modperms.circulation.override-check-out-by-barcode.post" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/circulation/check-in-by-barcode",
+      "permissionsRequired" : [ "circulation.check-in-by-barcode.post" ],
+      "modulePermissions" : [ "modperms.circulation.check-in-by-barcode.post" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/circulation/renew-by-barcode",
+      "permissionsRequired" : [ "circulation.renew-by-barcode.post" ],
+      "modulePermissions" : [ "modperms.circulation.renew-by-barcode.post" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/circulation/override-renewal-by-barcode",
+      "permissionsRequired" : [ "circulation.override-renewal-by-barcode.post" ],
+      "modulePermissions" : [ "modperms.circulation.override-renewal-by-barcode.post" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/circulation/renew-by-id",
+      "permissionsRequired" : [ "circulation.renew-by-id.post" ],
+      "modulePermissions" : [ "modperms.circulation.renew-by-id.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/circulation/loans",
+      "permissionsRequired" : [ "circulation.loans.collection.get" ],
+      "modulePermissions" : [ "modperms.circulation.loans.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/circulation/loans",
+      "permissionsRequired" : [ "circulation.loans.item.post" ],
+      "modulePermissions" : [ "modperms.circulation.loans.item.post" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/circulation/loans",
+      "permissionsRequired" : [ "circulation.loans.collection.delete" ],
+      "modulePermissions" : [ "circulation-storage.loans.collection.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/circulation/loans/{id}",
+      "permissionsRequired" : [ "circulation.loans.item.get" ],
+      "modulePermissions" : [ "modperms.circulation.loans.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/circulation/loans/{id}",
+      "permissionsRequired" : [ "circulation.loans.item.put" ],
+      "modulePermissions" : [ "modperms.circulation.loans.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/circulation/loans/{id}",
+      "permissionsRequired" : [ "circulation.loans.item.delete" ],
+      "modulePermissions" : [ "circulation-storage.loans.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/circulation/requests",
+      "permissionsRequired" : [ "circulation.requests.collection.get" ],
+      "modulePermissions" : [ "modperms.circulation.requests.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/circulation/requests",
+      "permissionsRequired" : [ "circulation.requests.item.post" ],
+      "modulePermissions" : [ "modperms.circulation.requests.item.post" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/circulation/requests",
+      "permissionsRequired" : [ "circulation.requests.collection.delete" ],
+      "modulePermissions" : [ "circulation-storage.requests.collection.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/circulation/requests/{id}",
+      "permissionsRequired" : [ "circulation.requests.item.get" ],
+      "modulePermissions" : [ "modperms.circulation.requests.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/circulation/requests/{id}",
+      "permissionsRequired" : [ "circulation.requests.item.put" ],
+      "modulePermissions" : [ "modperms.circulation.requests.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/circulation/requests/{id}",
+      "permissionsRequired" : [ "circulation.requests.item.delete" ],
+      "modulePermissions" : [ "modperms.circulation.requests.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/circulation/requests/queue/{id}",
+      "permissionsRequired" : [ "circulation.requests.queue.collection.get" ],
+      "modulePermissions" : [ "modperms.circulation.requests.queue.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/circulation/requests/queue/{itemId}/reorder",
+      "permissionsRequired" : [ "circulation.requests.queue.reorder.collection.post" ],
+      "modulePermissions" : [ "modperms.circulation.requests.queue.reorder.collection.post" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/circulation/requests/instances",
+      "permissionsRequired" : [ "circulation.requests.instances.item.post" ],
+      "modulePermissions" : [ "modperms.circulation.requests.instances.item.post" ]
+    } ]
+  }, {
+    "id" : "circulation-rules",
+    "version" : "1.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/circulation/rules",
+      "permissionsRequired" : [ "circulation.rules.get" ],
+      "modulePermissions" : [ "circulation-storage.circulation-rules.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/circulation/rules",
+      "permissionsRequired" : [ "circulation.rules.put" ],
+      "modulePermissions" : [ "circulation-storage.circulation-rules.put" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/circulation/rules/loan-policy",
+      "permissionsRequired" : [ "circulation.rules.loan-policy.get" ],
+      "modulePermissions" : [ "circulation-storage.circulation-rules.get", "inventory-storage.locations.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/circulation/rules/loan-policy-all",
+      "permissionsRequired" : [ "circulation.rules.loan-policy-all.get" ],
+      "modulePermissions" : [ "circulation-storage.circulation-rules.get", "inventory-storage.locations.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/circulation/rules/overdue-fine-policy",
+      "permissionsRequired" : [ "circulation.rules.overdue-fine-policy.get" ],
+      "modulePermissions" : [ "circulation-storage.circulation-rules.get", "inventory-storage.locations.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/circulation/rules/overdue-fine-policy-all",
+      "permissionsRequired" : [ "circulation.rules.overdue-fine-policy-all.get" ],
+      "modulePermissions" : [ "circulation-storage.circulation-rules.get", "inventory-storage.locations.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/circulation/rules/lost-item-policy",
+      "permissionsRequired" : [ "circulation.rules.lost-item-policy.get" ],
+      "modulePermissions" : [ "circulation-storage.circulation-rules.get", "inventory-storage.locations.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/circulation/rules/lost-item-policy-all",
+      "permissionsRequired" : [ "circulation.rules.lost-item-all.get" ],
+      "modulePermissions" : [ "circulation-storage.circulation-rules.get", "inventory-storage.locations.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/circulation/rules/request-policy",
+      "permissionsRequired" : [ "circulation.rules.request-policy.get" ],
+      "modulePermissions" : [ "circulation-storage.circulation-rules.get", "inventory-storage.locations.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/circulation/rules/request-policy-all",
+      "permissionsRequired" : [ "circulation.rules.request-policy-all.get" ],
+      "modulePermissions" : [ "circulation-storage.circulation-rules.get", "inventory-storage.locations.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/circulation/rules/notice-policy",
+      "permissionsRequired" : [ "circulation.rules.notice-policy.get" ],
+      "modulePermissions" : [ "circulation-storage.circulation-rules.get", "inventory-storage.locations.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/circulation/rules/notice-policy-all",
+      "permissionsRequired" : [ "circulation.rules.notice-policy-all.get" ],
+      "modulePermissions" : [ "circulation-storage.circulation-rules.get", "inventory-storage.locations.item.get" ]
+    } ]
+  }, {
+    "id" : "patron-action-session",
+    "version" : "0.2",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/circulation/end-patron-action-session",
+      "permissionsRequired" : [ "circulation.end-patron-action-session.post" ],
+      "modulePermissions" : [ "patron-action-session-storage.patron-action-sessions.collection.get", "circulation-storage.loans.collection.get", "inventory-storage.items.collection.get", "inventory-storage.holdings.collection.get", "inventory-storage.instances.collection.get", "inventory-storage.locations.collection.get", "inventory-storage.location-units.libraries.collection.get", "inventory-storage.location-units.campuses.collection.get", "inventory-storage.location-units.institutions.collection.get", "inventory-storage.material-types.collection.get", "circulation-storage.loan-policies.collection.get", "users.item.get", "circulation.rules.notice-policy.get", "circulation-storage.patron-notice-policies.item.get", "patron-notice.post", "patron-action-session-storage.patron-action-sessions.item.delete" ]
+    } ]
+  }, {
+    "id" : "_timer",
+    "version" : "1.0",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/circulation/notice-session-expiration-by-timeout",
+      "unit" : "minute",
+      "delay" : "3",
+      "modulePermissions" : [ "patron-action-session-storage.expired-session-patron-ids.collection.get", "patron-action-session-storage.patron-action-sessions.collection.get", "circulation-storage.loans.collection.get", "inventory-storage.items.collection.get", "inventory-storage.holdings.collection.get", "inventory-storage.instances.collection.get", "inventory-storage.locations.collection.get", "inventory-storage.location-units.libraries.collection.get", "inventory-storage.location-units.campuses.collection.get", "inventory-storage.location-units.institutions.collection.get", "inventory-storage.material-types.collection.get", "circulation-storage.loan-policies.collection.get", "users.item.get", "users.collection.get", "circulation.rules.notice-policy.get", "circulation-storage.patron-notice-policies.item.get", "patron-notice.post", "patron-action-session-storage.patron-action-sessions.item.delete", "configuration.entries.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/circulation/due-date-scheduled-notices-processing",
+      "unit" : "minute",
+      "delay" : "5",
+      "modulePermissions" : [ "scheduled-notice-storage.scheduled-notices.collection.get", "scheduled-notice-storage.scheduled-notices.item.delete", "scheduled-notice-storage.scheduled-notices.item.put", "circulation-storage.loans.item.get", "circulation-storage.loan-policies.item.get", "circulation-storage.loan-policies.collection.get", "inventory-storage.items.item.get", "inventory-storage.locations.item.get", "inventory-storage.location-units.institutions.item.get", "inventory-storage.location-units.campuses.item.get", "inventory-storage.location-units.libraries.item.get", "inventory-storage.material-types.item.get", "inventory-storage.holdings.item.get", "inventory-storage.loan-types.item.get", "inventory-storage.service-points.item.get", "inventory-storage.instances.item.get", "circulation.rules.loan-policy.get", "configuration.entries.collection.get", "patron-notice.post", "users.item.get", "templates.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/circulation/due-date-not-real-time-scheduled-notices-processing",
+      "unit" : "minute",
+      "delay" : "2",
+      "modulePermissions" : [ "scheduled-notice-storage.scheduled-notices.collection.get", "scheduled-notice-storage.scheduled-notices.item.delete", "scheduled-notice-storage.scheduled-notices.item.put", "circulation-storage.loans.item.get", "circulation-storage.loan-policies.item.get", "circulation-storage.loan-policies.collection.get", "circulation-storage.fixed-due-date-schedules.collection.get", "inventory-storage.items.item.get", "inventory-storage.locations.item.get", "inventory-storage.location-units.institutions.item.get", "inventory-storage.location-units.campuses.item.get", "inventory-storage.location-units.libraries.item.get", "inventory-storage.material-types.item.get", "inventory-storage.holdings.item.get", "inventory-storage.loan-types.item.get", "inventory-storage.service-points.item.get", "inventory-storage.instances.item.get", "circulation.rules.loan-policy.get", "configuration.entries.collection.get", "patron-notice.post", "users.item.get", "templates.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/circulation/request-scheduled-notices-processing",
+      "unit" : "minute",
+      "delay" : "2",
+      "modulePermissions" : [ "scheduled-notice-storage.scheduled-notices.collection.get", "scheduled-notice-storage.scheduled-notices.item.delete", "scheduled-notice-storage.scheduled-notices.item.put", "inventory-storage.items.item.get", "inventory-storage.locations.item.get", "inventory-storage.location-units.institutions.item.get", "inventory-storage.location-units.campuses.item.get", "inventory-storage.location-units.libraries.item.get", "inventory-storage.material-types.item.get", "inventory-storage.holdings.item.get", "inventory-storage.loan-types.item.get", "inventory-storage.service-points.item.get", "inventory-storage.instances.item.get", "circulation-storage.loans.collection.get", "circulation-storage.requests.item.get", "patron-notice.post", "users.item.get", "usergroups.collection.get", "configuration.entries.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/circulation/fee-fine-scheduled-notices-processing",
+      "unit" : "minute",
+      "delay" : "2",
+      "modulePermissions" : [ "scheduled-notice-storage.scheduled-notices.item.get", "scheduled-notice-storage.scheduled-notices.collection.get", "scheduled-notice-storage.scheduled-notices.item.delete", "scheduled-notice-storage.scheduled-notices.item.put", "configuration.entries.item.get", "configuration.entries.collection.get", "patron-notice.post", "accounts.item.get", "accounts.collection.get", "feefineactions.item.get", "feefineactions.collection.get", "circulation-storage.loans.item.get", "circulation-storage.loans.collection.get", "inventory-storage.items.item.get", "inventory-storage.items.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.holdings.collection.get", "inventory-storage.instances.item.get", "inventory-storage.instances.collection.get", "inventory-storage.locations.item.get", "inventory-storage.locations.collection.get", "inventory-storage.location-units.libraries.item.get", "inventory-storage.location-units.libraries.collection.get", "inventory-storage.location-units.campuses.item.get", "inventory-storage.location-units.campuses.collection.get", "inventory-storage.location-units.institutions.item.get", "inventory-storage.location-units.institutions.collection.get", "inventory-storage.material-types.item.get", "inventory-storage.material-types.collection.get", "inventory-storage.service-points.item.get", "inventory-storage.service-points.collection.get", "inventory-storage.loan-types.item.get", "inventory-storage.loan-types.collection.get", "users.item.get", "users.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/circulation/scheduled-anonymize-processing",
+      "unit" : "minute",
+      "delay" : "1",
+      "modulePermissions" : [ "circulation-storage.loans.item.put", "circulation-storage.loans.item.get", "circulation-storage.loans.collection.get", "circulation.rules.loan-policy.get", "circulation.rules.request-policy.get", "circulation-storage.requests.collection.get", "circulation-storage.requests.item.put", "inventory-storage.items.item.put", "inventory-storage.items.item.get", "inventory-storage.items.collection.get", "inventory-storage.locations.item.get", "inventory-storage.locations.collection.get", "inventory-storage.location-units.institutions.item.get", "inventory-storage.location-units.campuses.item.get", "inventory-storage.location-units.libraries.item.get", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.instances.collection.get", "inventory-storage.instances.item.get", "inventory-storage.material-types.item.get", "inventory-storage.material-types.collection.get", "inventory-storage.service-points.collection.get", "inventory-storage.service-points.item.get", "inventory-storage.loan-types.item.get", "inventory.items.collection.get", "users.item.get", "users.collection.get", "proxiesfor.collection.get", "circulation-storage.loan-policies.item.get", "circulation-storage.loan-policies.collection.get", "circulation-storage.request-policies.item.get", "circulation-storage.fixed-due-date-schedules.item.get", "circulation-storage.fixed-due-date-schedules.collection.get", "configuration.entries.collection.get", "circulation.rules.notice-policy.get", "circulation-storage.patron-notice-policies.item.get", "scheduled-notice-storage.scheduled-notices.collection.delete", "scheduled-notice-storage.scheduled-notices.item.post", "patron-notice.post", "anonymize-storage-loans.post", "accounts.collection.get", "feefineactions.collection.get" ]
+    } ]
+  }, {
+    "id" : "circulation-event-handlers",
+    "version" : "0.1",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/circulation/handlers/loan-related-fee-fine-closed",
+      "permissionsRequired" : [ "circulation.events.post" ],
+      "modulePermissions" : [ "modperms.circulation.handlers.loan-related-fee-fine-closed.post" ]
+    } ]
+  }, {
+    "id" : "_tenant",
+    "version" : "1.0",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/_/tenant",
+      "modulePermissions" : [ "pubsub.event-types.post", "pubsub.publishers.post", "pubsub.subscribers.post" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/_/tenant",
+      "modulePermissions" : [ "pubsub.publishers.delete" ]
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "circulation.requests.queue.reorder.collection.post",
+    "displayName" : "circulation - reorder queue for an item",
+    "description" : "change request positions in queue for an item"
+  }, {
+    "permissionName" : "circulation.check-out-by-barcode.post",
+    "displayName" : "circulation - check out item by barcode",
+    "description" : "check out an item using barcodes for item and loanee"
+  }, {
+    "permissionName" : "circulation.override-check-out-by-barcode.post",
+    "displayName" : "circulation - override item checkout by barcode",
+    "description" : "override item check out using barcodes for item and loanee"
+  }, {
+    "permissionName" : "circulation.check-in-by-barcode.post",
+    "displayName" : "circulation - checkin loan by barcode",
+    "description" : "checkin a loan using barcodes for item and loanee"
+  }, {
+    "permissionName" : "circulation.renew-by-barcode.post",
+    "displayName" : "circulation - renew loan by barcode",
+    "description" : "renew a loan using barcodes for item and loanee"
+  }, {
+    "permissionName" : "circulation.renew-by-id.post",
+    "displayName" : "circulation - renew loan using id",
+    "description" : "renew a loan using IDs for item and loanee"
+  }, {
+    "permissionName" : "circulation.override-renewal-by-barcode.post",
+    "displayName" : "circulation - override renewal by barcode",
+    "description" : "override renewal using barcodes for item and loanee"
+  }, {
+    "permissionName" : "circulation.loans.collection.get",
+    "displayName" : "circulation - get loan collection",
+    "description" : "get loan collection"
+  }, {
+    "permissionName" : "circulation.loans.collection.delete",
+    "displayName" : "circulation - delete entire loan collection",
+    "description" : "delete entire loan collection"
+  }, {
+    "permissionName" : "circulation.loans.item.get",
+    "displayName" : "circulation - get individual loan",
+    "description" : "get individual loan"
+  }, {
+    "permissionName" : "circulation.loans.item.post",
+    "displayName" : "circulation - create individual loan",
+    "description" : "create individual loan"
+  }, {
+    "permissionName" : "circulation.loans.item.put",
+    "displayName" : "circulation - modify loan",
+    "description" : "modify individual loan"
+  }, {
+    "permissionName" : "circulation.loans.collection.anonymize.user.post",
+    "displayName" : "circulation - anonymize loans",
+    "description" : "anonymize loans"
+  }, {
+    "permissionName" : "circulation.loans.item.delete",
+    "displayName" : "circulation - delete individual loan",
+    "description" : "delete individual loan"
+  }, {
+    "permissionName" : "circulation.loans.declare-item-lost.post",
+    "displayName" : "circulation - declare the loaned item lost",
+    "description" : "declares the loaned item lost"
+  }, {
+    "permissionName" : "circulation.loans.change-due-date.post",
+    "displayName" : "circulation - change loan due date",
+    "description" : "changes the due date of the loan"
+  }, {
+    "permissionName" : "circulation.loans.claim-item-returned.post",
+    "displayName" : "circulation - declare the loaned item as claimed returned",
+    "description" : "declares the loaned item as claimed returned"
+  }, {
+    "permissionName" : "circulation.loans.declare-claimed-returned-item-as-missing.post",
+    "displayName" : "circulation -  declare the claimed returned loaned item as missing",
+    "description" : "declare the claimed returned loaned item as missing"
+  }, {
+    "permissionName" : "circulation.rules.get",
+    "displayName" : "Circulation - get circulation rules",
+    "description" : "Get circulation rules"
+  }, {
+    "permissionName" : "circulation.rules.put",
+    "displayName" : "Circulation - modify circulation rules",
+    "description" : "Modify circulation rules"
+  }, {
+    "permissionName" : "circulation.rules.loan-policy.get",
+    "displayName" : "Circulation - use circulation rules to get matching loan policy",
+    "description" : "Apply circulation rules to get matching loan policy"
+  }, {
+    "permissionName" : "circulation.rules.loan-policy-all.get",
+    "displayName" : "Circulation - use circulation rules to get all matching loan policies",
+    "description" : "Apply circulation rules to get all matching loan policies"
+  }, {
+    "permissionName" : "circulation.rules.request-policy.get",
+    "displayName" : "Circulation - use circulation rules to get matching request policy",
+    "description" : "Apply circulation rules to get matching request policy"
+  }, {
+    "permissionName" : "circulation.rules.request-policy-all.get",
+    "displayName" : "Circulation - use circulation rules to get all matching request policies",
+    "description" : "Apply circulation rules to get all matching request policies"
+  }, {
+    "permissionName" : "circulation.rules.notice-policy.get",
+    "displayName" : "Circulation - use circulation rules to get matching notice policy",
+    "description" : "Apply circulation rules to get matching notice policy"
+  }, {
+    "permissionName" : "circulation.rules.notice-policy-all.get",
+    "displayName" : "Circulation - use circulation rules to get all matching notice policies",
+    "description" : "Apply circulation rules to get all matching notice policies"
+  }, {
+    "permissionName" : "circulation.requests.collection.get",
+    "displayName" : "circulation - get request collection",
+    "description" : "get request collection"
+  }, {
+    "permissionName" : "circulation.requests.collection.delete",
+    "displayName" : "circulation - delete entire request collection",
+    "description" : "delete entire request collection"
+  }, {
+    "permissionName" : "circulation.requests.item.get",
+    "displayName" : "circulation - get individual request",
+    "description" : "get individual request"
+  }, {
+    "permissionName" : "circulation.requests.item.post",
+    "displayName" : "circulation - create individual requests",
+    "description" : "create individual request"
+  }, {
+    "permissionName" : "circulation.requests.item.put",
+    "displayName" : "circulation - modify request",
+    "description" : "modify individual request"
+  }, {
+    "permissionName" : "circulation.requests.item.delete",
+    "displayName" : "circulation - delete individual request",
+    "description" : "delete individual request"
+  }, {
+    "permissionName" : "circulation.requests.item.move.post",
+    "displayName" : "circulation - move individual requests to another item",
+    "description" : "move individual request to another item"
+  }, {
+    "permissionName" : "circulation.requests.queue.collection.get",
+    "displayName" : "circulation - request queue for an item",
+    "description" : "get request queue for an item"
+  }, {
+    "permissionName" : "circulation.requests.instances.item.post",
+    "displayName" : "circulation - create instance level request",
+    "description" : "create a request given an instance"
+  }, {
+    "permissionName" : "circulation.requests.hold-shelf-clearance-report.get",
+    "displayName" : "circulation - request hold shelf clearance report",
+    "description" : "get all hold shelf clearance requests to generating a report"
+  }, {
+    "permissionName" : "circulation.inventory.items-in-transit-report.get",
+    "displayName" : "circulation - items in transit report",
+    "description" : "get all items in transit to generating a report"
+  }, {
+    "permissionName" : "circulation.pick-slips.get",
+    "displayName" : "circulation - pick slips",
+    "description" : "get items for pick slips generation"
+  }, {
+    "permissionName" : "circulation.end-patron-action-session.post",
+    "displayName" : "circulation - end patron action session",
+    "description" : "end patron action session"
+  }, {
+    "permissionName" : "circulation.events.post",
+    "displayName" : "Circulation - post event",
+    "description" : "Post event to handle in circulation"
+  }, {
+    "permissionName" : "circulation.all",
+    "displayName" : "circulation - all permissions",
+    "description" : "Entire set of permissions needed to use the circulation",
+    "subPermissions" : [ "circulation.check-out-by-barcode.post", "circulation.override-check-out-by-barcode.post", "circulation.check-in-by-barcode.post", "circulation.renew-by-barcode.post", "circulation.renew-by-id.post", "circulation.override-renewal-by-barcode.post", "circulation.loans.collection.get", "circulation.loans.item.get", "circulation.loans.item.post", "circulation.loans.item.put", "circulation.loans.item.delete", "circulation.loans.collection.delete", "circulation.loans.change-due-date.post", "circulation.loans.claim-item-returned.post", "circulation.loans.declare-claimed-returned-item-as-missing.post", "circulation.rules.put", "circulation.rules.get", "circulation.rules.loan-policy.get", "circulation.rules.loan-policy-all.get", "circulation.rules.request-policy.get", "circulation.rules.request-policy-all.get", "circulation.rules.notice-policy.get", "circulation.rules.notice-policy-all.get", "circulation.requests.collection.get", "circulation.requests.item.get", "circulation.requests.item.post", "circulation.requests.item.put", "circulation.requests.item.delete", "circulation.requests.item.move.post", "circulation.requests.collection.delete", "circulation.requests.queue.collection.get", "circulation.requests.queue.reorder.collection.post", "circulation.requests.instances.item.post", "circulation.requests.hold-shelf-clearance-report.get", "circulation.inventory.items-in-transit-report.get", "circulation.pick-slips.get" ]
+  }, {
+    "permissionName" : "modperms.circulation.requests.hold-shelf-clearance-report.get",
+    "displayName" : "module permissions for one op",
+    "description" : "to reduce X-Okapi-Token size",
+    "subPermissions" : [ "inventory-storage.items.item.get", "inventory-storage.items.collection.get", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.instances.collection.get", "inventory-storage.instances.item.get", "inventory-storage.service-points.collection.get", "inventory-storage.service-points.item.get", "circulation-storage.requests.item.get", "circulation-storage.requests.collection.get", "users.collection.get", "users.item.get" ],
+    "visible" : false
+  }, {
+    "permissionName" : "modperms.circulation.handlers.loan-related-fee-fine-closed.post",
+    "displayName" : "module permissions for one op",
+    "description" : "to reduce X-Okapi-Token size",
+    "subPermissions" : [ "circulation-storage.loans.item.get", "circulation-storage.loans.item.put", "inventory-storage.items.item.get", "inventory-storage.items.item.put", "inventory-storage.holdings.item.get", "inventory-storage.instances.item.get", "inventory-storage.locations.item.get", "inventory-storage.location-units.libraries.item.get", "inventory-storage.location-units.campuses.item.get", "inventory-storage.location-units.institutions.item.get", "inventory-storage.service-points.item.get", "inventory-storage.material-types.item.get", "inventory-storage.loan-types.item.get", "inventory-storage.service-points.item.get", "lost-item-fees-policies.item.get", "accounts.collection.get", "users.item.get" ],
+    "visible" : false
+  }, {
+    "permissionName" : "modperms.circulation.requests.item.move.post",
+    "displayName" : "module permissions for one op",
+    "description" : "to reduce X-Okapi-Token size",
+    "subPermissions" : [ "circulation-storage.requests.item.put", "circulation-storage.requests.item.post", "circulation-storage.request-batch.item.post", "inventory-storage.items.item.put", "circulation-storage.requests.collection.get", "circulation-storage.requests.item.get", "circulation-storage.loans.item.put", "circulation-storage.loans.collection.get", "circulation-storage.request-policies.item.get", "inventory-storage.items.item.get", "inventory-storage.items.collection.get", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.instances.collection.get", "inventory-storage.instances.item.get", "inventory-storage.locations.collection.get", "inventory-storage.locations.item.get", "inventory-storage.location-units.institutions.item.get", "inventory-storage.location-units.campuses.item.get", "inventory-storage.location-units.libraries.item.get", "inventory-storage.location-units.libraries.collection.get", "inventory-storage.service-points.collection.get", "inventory-storage.service-points.item.get", "users.item.get", "users.collection.get", "usergroups.collection.get", "usergroups.item.get", "proxiesfor.collection.get", "circulation.rules.notice-policy.get", "circulation-storage.patron-notice-policies.item.get", "patron-notice.post", "circulation-storage.cancellation-reasons.item.get", "inventory-storage.loan-types.item.get", "configuration.entries.collection.get", "calendar.opening-hours.collection.get", "circulation.internal.apply-rules", "pubsub.publish.post" ],
+    "visible" : false
+  }, {
+    "permissionName" : "modperms.circulation.check-out-by-barcode.post",
+    "displayName" : "module permissions for one op",
+    "description" : "to reduce X-Okapi-Token size",
+    "subPermissions" : [ "circulation-storage.loans.item.post", "calendar.opening-hours.collection.get", "circulation-storage.loans.item.get", "circulation-storage.loans.collection.get", "circulation-storage.request-batch.item.post", "circulation.rules.loan-policy.get", "circulation.rules.request-policy.get", "circulation-storage.requests.collection.get", "circulation-storage.requests.item.put", "inventory-storage.items.item.put", "inventory-storage.items.item.get", "inventory-storage.items.collection.get", "inventory-storage.locations.item.get", "inventory-storage.locations.collection.get", "inventory-storage.location-units.institutions.item.get", "inventory-storage.location-units.campuses.item.get", "inventory-storage.location-units.libraries.item.get", "inventory-storage.location-units.libraries.collection.get", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.instances.collection.get", "inventory-storage.instances.item.get", "inventory-storage.service-points.collection.get", "inventory-storage.service-points.item.get", "users.item.get", "proxiesfor.collection.get", "inventory-storage.material-types.item.get", "inventory-storage.material-types.collection.get", "circulation-storage.loan-policies.item.get", "circulation-storage.loan-policies.collection.get", "circulation-storage.request-policies.item.get", "circulation-storage.fixed-due-date-schedules.item.get", "circulation-storage.fixed-due-date-schedules.collection.get", "configuration.entries.collection.get", "users.collection.get", "inventory-storage.loan-types.item.get", "scheduled-notice-storage.scheduled-notices.item.post", "usergroups.collection.get", "usergroups.item.get", "patron-action-session-storage.patron-action-sessions.item.post", "circulation.rules.overdue-fine-policy.get", "circulation.rules.lost-item-policy.get", "overdue-fines-policies.item.get", "overdue-fines-policies.collection.get", "lost-item-fees-policies.item.get", "lost-item-fees-policies.collection.get", "pubsub.publish.post" ],
+    "visible" : false
+  }, {
+    "permissionName" : "modperms.circulation.override-check-out-by-barcode.post",
+    "displayName" : "module permissions for one op",
+    "description" : "to reduce X-Okapi-Token size",
+    "subPermissions" : [ "circulation-storage.loans.item.post", "circulation-storage.loans.item.get", "circulation-storage.loans.collection.get", "circulation.rules.loan-policy.get", "circulation.rules.request-policy.get", "circulation.rules.overdue-fine-policy.get", "lost-item-fees-policies.collection.get", "circulation-storage.requests.collection.get", "circulation-storage.requests.item.put", "circulation-storage.request-batch.item.post", "inventory-storage.items.item.put", "inventory-storage.items.item.get", "inventory-storage.items.collection.get", "inventory-storage.locations.item.get", "inventory-storage.locations.collection.get", "inventory-storage.location-units.institutions.item.get", "inventory-storage.location-units.campuses.item.get", "inventory-storage.location-units.libraries.item.get", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.instances.collection.get", "inventory-storage.instances.item.get", "inventory-storage.service-points.collection.get", "inventory-storage.service-points.item.get", "users.item.get", "proxiesfor.collection.get", "inventory-storage.material-types.item.get", "inventory-storage.material-types.collection.get", "circulation-storage.loan-policies.item.get", "circulation-storage.loan-policies.collection.get", "circulation-storage.request-policies.item.get", "circulation-storage.fixed-due-date-schedules.item.get", "circulation-storage.fixed-due-date-schedules.collection.get", "circulation-storage.patron-notice-policies.item.get", "patron-notice.post", "circulation.rules.notice-policy.get", "circulation.rules.lost-item-policy.get", "lost-item-fees-policies.item.get", "overdue-fines-policies.item.get", "configuration.entries.collection.get", "users.collection.get", "inventory-storage.loan-types.item.get", "scheduled-notice-storage.scheduled-notices.item.post", "usergroups.collection.get", "usergroups.item.get", "automated-patron-blocks.collection.get", "accounts.collection.get", "feefineactions.collection.get", "feefineactions.item.post", "accounts.item.put", "pubsub.publish.post" ],
+    "visible" : false
+  }, {
+    "permissionName" : "modperms.circulation.check-in-by-barcode.post",
+    "displayName" : "module permissions for one op",
+    "description" : "to reduce X-Okapi-Token size",
+    "subPermissions" : [ "circulation-storage.loans.item.put", "circulation-storage.loans.item.get", "circulation-storage.loans.collection.get", "circulation.rules.loan-policy.get", "circulation.rules.request-policy.get", "circulation-storage.requests.collection.get", "circulation-storage.requests.item.put", "inventory-storage.items.item.put", "inventory-storage.items.item.get", "inventory-storage.items.collection.get", "inventory-storage.locations.item.get", "inventory-storage.locations.collection.get", "inventory-storage.location-units.institutions.collection.get", "inventory-storage.location-units.institutions.item.get", "inventory-storage.location-units.campuses.collection.get", "inventory-storage.location-units.campuses.item.get", "inventory-storage.location-units.libraries.collection.get", "inventory-storage.location-units.libraries.item.get", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.instances.collection.get", "inventory-storage.instances.item.get", "inventory-storage.material-types.item.get", "inventory-storage.material-types.collection.get", "inventory-storage.service-points.collection.get", "inventory-storage.service-points.item.get", "users.item.get", "users.collection.get", "addresstypes.item.get", "proxiesfor.collection.get", "circulation-storage.loan-policies.item.get", "circulation-storage.loan-policies.collection.get", "circulation-storage.request-policies.item.get", "circulation-storage.fixed-due-date-schedules.item.get", "circulation-storage.fixed-due-date-schedules.collection.get", "circulation-storage.patron-notice-policies.item.get", "patron-notice.post", "circulation.rules.notice-policy.get", "inventory-storage.loan-types.item.get", "patron-action-session-storage.patron-action-sessions.item.post", "feefines.collection.get", "feefines.item.post", "owners.collection.get", "accounts.item.post", "check-in-storage.check-ins.item.post", "overdue-fines-policies.item.get", "lost-item-fees-policies.item.get", "accounts.collection.get", "feefineactions.collection.get", "feefineactions.item.post", "accounts.item.put", "pubsub.publish.post", "scheduled-notice-storage.scheduled-notices.item.delete" ],
+    "visible" : false
+  }, {
+    "permissionName" : "modperms.circulation.renew-by-barcode.post",
+    "displayName" : "module permissions for one op",
+    "description" : "to reduce X-Okapi-Token size",
+    "subPermissions" : [ "circulation-storage.loans.item.put", "circulation-storage.loans.item.get", "circulation-storage.loans.collection.get", "circulation.rules.loan-policy.get", "circulation.rules.request-policy.get", "circulation-storage.requests.collection.get", "circulation-storage.requests.item.put", "inventory-storage.items.item.put", "inventory-storage.items.item.get", "inventory-storage.items.collection.get", "inventory-storage.locations.item.get", "inventory-storage.locations.collection.get", "inventory-storage.location-units.institutions.item.get", "inventory-storage.location-units.campuses.item.get", "inventory-storage.location-units.libraries.item.get", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.instances.collection.get", "inventory-storage.instances.item.get", "inventory-storage.material-types.item.get", "inventory-storage.material-types.collection.get", "inventory-storage.service-points.collection.get", "inventory-storage.service-points.item.get", "inventory-storage.loan-types.item.get", "users.item.get", "users.collection.get", "proxiesfor.collection.get", "circulation-storage.loan-policies.item.get", "circulation-storage.loan-policies.collection.get", "circulation-storage.request-policies.item.get", "circulation-storage.fixed-due-date-schedules.item.get", "circulation-storage.fixed-due-date-schedules.collection.get", "calendar.opening-hours.collection.get", "configuration.entries.collection.get", "circulation.rules.notice-policy.get", "circulation-storage.patron-notice-policies.item.get", "scheduled-notice-storage.scheduled-notices.collection.delete", "scheduled-notice-storage.scheduled-notices.item.post", "patron-notice.post", "feefines.collection.get", "feefines.item.post", "owners.collection.get", "accounts.item.post", "pubsub.publish.post", "automated-patron-blocks.collection.get", "scheduled-notice-storage.scheduled-notices.item.delete", "overdue-fines-policies.item.get", "lost-item-fees-policies.item.get" ],
+    "visible" : false
+  }, {
+    "permissionName" : "modperms.circulation.override-renewal-by-barcode.post",
+    "displayName" : "module permissions for one op",
+    "description" : "to reduce X-Okapi-Token size",
+    "subPermissions" : [ "circulation-storage.loans.item.put", "circulation-storage.loans.item.get", "circulation-storage.loans.collection.get", "circulation.rules.loan-policy.get", "circulation.rules.request-policy.get", "circulation-storage.requests.collection.get", "circulation-storage.requests.item.put", "inventory-storage.items.item.put", "inventory-storage.items.item.get", "inventory-storage.items.collection.get", "inventory-storage.locations.item.get", "inventory-storage.locations.collection.get", "inventory-storage.location-units.institutions.item.get", "inventory-storage.location-units.campuses.item.get", "inventory-storage.location-units.libraries.item.get", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.instances.collection.get", "inventory-storage.instances.item.get", "inventory-storage.material-types.item.get", "inventory-storage.material-types.collection.get", "inventory-storage.service-points.collection.get", "inventory-storage.service-points.item.get", "inventory-storage.loan-types.item.get", "users.item.get", "users.collection.get", "proxiesfor.collection.get", "circulation-storage.loan-policies.item.get", "circulation-storage.loan-policies.collection.get", "circulation-storage.request-policies.item.get", "circulation-storage.fixed-due-date-schedules.item.get", "circulation-storage.fixed-due-date-schedules.collection.get", "configuration.entries.collection.get", "circulation.rules.notice-policy.get", "circulation-storage.patron-notice-policies.item.get", "scheduled-notice-storage.scheduled-notices.collection.delete", "scheduled-notice-storage.scheduled-notices.item.post", "patron-notice.post", "automated-patron-blocks.collection.get", "overdue-fines-policies.item.get", "lost-item-fees-policies.item.get" ],
+    "visible" : false
+  }, {
+    "permissionName" : "modperms.circulation.loans.anonymize",
+    "displayName" : "module permissions for one op",
+    "description" : "to reduce X-Okapi-Token size",
+    "subPermissions" : [ "circulation-storage.loans.item.put", "circulation-storage.loans.item.get", "circulation-storage.loans.collection.get", "circulation.rules.loan-policy.get", "circulation.rules.request-policy.get", "circulation-storage.requests.collection.get", "circulation-storage.requests.item.put", "inventory-storage.items.item.put", "inventory-storage.items.item.get", "inventory-storage.items.collection.get", "inventory-storage.locations.item.get", "inventory-storage.locations.collection.get", "inventory-storage.location-units.institutions.item.get", "inventory-storage.location-units.campuses.item.get", "inventory-storage.location-units.libraries.item.get", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.instances.collection.get", "inventory-storage.instances.item.get", "inventory-storage.material-types.item.get", "inventory-storage.material-types.collection.get", "inventory-storage.service-points.collection.get", "inventory-storage.service-points.item.get", "inventory-storage.loan-types.item.get", "users.item.get", "users.collection.get", "proxiesfor.collection.get", "circulation-storage.loan-policies.item.get", "circulation-storage.loan-policies.collection.get", "circulation-storage.request-policies.item.get", "circulation-storage.fixed-due-date-schedules.item.get", "circulation-storage.fixed-due-date-schedules.collection.get", "configuration.entries.collection.get", "circulation.rules.notice-policy.get", "circulation-storage.patron-notice-policies.item.get", "scheduled-notice-storage.scheduled-notices.collection.delete", "scheduled-notice-storage.scheduled-notices.item.post", "patron-notice.post", "anonymize-storage-loans.post", "feefineactions.collection.get" ],
+    "visible" : false
+  }, {
+    "permissionName" : "modperms.circulation.renew-by-id.post",
+    "displayName" : "module permissions for one op",
+    "description" : "to reduce X-Okapi-Token size",
+    "subPermissions" : [ "circulation-storage.loans.item.put", "circulation-storage.loans.item.get", "circulation-storage.loans.collection.get", "circulation.rules.loan-policy.get", "circulation.rules.request-policy.get", "circulation-storage.requests.collection.get", "circulation-storage.requests.item.put", "inventory-storage.items.item.put", "inventory-storage.items.item.get", "inventory-storage.items.collection.get", "inventory-storage.locations.item.get", "inventory-storage.locations.collection.get", "inventory-storage.location-units.institutions.item.get", "inventory-storage.location-units.campuses.item.get", "inventory-storage.location-units.libraries.item.get", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.instances.collection.get", "inventory-storage.instances.item.get", "inventory-storage.material-types.item.get", "inventory-storage.material-types.collection.get", "inventory-storage.service-points.collection.get", "inventory-storage.service-points.item.get", "inventory-storage.loan-types.item.get", "users.item.get", "users.collection.get", "proxiesfor.collection.get", "circulation-storage.loan-policies.item.get", "circulation-storage.loan-policies.collection.get", "circulation-storage.request-policies.item.get", "circulation-storage.fixed-due-date-schedules.item.get", "circulation-storage.fixed-due-date-schedules.collection.get", "calendar.opening-hours.collection.get", "configuration.entries.collection.get", "circulation.rules.notice-policy.get", "circulation-storage.patron-notice-policies.item.get", "scheduled-notice-storage.scheduled-notices.collection.delete", "scheduled-notice-storage.scheduled-notices.item.post", "patron-notice.post", "feefines.collection.get", "feefines.item.post", "owners.collection.get", "accounts.item.post", "pubsub.publish.post", "scheduled-notice-storage.scheduled-notices.item.delete" ],
+    "visible" : false
+  }, {
+    "permissionName" : "modperms.circulation.loans.item.post",
+    "displayName" : "module permissions for one op",
+    "description" : "to reduce X-Okapi-Token size",
+    "subPermissions" : [ "circulation-storage.loans.item.post", "circulation-storage.loans.item.get", "circulation-storage.loans.collection.get", "circulation.rules.loan-policy.get", "circulation.rules.request-policy.get", "circulation-storage.requests.collection.get", "circulation-storage.requests.item.put", "inventory-storage.items.item.put", "inventory-storage.items.item.get", "inventory-storage.items.collection.get", "inventory-storage.locations.item.get", "inventory-storage.locations.collection.get", "inventory-storage.location-units.institutions.item.get", "inventory-storage.location-units.campuses.item.get", "inventory-storage.location-units.libraries.item.get", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.instances.collection.get", "inventory-storage.instances.item.get", "inventory-storage.material-types.collection.get", "inventory-storage.material-types.item.get", "inventory-storage.service-points.collection.get", "inventory-storage.service-points.item.get", "users.item.get", "proxiesfor.collection.get", "inventory-storage.material-types.item.get", "circulation-storage.loan-policies.item.get", "circulation-storage.loan-policies.collection.get", "circulation-storage.request-policies.item.get", "circulation-storage.fixed-due-date-schedules.item.get", "circulation-storage.fixed-due-date-schedules.collection.get", "pubsub.publish.post" ],
+    "visible" : false
+  }, {
+    "permissionName" : "modperms.circulation.loans.collection.get",
+    "displayName" : "module permissions for one op",
+    "description" : "to reduce X-Okapi-Token size",
+    "subPermissions" : [ "circulation-storage.loans.collection.get", "circulation-storage.loan-policies.item.get", "circulation-storage.loan-policies.collection.get", "inventory-storage.items.item.get", "inventory-storage.items.collection.get", "inventory-storage.locations.item.get", "inventory-storage.locations.collection.get", "inventory-storage.location-units.institutions.item.get", "inventory-storage.location-units.campuses.item.get", "inventory-storage.location-units.libraries.item.get", "inventory-storage.location-units.libraries.collection.get", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.instances.collection.get", "inventory-storage.instances.item.get", "inventory-storage.material-types.collection.get", "inventory-storage.material-types.item.get", "inventory-storage.service-points.collection.get", "inventory-storage.service-points.item.get", "users.collection.get", "users.item.get", "inventory-storage.locations.collection.get", "accounts.collection.get", "usergroups.collection.get", "usergroups.item.get", "feefineactions.collection.get", "feefineactions.item.get", "overdue-fines-policies.collection.get", "lost-item-fees-policies.collection.get" ],
+    "visible" : false
+  }, {
+    "permissionName" : "modperms.circulation.loans.item.get",
+    "displayName" : "module permissions for one op",
+    "description" : "to reduce X-Okapi-Token size",
+    "subPermissions" : [ "circulation-storage.loans.item.get", "circulation-storage.loan-policies.item.get", "circulation-storage.loan-policies.collection.get", "inventory-storage.items.item.get", "inventory-storage.items.collection.get", "inventory-storage.locations.item.get", "inventory-storage.locations.collection.get", "inventory-storage.location-units.institutions.item.get", "inventory-storage.location-units.campuses.item.get", "inventory-storage.location-units.libraries.item.get", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.instances.collection.get", "inventory-storage.instances.item.get", "inventory-storage.material-types.collection.get", "inventory-storage.material-types.item.get", "inventory-storage.service-points.collection.get", "inventory-storage.service-points.item.get", "accounts.collection.get", "usergroups.collection.get", "usergroups.item.get", "overdue-fines-policies.collection.get", "lost-item-fees-policies.collection.get" ],
+    "visible" : false
+  }, {
+    "permissionName" : "modperms.circulation.requests.collection.get",
+    "displayName" : "module permissions for one op",
+    "description" : "to reduce X-Okapi-Token size",
+    "subPermissions" : [ "circulation-storage.requests.item.get", "circulation-storage.requests.collection.get", "circulation-storage.loans.collection.get", "circulation-storage.loans.item.get", "inventory-storage.items.collection.get", "inventory-storage.items.item.get", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.instances.collection.get", "inventory-storage.instances.item.get", "inventory-storage.locations.collection.get", "inventory-storage.locations.item.get", "inventory-storage.location-units.institutions.item.get", "inventory-storage.location-units.campuses.item.get", "inventory-storage.location-units.libraries.item.get", "inventory-storage.service-points.collection.get", "inventory-storage.service-points.item.get", "users.item.get", "users.collection.get", "usergroups.collection.get", "usergroups.item.get", "inventory-storage.location-units.libraries.collection.get" ],
+    "visible" : false
+  }, {
+    "permissionName" : "modperms.circulation.requests.item.post",
+    "displayName" : "module permissions for one op",
+    "description" : "to reduce X-Okapi-Token size",
+    "subPermissions" : [ "circulation.rules.loan-policy.get", "circulation-storage.requests.item.post", "inventory-storage.items.item.put", "circulation-storage.requests.collection.get", "circulation-storage.requests.item.get", "circulation-storage.request-batch.item.post", "circulation-storage.loans.item.put", "circulation-storage.loans.collection.get", "circulation-storage.loans.item.get", "circulation-storage.loan-policies.item.get", "inventory-storage.items.item.get", "inventory-storage.items.collection.get", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.instances.collection.get", "inventory-storage.instances.item.get", "inventory-storage.locations.collection.get", "inventory-storage.locations.item.get", "inventory-storage.location-units.institutions.item.get", "inventory-storage.location-units.campuses.item.get", "inventory-storage.location-units.libraries.item.get", "inventory-storage.location-units.libraries.collection.get", "inventory-storage.material-types.collection.get", "inventory-storage.material-types.item.get", "inventory-storage.service-points.collection.get", "inventory-storage.service-points.item.get", "users.item.get", "users.collection.get", "usergroups.collection.get", "usergroups.item.get", "proxiesfor.collection.get", "circulation.rules.notice-policy.get", "circulation-storage.patron-notice-policies.item.get", "circulation.rules.request-policy.get", "circulation-storage.request-policies.item.get", "circulation-storage.requests.item.put", "patron-notice.post", "inventory-storage.loan-types.item.get", "calendar.opening-hours.collection.get", "scheduled-notice-storage.scheduled-notices.collection.delete", "scheduled-notice-storage.scheduled-notices.item.post", "configuration.entries.collection.get", "manualblocks.collection.get", "pubsub.publish.post", "automated-patron-blocks.collection.get" ],
+    "visible" : false
+  }, {
+    "permissionName" : "modperms.circulation.requests.item.get",
+    "displayName" : "module permissions for one op",
+    "description" : "to reduce X-Okapi-Token size",
+    "subPermissions" : [ "circulation-storage.requests.item.get", "circulation-storage.requests.collection.get", "circulation-storage.loans.collection.get", "circulation-storage.loans.item.get", "inventory-storage.items.collection.get", "inventory-storage.items.item.get", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.instances.collection.get", "inventory-storage.instances.item.get", "inventory-storage.locations.collection.get", "inventory-storage.locations.item.get", "inventory-storage.location-units.institutions.item.get", "inventory-storage.location-units.campuses.item.get", "inventory-storage.location-units.libraries.item.get", "inventory-storage.service-points.collection.get", "inventory-storage.service-points.item.get", "users.item.get", "users.collection.get", "usergroups.collection.get", "usergroups.item.get", "inventory-storage.location-units.libraries.collection.get" ],
+    "visible" : false
+  }, {
+    "permissionName" : "modperms.circulation.requests.item.delete",
+    "displayName" : "module permissions for one op",
+    "description" : "to reduce X-Okapi-Token size",
+    "subPermissions" : [ "circulation-storage.requests.item.get", "circulation-storage.requests.collection.get", "circulation-storage.loans.collection.get", "circulation-storage.loans.item.get", "inventory-storage.items.collection.get", "inventory-storage.items.item.get", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.instances.collection.get", "inventory-storage.instances.item.get", "inventory-storage.locations.collection.get", "inventory-storage.locations.item.get", "inventory-storage.location-units.institutions.item.get", "inventory-storage.location-units.campuses.item.get", "inventory-storage.location-units.libraries.item.get", "inventory-storage.service-points.collection.get", "inventory-storage.service-points.item.get", "users.item.get", "users.collection.get", "usergroups.collection.get", "usergroups.item.get", "inventory-storage.location-units.libraries.collection.get", "circulation-storage.requests.item.delete", "circulation-storage.request-batch.item.post" ],
+    "visible" : false
+  }, {
+    "permissionName" : "modperms.circulation.requests.item.put",
+    "displayName" : "module permissions for one op",
+    "description" : "to reduce X-Okapi-Token size",
+    "subPermissions" : [ "calendar.opening-hours.collection.get", "circulation.rules.loan-policy.get", "circulation.rules.request-policy.get", "circulation-storage.requests.item.put", "circulation-storage.requests.item.post", "circulation-storage.request-batch.item.post", "inventory-storage.items.item.put", "circulation-storage.request-policies.item.get", "circulation-storage.requests.collection.get", "circulation-storage.requests.item.get", "circulation-storage.loan-policies.item.get", "circulation-storage.loans.item.get", "circulation-storage.loans.item.put", "circulation-storage.loans.collection.get", "inventory-storage.items.item.get", "inventory-storage.items.collection.get", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.instances.collection.get", "inventory-storage.instances.item.get", "inventory-storage.locations.collection.get", "inventory-storage.locations.item.get", "inventory-storage.location-units.institutions.item.get", "inventory-storage.location-units.campuses.item.get", "inventory-storage.location-units.libraries.item.get", "inventory-storage.location-units.libraries.collection.get", "inventory-storage.material-types.collection.get", "inventory-storage.material-types.item.get", "inventory-storage.service-points.collection.get", "inventory-storage.service-points.item.get", "users.item.get", "users.collection.get", "usergroups.collection.get", "usergroups.item.get", "proxiesfor.collection.get", "circulation.rules.notice-policy.get", "circulation-storage.patron-notice-policies.item.get", "patron-notice.post", "circulation-storage.cancellation-reasons.item.get", "inventory-storage.loan-types.item.get", "configuration.entries.collection.get", "scheduled-notice-storage.scheduled-notices.collection.delete", "scheduled-notice-storage.scheduled-notices.item.post", "pubsub.publish.post" ],
+    "visible" : false
+  }, {
+    "permissionName" : "modperms.circulation.requests.queue.collection.get",
+    "displayName" : "module permissions for one op",
+    "description" : "to reduce X-Okapi-Token size",
+    "subPermissions" : [ "circulation-storage.requests.item.get", "circulation-storage.requests.collection.get", "circulation-storage.loans.collection.get", "circulation-storage.loans.item.get", "inventory-storage.items.collection.get", "inventory-storage.items.item.get", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.instances.collection.get", "inventory-storage.instances.item.get", "inventory-storage.locations.collection.get", "inventory-storage.locations.item.get", "inventory-storage.location-units.institutions.item.get", "inventory-storage.location-units.campuses.item.get", "inventory-storage.location-units.libraries.item.get", "inventory-storage.service-points.collection.get", "inventory-storage.service-points.item.get", "users.item.get", "users.collection.get", "usergroups.collection.get", "usergroups.item.get" ],
+    "visible" : false
+  }, {
+    "permissionName" : "modperms.circulation.requests.queue.reorder.collection.post",
+    "displayName" : "module permissions for one op",
+    "description" : "to reduce X-Okapi-Token size",
+    "subPermissions" : [ "circulation-storage.requests.item.get", "circulation-storage.request-batch.item.post", "circulation-storage.requests.collection.get", "circulation-storage.loans.collection.get", "circulation-storage.loans.item.get", "inventory-storage.items.collection.get", "inventory-storage.items.item.get", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.instances.collection.get", "inventory-storage.instances.item.get", "inventory-storage.locations.collection.get", "inventory-storage.locations.item.get", "inventory-storage.location-units.institutions.item.get", "inventory-storage.location-units.campuses.item.get", "inventory-storage.location-units.libraries.item.get", "inventory-storage.location-units.libraries.collection.get", "inventory-storage.service-points.collection.get", "inventory-storage.service-points.item.get", "users.item.get", "users.collection.get", "usergroups.collection.get", "usergroups.item.get" ],
+    "visible" : false
+  }, {
+    "permissionName" : "modperms.circulation.requests.instances.item.post",
+    "displayName" : "module permissions for one op",
+    "description" : "to reduce X-Okapi-Token size",
+    "subPermissions" : [ "circulation.rules.loan-policy.get", "circulation.rules.request-policy.get", "circulation-storage.request-policies.item.get", "circulation-storage.requests.item.post", "circulation-storage.requests.item.put", "inventory-storage.items.item.put", "circulation-storage.requests.collection.get", "circulation-storage.requests.item.get", "circulation-storage.loan-policies.item.get", "circulation-storage.loans.item.get", "circulation-storage.loans.item.put", "circulation-storage.loans.collection.get", "inventory-storage.items.item.get", "inventory-storage.items.collection.get", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.instances.collection.get", "inventory-storage.instances.item.get", "inventory-storage.locations.collection.get", "inventory-storage.locations.item.get", "inventory-storage.location-units.institutions.item.get", "inventory-storage.location-units.campuses.item.get", "inventory-storage.location-units.libraries.collection.get", "inventory-storage.location-units.libraries.item.get", "inventory-storage.material-types.collection.get", "inventory-storage.material-types.item.get", "inventory-storage.service-points.collection.get", "inventory-storage.service-points.item.get", "users.item.get", "users.collection.get", "usergroups.collection.get", "usergroups.item.get", "proxiesfor.collection.get", "circulation.rules.notice-policy.get", "circulation-storage.patron-notice-policies.item.get", "patron-notice.post", "inventory-storage.loan-types.item.get", "calendar.opening-hours.collection.get", "configuration.entries.collection.get", "scheduled-notice-storage.scheduled-notices.collection.delete", "scheduled-notice-storage.scheduled-notices.item.post", "manualblocks.collection.get", "automated-patron-blocks.collection.get", "circulation-storage.request-batch.item.post" ],
+    "visible" : false
+  }, {
+    "permissionName" : "modperms.circulation.loans.declare-item-lost.post",
+    "displayName" : "module permissions for one op",
+    "description" : "to reduce X-Okapi-Token size",
+    "subPermissions" : [ "circulation-storage.loans.item.get", "circulation-storage.loans.item.put", "inventory-storage.items.item.get", "inventory-storage.items.item.put", "inventory-storage.holdings.item.get", "inventory-storage.instances.item.get", "inventory-storage.locations.item.get", "inventory-storage.location-units.libraries.item.get", "inventory-storage.location-units.campuses.item.get", "inventory-storage.location-units.institutions.item.get", "inventory-storage.service-points.item.get", "inventory-storage.material-types.item.get", "inventory-storage.loan-types.item.get", "inventory-storage.service-points.item.get", "lost-item-fees-policies.item.get", "owners.collection.get", "feefines.collection.get", "accounts.item.post", "users.item.get", "feefineactions.item.post", "pubsub.publish.post" ],
+    "visible" : false
+  }, {
+    "permissionName" : "modperms.circulation.loans.change-due-date.post",
+    "displayName" : "module permissions for one op",
+    "description" : "to reduce X-Okapi-Token size",
+    "subPermissions" : [ "circulation.rules.loan-policy.get", "circulation.rules.notice-policy.get", "circulation-storage.loan-policies.item.get", "circulation-storage.loans.item.get", "circulation-storage.loans.item.put", "circulation-storage.patron-notice-policies.item.get", "inventory-storage.items.item.get", "inventory-storage.items.item.put", "scheduled-notice-storage.scheduled-notices.collection.delete", "scheduled-notice-storage.scheduled-notices.item.post", "users.item.get", "pubsub.publish.post" ],
+    "visible" : false
+  }, {
+    "permissionName" : "modperms.circulation.loans.claim-item-returned.post",
+    "displayName" : "module permissions for one op",
+    "description" : "to reduce X-Okapi-Token size",
+    "subPermissions" : [ "circulation-storage.loans.item.get", "circulation-storage.loans.item.put", "inventory-storage.items.item.get", "inventory-storage.items.item.put", "inventory-storage.holdings.item.get", "inventory-storage.instances.item.get", "users.item.get" ],
+    "visible" : false
+  }, {
+    "permissionName" : "modperms.circulation.loans.declare-claimed-returned-item-as-missing.post",
+    "displayName" : "module permissions for one op",
+    "description" : "to reduce X-Okapi-Token size",
+    "subPermissions" : [ "circulation-storage.loans.item.get", "circulation-storage.loans.item.put", "inventory-storage.items.item.get", "inventory-storage.items.item.put", "inventory-storage.holdings.item.get", "inventory-storage.instances.item.get", "users.item.get" ],
+    "visible" : false
+  }, {
+    "permissionName" : "modperms.circulation.loans.item.put",
+    "displayName" : "module permissions for one op",
+    "description" : "to reduce X-Okapi-Token size",
+    "subPermissions" : [ "circulation-storage.loans.item.put", "circulation-storage.loans.collection.get", "circulation.rules.loan-policy.get", "circulation.rules.request-policy.get", "circulation-storage.requests.item.put", "circulation-storage.requests.collection.get", "inventory-storage.items.item.get", "inventory-storage.items.item.put", "inventory-storage.items.collection.get", "inventory-storage.locations.item.get", "inventory-storage.locations.collection.get", "inventory-storage.location-units.institutions.item.get", "inventory-storage.location-units.campuses.item.get", "inventory-storage.location-units.libraries.item.get", "inventory-storage.location-units.libraries.collection.get", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.instances.collection.get", "inventory-storage.instances.item.get", "inventory-storage.service-points.collection.get", "inventory-storage.service-points.item.get", "proxiesfor.collection.get", "users.item.get", "proxiesfor.collection.get", "inventory-storage.material-types.item.get", "inventory-storage.material-types.collection.get", "inventory-storage.loan-types.item.get", "circulation-storage.loan-policies.item.get", "circulation-storage.loan-policies.collection.get", "circulation-storage.request-policies.item.get", "circulation-storage.fixed-due-date-schedules.item.get", "circulation.rules.notice-policy.get", "circulation-storage.patron-notice-policies.item.get", "scheduled-notice-storage.scheduled-notices.collection.delete", "scheduled-notice-storage.scheduled-notices.item.post", "pubsub.publish.post", "configuration.entries.collection.get" ],
+    "visible" : false
+  }, {
+    "permissionName" : "modperms.inventory.items-in-transit-report.get",
+    "displayName" : "module permissions for one op",
+    "description" : "to reduce X-Okapi-Token size",
+    "subPermissions" : [ "inventory-storage.items.item.get", "inventory-storage.items.collection.get", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.locations.item.get", "inventory-storage.instances.collection.get", "inventory-storage.instances.item.get", "inventory-storage.service-points.collection.get", "inventory-storage.service-points.item.get", "inventory-storage.material-types.collection.get", "inventory-storage.material-types.item.get", "circulation-storage.requests.item.get", "circulation-storage.requests.collection.get", "inventory-storage.locations.item.get", "inventory-storage.locations.collection.get", "inventory-storage.location-units.institutions.item.get", "inventory-storage.location-units.campuses.item.get", "inventory-storage.location-units.libraries.item.get", "inventory-storage.location-units.libraries.collection.get", "circulation-storage.loans.collection.get", "circulation-storage.loans.item.get" ],
+    "visible" : false
+  }, {
+    "permissionName" : "modperms.circulation.pick-slips.get",
+    "displayName" : "module permissions for one op",
+    "description" : "to reduce X-Okapi-Token size",
+    "subPermissions" : [ "inventory-storage.items.item.get", "inventory-storage.items.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.holdings.collection.get", "inventory-storage.instances.item.get", "inventory-storage.instances.collection.get", "inventory-storage.material-types.item.get", "inventory-storage.material-types.collection.get", "inventory-storage.loan-types.item.get", "inventory-storage.loan-types.collection.get", "inventory-storage.service-points.item.get", "inventory-storage.service-points.collection.get", "inventory-storage.locations.item.get", "inventory-storage.locations.collection.get", "inventory-storage.location-units.libraries.item.get", "inventory-storage.location-units.libraries.collection.get", "inventory-storage.location-units.campuses.item.get", "inventory-storage.location-units.campuses.collection.get", "inventory-storage.location-units.institutions.item.get", "inventory-storage.location-units.institutions.collection.get", "circulation-storage.requests.item.get", "circulation-storage.requests.collection.get", "users.item.get", "users.collection.get", "addresstypes.item.get", "addresstypes.collection.get" ],
+    "visible" : false
+  }, {
+    "permissionName" : "circulation.internal.apply-rules",
+    "displayName" : "Apply circulation rules",
+    "description" : "Internal permission set for applying circulation rules",
+    "subPermissions" : [ "circulation.rules.loan-policy.get", "circulation-storage.loan-policies.collection.get", "circulation-storage.loan-policies.item.get", "circulation.rules.request-policy.get", "circulation-storage.request-policies.item.get", "circulation-storage.request-policies.collection.get", "circulation.rules.notice-policy.get", "circulation-storage.patron-notice-policies.item.get", "circulation-storage.patron-notice-policies.collection.get" ],
+    "visible" : false
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-circulation:19.0.16",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 715827882,
+        "PortBindings" : {
+          "9801/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-circulation-storage-12.0.3",
+  "name" : "Circulation Storage Module",
+  "provides" : [ {
+    "id" : "request-storage-batch",
+    "version" : "0.3",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/request-storage-batch/requests",
+      "permissionsRequired" : [ "circulation-storage.request-batch.item.post" ]
+    } ]
+  }, {
+    "id" : "loan-storage",
+    "version" : "7.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/loan-storage/loans",
+      "permissionsRequired" : [ "circulation-storage.loans.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/loan-storage/loans/{id}",
+      "permissionsRequired" : [ "circulation-storage.loans.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/loan-storage/loans",
+      "permissionsRequired" : [ "circulation-storage.loans.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/loan-storage/loans/{id}",
+      "permissionsRequired" : [ "circulation-storage.loans.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/loan-storage/loans/{id}",
+      "permissionsRequired" : [ "circulation-storage.loans.item.delete" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/loan-storage/loans",
+      "permissionsRequired" : [ "circulation-storage.loans.collection.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/loan-storage/loan-history",
+      "permissionsRequired" : [ "circulation-storage.loans-history.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/loan-storage/loans/anonymize/{userId}",
+      "permissionsRequired" : [ "circulation-storage.loans.collection.anonymize.user.post" ]
+    } ]
+  }, {
+    "id" : "anonymize-storage-loans",
+    "version" : "0.1",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/anonymize-storage-loans",
+      "permissionsRequired" : [ "anonymize-storage-loans.post" ]
+    } ]
+  }, {
+    "id" : "circulation-rules-storage",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/circulation-rules-storage",
+      "permissionsRequired" : [ "circulation-storage.circulation-rules.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/circulation-rules-storage",
+      "permissionsRequired" : [ "circulation-storage.circulation-rules.put" ]
+    } ]
+  }, {
+    "id" : "loan-policy-storage",
+    "version" : "2.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/loan-policy-storage/loan-policies",
+      "permissionsRequired" : [ "circulation-storage.loan-policies.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/loan-policy-storage/loan-policies/{id}",
+      "permissionsRequired" : [ "circulation-storage.loan-policies.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/loan-policy-storage/loan-policies",
+      "permissionsRequired" : [ "circulation-storage.loan-policies.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/loan-policy-storage/loan-policies/{id}",
+      "permissionsRequired" : [ "circulation-storage.loan-policies.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/loan-policy-storage/loan-policies/{id}",
+      "permissionsRequired" : [ "circulation-storage.loan-policies.item.delete" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/loan-policy-storage/loan-policies",
+      "permissionsRequired" : [ "circulation-storage.loan-policies.collection.delete" ]
+    } ]
+  }, {
+    "id" : "request-storage",
+    "version" : "3.3",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/request-storage/requests",
+      "permissionsRequired" : [ "circulation-storage.requests.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/request-storage/requests/{id}",
+      "permissionsRequired" : [ "circulation-storage.requests.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/request-storage/requests",
+      "permissionsRequired" : [ "circulation-storage.requests.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/request-storage/requests/{id}",
+      "permissionsRequired" : [ "circulation-storage.requests.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/request-storage/requests/{id}",
+      "permissionsRequired" : [ "circulation-storage.requests.item.delete" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/request-storage/requests",
+      "permissionsRequired" : [ "circulation-storage.requests.collection.delete" ]
+    } ]
+  }, {
+    "id" : "fixed-due-date-schedules-storage",
+    "version" : "2.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/fixed-due-date-schedule-storage/fixed-due-date-schedules",
+      "permissionsRequired" : [ "circulation-storage.fixed-due-date-schedules.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/fixed-due-date-schedule-storage/fixed-due-date-schedules/{id}",
+      "permissionsRequired" : [ "circulation-storage.fixed-due-date-schedules.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/fixed-due-date-schedule-storage/fixed-due-date-schedules",
+      "permissionsRequired" : [ "circulation-storage.fixed-due-date-schedules.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/fixed-due-date-schedule-storage/fixed-due-date-schedules/{id}",
+      "permissionsRequired" : [ "circulation-storage.fixed-due-date-schedules.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/fixed-due-date-schedule-storage/fixed-due-date-schedules/{id}",
+      "permissionsRequired" : [ "circulation-storage.fixed-due-date-schedules.item.delete" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/fixed-due-date-schedule-storage/fixed-due-date-schedules",
+      "permissionsRequired" : [ "circulation-storage.fixed-due-date-schedules.collection.delete" ]
+    } ]
+  }, {
+    "id" : "staff-slips-storage",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/staff-slips-storage/staff-slips",
+      "permissionsRequired" : [ "circulation-storage.staff-slips.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/staff-slips-storage/staff-slips",
+      "permissionsRequired" : [ "circulation-storage.staff-slips.item.post" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/staff-slips-storage/staff-slips",
+      "permissionsRequired" : [ "circulation-storage.staff-slips.collection.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/staff-slips-storage/staff-slips/{id}",
+      "permissionsRequired" : [ "circulation-storage.staff-slips.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/staff-slips-storage/staff-slips/{id}",
+      "permissionsRequired" : [ "circulation-storage.staff-slips.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/staff-slips-storage/staff-slips/{id}",
+      "permissionsRequired" : [ "circulation-storage.staff-slips.item.delete" ]
+    } ]
+  }, {
+    "id" : "cancellation-reason-storage",
+    "version" : "1.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/cancellation-reason-storage/cancellation-reasons",
+      "permissionsRequired" : [ "circulation-storage.cancellation-reasons.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/cancellation-reason-storage/cancellation-reasons/{id}",
+      "permissionsRequired" : [ "circulation-storage.cancellation-reasons.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/cancellation-reason-storage/cancellation-reasons",
+      "permissionsRequired" : [ "circulation-storage.cancellation-reasons.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/cancellation-reason-storage/cancellation-reasons/{id}",
+      "permissionsRequired" : [ "circulation-storage.cancellation-reasons.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/cancellation-reason-storage/cancellation-reasons",
+      "permissionsRequired" : [ "circulation-storage.cancellation-reasons.collection.delete" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/cancellation-reason-storage/cancellation-reasons/{id}",
+      "permissionsRequired" : [ "circulation-storage.cancellation-reasons.item.delete" ]
+    } ]
+  }, {
+    "id" : "patron-notice-policy-storage",
+    "version" : "0.12",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/patron-notice-policy-storage/patron-notice-policies",
+      "permissionsRequired" : [ "circulation-storage.patron-notice-policies.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/patron-notice-policy-storage/patron-notice-policies/{id}",
+      "permissionsRequired" : [ "circulation-storage.patron-notice-policies.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/patron-notice-policy-storage/patron-notice-policies/{id}",
+      "permissionsRequired" : [ "circulation-storage.patron-notice-policies.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/patron-notice-policy-storage/patron-notice-policies",
+      "permissionsRequired" : [ "circulation-storage.patron-notice-policies.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/patron-notice-policy-storage/patron-notice-policies/{id}",
+      "permissionsRequired" : [ "circulation-storage.patron-notice-policies.item.get" ]
+    } ]
+  }, {
+    "id" : "request-policy-storage",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/request-policy-storage/request-policies",
+      "permissionsRequired" : [ "circulation-storage.request-policies.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/request-policy-storage/request-policies/{id}",
+      "permissionsRequired" : [ "circulation-storage.request-policies.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/request-policy-storage/request-policies",
+      "permissionsRequired" : [ "circulation-storage.request-policies.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/request-policy-storage/request-policies/{id}",
+      "permissionsRequired" : [ "circulation-storage.request-policies.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/request-policy-storage/request-policies/{id}",
+      "permissionsRequired" : [ "circulation-storage.request-policies.item.delete" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/request-policy-storage/request-policies",
+      "permissionsRequired" : [ "circulation-storage.request-policies.collection.delete" ]
+    } ]
+  }, {
+    "id" : "request-preference-storage",
+    "version" : "2.0",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/request-preference-storage/request-preference",
+      "permissionsRequired" : [ "circulation-storage.request-preferences.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/request-preference-storage/request-preference/{id}",
+      "permissionsRequired" : [ "circulation-storage.request-preferences.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/request-preference-storage/request-preference/{id}",
+      "permissionsRequired" : [ "circulation-storage.request-preferences.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/request-preference-storage/request-preference",
+      "permissionsRequired" : [ "circulation-storage.request-preferences.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/request-preference-storage/request-preference/{id}",
+      "permissionsRequired" : [ "circulation-storage.request-preferences.item.get" ]
+    } ]
+  }, {
+    "id" : "scheduled-notice-storage",
+    "version" : "0.4",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/scheduled-notice-storage/scheduled-notices",
+      "permissionsRequired" : [ "scheduled-notice-storage.scheduled-notices.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/scheduled-notice-storage/scheduled-notices/{id}",
+      "permissionsRequired" : [ "scheduled-notice-storage.scheduled-notices.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/scheduled-notice-storage/scheduled-notices",
+      "permissionsRequired" : [ "scheduled-notice-storage.scheduled-notices.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/scheduled-notice-storage/scheduled-notices/{id}",
+      "permissionsRequired" : [ "scheduled-notice-storage.scheduled-notices.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/scheduled-notice-storage/scheduled-notices",
+      "permissionsRequired" : [ "scheduled-notice-storage.scheduled-notices.collection.delete" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/scheduled-notice-storage/scheduled-notices/{id}",
+      "permissionsRequired" : [ "scheduled-notice-storage.scheduled-notices.item.delete" ]
+    } ]
+  }, {
+    "id" : "_tenant",
+    "version" : "1.2",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/_/tenant"
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/_/tenant"
+    } ]
+  }, {
+    "id" : "patron-action-session-storage",
+    "version" : "0.2",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/patron-action-session-storage/patron-action-sessions",
+      "permissionsRequired" : [ "patron-action-session-storage.patron-action-sessions.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/patron-action-session-storage/patron-action-sessions/{id}",
+      "permissionsRequired" : [ "patron-action-session-storage.patron-action-sessions.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/patron-action-session-storage/patron-action-sessions",
+      "permissionsRequired" : [ "patron-action-session-storage.patron-action-sessions.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/patron-action-session-storage/patron-action-sessions/{id}",
+      "permissionsRequired" : [ "patron-action-session-storage.patron-action-sessions.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/patron-action-session-storage/patron-action-sessions/{id}",
+      "permissionsRequired" : [ "patron-action-session-storage.patron-action-sessions.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/patron-action-session-storage/expired-session-patron-ids",
+      "permissionsRequired" : [ "patron-action-session-storage.expired-session-patron-ids.collection.get" ]
+    } ]
+  }, {
+    "id" : "check-in-storage",
+    "version" : "0.2",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/check-in-storage/check-ins",
+      "permissionsRequired" : [ "check-in-storage.check-ins.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/check-in-storage/check-ins",
+      "permissionsRequired" : [ "check-in-storage.check-ins.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/check-in-storage/check-ins/{id}",
+      "permissionsRequired" : [ "check-in-storage.check-ins.item.get" ]
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "check-in-storage.check-ins.collection.get",
+    "displayName" : "Check-in storage - get check-ins collection",
+    "description" : "Get check-ins collection from storage"
+  }, {
+    "permissionName" : "check-in-storage.check-ins.item.post",
+    "displayName" : "Check-in storage - create a check-in record",
+    "description" : "Create a check-in record"
+  }, {
+    "permissionName" : "check-in-storage.check-ins.item.get",
+    "displayName" : "Check-in storage - get a check-in record by id",
+    "description" : "Get individual check-in by id"
+  }, {
+    "permissionName" : "circulation-storage.loans.collection.get",
+    "displayName" : "Circulation storage - get loan collection",
+    "description" : "Get loan collection from storage"
+  }, {
+    "permissionName" : "circulation-storage.loans.collection.delete",
+    "displayName" : "Circulation storage - delete entire loan collection",
+    "description" : "Delete entire loan collection from storage"
+  }, {
+    "permissionName" : "circulation-storage.loans.item.get",
+    "displayName" : "Circulation storage - get individual loan",
+    "description" : "Get individual loan from storage"
+  }, {
+    "permissionName" : "circulation-storage.loans.item.post",
+    "displayName" : "Circulation storage - create individual loan",
+    "description" : "Create individual loan in storage"
+  }, {
+    "permissionName" : "circulation-storage.loans.item.put",
+    "displayName" : "Circulation storage - modify loan",
+    "description" : "Modify loan in storage"
+  }, {
+    "permissionName" : "circulation-storage.loans.item.delete",
+    "displayName" : "Circulation storage - delete individual loan",
+    "description" : "Delete individual loan from storage"
+  }, {
+    "permissionName" : "circulation-storage.loans.collection.anonymize.user.post",
+    "displayName" : "Circulation storage - anonymize loans for a user",
+    "description" : "Anonymize closed loans for a single user"
+  }, {
+    "permissionName" : "anonymize-storage-loans.post",
+    "displayName" : "circulation - anonymize loans",
+    "description" : "anonymize a list of loans"
+  }, {
+    "permissionName" : "circulation-storage.circulation-rules.get",
+    "displayName" : "Circulation storage - get circulation rules",
+    "description" : "Get circulation rules from storage"
+  }, {
+    "permissionName" : "circulation-storage.circulation-rules.put",
+    "displayName" : "Circulation storage - modify circulation rules",
+    "description" : "Modify circulation rules in storage"
+  }, {
+    "permissionName" : "circulation-storage.loan-policies.collection.get",
+    "displayName" : "Circulation storage - get loan policy collection",
+    "description" : "Get loan policy collection from storage"
+  }, {
+    "permissionName" : "circulation-storage.loan-policies.collection.delete",
+    "displayName" : "Circulation storage - delete entire loan collection",
+    "description" : "Delete entire loan collection from storage"
+  }, {
+    "permissionName" : "circulation-storage.loan-policies.item.get",
+    "displayName" : "Circulation storage - get individual loan policy",
+    "description" : "Get individual loan policy from storage"
+  }, {
+    "permissionName" : "circulation-storage.loan-policies.item.post",
+    "displayName" : "Circulation storage - create individual loan policy",
+    "description" : "Create individual loan policy in storage"
+  }, {
+    "permissionName" : "circulation-storage.loan-policies.item.put",
+    "displayName" : "Circulation storage - modify loan policy",
+    "description" : "Modify loan policy in storage"
+  }, {
+    "permissionName" : "circulation-storage.loan-policies.item.delete",
+    "displayName" : "Circulation storage - delete individual loan policy",
+    "description" : "Delete individual loan policy from storage"
+  }, {
+    "permissionName" : "circulation-storage.loans-history.collection.get",
+    "displayName" : "Circulation storage - get loan history collection",
+    "description" : "Get loan history collection from storage"
+  }, {
+    "permissionName" : "circulation-storage.requests.collection.get",
+    "displayName" : "Circulation storage - get request collection",
+    "description" : "Get request collection from storage"
+  }, {
+    "permissionName" : "circulation-storage.requests.collection.delete",
+    "displayName" : "Circulation storage - delete entire request collection",
+    "description" : "Delete entire request collection from storage"
+  }, {
+    "permissionName" : "circulation-storage.requests.item.get",
+    "displayName" : "Circulation storage - get individual request",
+    "description" : "Get individual request from storage"
+  }, {
+    "permissionName" : "circulation-storage.requests.item.post",
+    "displayName" : "Circulation storage - create individual request",
+    "description" : "Create individual request in storage"
+  }, {
+    "permissionName" : "circulation-storage.requests.item.put",
+    "displayName" : "Circulation storage - modify request",
+    "description" : "Modify request in storage"
+  }, {
+    "permissionName" : "circulation-storage.request-batch.item.post",
+    "displayName" : "Circulation storage batch - modify requests",
+    "description" : "Modify requests in storage"
+  }, {
+    "permissionName" : "circulation-storage.requests.item.delete",
+    "displayName" : "Circulation storage - delete individual request",
+    "description" : "Delete individual request from storage"
+  }, {
+    "permissionName" : "circulation-storage.fixed-due-date-schedules.collection.get",
+    "displayName" : "Circulation storage - get fixed due date collection",
+    "description" : "Get fixed due date collection from storage"
+  }, {
+    "permissionName" : "circulation-storage.fixed-due-date-schedules.item.get",
+    "displayName" : "Circulation storage - get individual fixed due date",
+    "description" : "Get individual fixed due date from storage"
+  }, {
+    "permissionName" : "circulation-storage.fixed-due-date-schedules.item.post",
+    "displayName" : "Circulation storage - create individual fixed due date",
+    "description" : "Create individual fixed due date from storage"
+  }, {
+    "permissionName" : "circulation-storage.fixed-due-date-schedules.item.put",
+    "displayName" : "Circulation storage - modify individual fixed due date",
+    "description" : "Modify individual fixed due date from storage"
+  }, {
+    "permissionName" : "circulation-storage.fixed-due-date-schedules.item.delete",
+    "displayName" : "Circulation storage - delete individual fixed due date",
+    "description" : "Delete individual fixed due date from storage"
+  }, {
+    "permissionName" : "circulation-storage.fixed-due-date-schedules.collection.delete",
+    "displayName" : "Circulation storage - delete collection of fixed due date",
+    "description" : "Delete collection of fixed due date from storage"
+  }, {
+    "permissionName" : "circulation-storage.staff-slips.collection.get",
+    "displayName" : "Circulation storage - get staff slip collection from storage",
+    "description" : "Get staff slip collection from storage"
+  }, {
+    "permissionName" : "circulation-storage.staff-slips.collection.delete",
+    "displayName" : "Circulation storage - delete entire staff slipp collection",
+    "description" : "Delete entire staff slip collection"
+  }, {
+    "permissionName" : "circulation-storage.staff-slips.item.post",
+    "displayName" : "Circulation storage - create indavidual staff slip in storage",
+    "description" : "Create individual staff slip in storage"
+  }, {
+    "permissionName" : "circulation-storage.staff-slips.item.get",
+    "displayName" : "Circulation storage - get indavidual staff slip from storage",
+    "description" : "Get individual staff slip from storage"
+  }, {
+    "permissionName" : "circulation-storage.staff-slips.item.delete",
+    "displayName" : "Circulation storage - delete indavidual staff slip from storage",
+    "description" : "Delete individual staff slip from storage"
+  }, {
+    "permissionName" : "circulation-storage.staff-slips.item.put",
+    "displayName" : "Circulation storage - modify indavidual staff slip in storage",
+    "description" : "Modify individual staff slip in storage"
+  }, {
+    "permissionName" : "circulation-storage.cancellation-reasons.collection.get",
+    "displayName" : "Circulation storage - get cancellation reasons collection",
+    "description" : "Get cancellation reasons from storage"
+  }, {
+    "permissionName" : "circulation-storage.cancellation-reasons.item.get",
+    "displayName" : "Circulation storage - get individual cancellation reason",
+    "description" : "Get individual cancellation reason by id"
+  }, {
+    "permissionName" : "circulation-storage.cancellation-reasons.item.post",
+    "displayName" : "Circulation storage - create individual cancellation reason",
+    "description" : "Create individual cancellation reason"
+  }, {
+    "permissionName" : "circulation-storage.cancellation-reasons.item.put",
+    "displayName" : "Circulation storage - put individual cancellation reason",
+    "description" : "Modify individual cancellation reason by id"
+  }, {
+    "permissionName" : "circulation-storage.cancellation-reasons.collection.delete",
+    "displayName" : "Circulation storage - delete cancellation reasons",
+    "description" : "Delete entire cancellation reasons collection"
+  }, {
+    "permissionName" : "circulation-storage.cancellation-reasons.item.delete",
+    "displayName" : "Circulation storage - delete individual cancellation reason",
+    "description" : "Delete individual cancellation reason by id"
+  }, {
+    "permissionName" : "circulation-storage.patron-notice-policies.item.post",
+    "displayName" : "Circulation storage - post individual patron notice policy",
+    "description" : "Post individual patron notice policy"
+  }, {
+    "permissionName" : "circulation-storage.patron-notice-policies.item.put",
+    "displayName" : "Circulation storage - put individual patron notice policy",
+    "description" : "Put individual patron notice policy by id"
+  }, {
+    "permissionName" : "circulation-storage.patron-notice-policies.item.delete",
+    "displayName" : "Circulation storage - delete patron notice policy",
+    "description" : "Delete patron notice policy by id"
+  }, {
+    "permissionName" : "circulation-storage.patron-notice-policies.collection.get",
+    "displayName" : "Circulation storage - get patron notice policy collection",
+    "description" : "Get patron notice policy collection from storage"
+  }, {
+    "permissionName" : "circulation-storage.patron-notice-policies.item.get",
+    "displayName" : "Circulation storage - get individual patron notice policy",
+    "description" : "Get individual patron notice policy by id"
+  }, {
+    "permissionName" : "circulation-storage.request-preferences.item.post",
+    "displayName" : "Circulation storage - post individual request preference",
+    "description" : "Post individual request preference"
+  }, {
+    "permissionName" : "circulation-storage.request-preferences.item.put",
+    "displayName" : "Circulation storage - put individual request preference",
+    "description" : "Put individual request preference by id"
+  }, {
+    "permissionName" : "circulation-storage.request-preferences.item.delete",
+    "displayName" : "Circulation storage - delete request preference",
+    "description" : "Delete request preference by id"
+  }, {
+    "permissionName" : "circulation-storage.request-preferences.collection.get",
+    "displayName" : "Circulation storage - get request preference collection",
+    "description" : "Get request preference collection from storage"
+  }, {
+    "permissionName" : "circulation-storage.request-preferences.item.get",
+    "displayName" : "Circulation storage - get individual request preference",
+    "description" : "Get individual request preference by id"
+  }, {
+    "permissionName" : "scheduled-notice-storage.scheduled-notices.collection.get",
+    "displayName" : "Circulation storage - get scheduled notice collection",
+    "description" : "Get scheduled notice collection from storage"
+  }, {
+    "permissionName" : "scheduled-notice-storage.scheduled-notices.item.get",
+    "displayName" : "Circulation storage - get individual scheduled notice",
+    "description" : "Get individual scheduled notice by id"
+  }, {
+    "permissionName" : "scheduled-notice-storage.scheduled-notices.item.post",
+    "displayName" : "Circulation storage - post individual scheduled notice",
+    "description" : "Create individual scheduled notice"
+  }, {
+    "permissionName" : "scheduled-notice-storage.scheduled-notices.item.put",
+    "displayName" : "Circulation storage - put individual scheduled notice",
+    "description" : "Put individual scheduled notice by id"
+  }, {
+    "permissionName" : "scheduled-notice-storage.scheduled-notices.item.delete",
+    "displayName" : "Circulation storage - delete individual scheduled notice",
+    "description" : "Delete individual scheduled notice by id"
+  }, {
+    "permissionName" : "scheduled-notice-storage.scheduled-notices.collection.delete",
+    "displayName" : "Circulation storage - delete all scheduled notices",
+    "description" : "Delete all scheduled notices from storage"
+  }, {
+    "permissionName" : "patron-action-session-storage.patron-action-sessions.collection.get",
+    "displayName" : "Circulation storage - get patron action session collection",
+    "description" : "Get patron action session collection from storage"
+  }, {
+    "permissionName" : "patron-action-session-storage.patron-action-sessions.item.get",
+    "displayName" : "Circulation storage - get patron action session",
+    "description" : "Get individual patron action session by id"
+  }, {
+    "permissionName" : "patron-action-session-storage.patron-action-sessions.item.post",
+    "displayName" : "Circulation storage - post patron action session",
+    "description" : "Create individual patron action session"
+  }, {
+    "permissionName" : "patron-action-session-storage.patron-action-sessions.item.put",
+    "displayName" : "Circulation storage - put patron action session",
+    "description" : "Put patron action session by id"
+  }, {
+    "permissionName" : "patron-action-session-storage.patron-action-sessions.item.delete",
+    "displayName" : "Circulation storage - delete patron action session",
+    "description" : "Delete patron action session by id"
+  }, {
+    "permissionName" : "circulation-storage.all",
+    "displayName" : "Circulation storage module - all permissions",
+    "description" : "Entire set of permissions needed to use the circulation storage module",
+    "subPermissions" : [ "circulation-storage.loans.collection.get", "circulation-storage.loans.item.get", "circulation-storage.loans.item.post", "circulation-storage.loans.item.put", "circulation-storage.loans.item.delete", "circulation-storage.loans.collection.delete", "circulation-storage.loans.collection.anonymize.user.post", "circulation-storage.loans-history.collection.get", "circulation-storage.circulation-rules.get", "circulation-storage.circulation-rules.put", "circulation-storage.loan-policies.collection.get", "circulation-storage.loan-policies.item.get", "circulation-storage.loan-policies.item.post", "circulation-storage.loan-policies.item.put", "circulation-storage.loan-policies.item.delete", "circulation-storage.loan-policies.collection.delete", "circulation-storage.requests.collection.get", "circulation-storage.requests.item.get", "circulation-storage.requests.item.post", "circulation-storage.requests.item.put", "circulation-storage.requests.item.delete", "circulation-storage.requests.collection.delete", "circulation-storage.fixed-due-date-schedules.collection.delete", "circulation-storage.fixed-due-date-schedules.item.delete", "circulation-storage.fixed-due-date-schedules.item.put", "circulation-storage.fixed-due-date-schedules.item.post", "circulation-storage.fixed-due-date-schedules.item.get", "circulation-storage.fixed-due-date-schedules.collection.get", "circulation-storage.staff-slips.item.delete", "circulation-storage.staff-slips.collection.delete", "circulation-storage.staff-slips.collection.get", "circulation-storage.staff-slips.item.post", "circulation-storage.staff-slips.item.put", "circulation-storage.staff-slips.item.get", "circulation-storage.cancellation-reasons.collection.get", "circulation-storage.cancellation-reasons.item.get", "circulation-storage.cancellation-reasons.item.post", "circulation-storage.cancellation-reasons.item.put", "circulation-storage.cancellation-reasons.collection.delete", "circulation-storage.cancellation-reasons.item.delete", "circulation-storage.patron-notice-policies.item.post", "circulation-storage.patron-notice-policies.item.put", "circulation-storage.patron-notice-policies.item.delete", "circulation-storage.patron-notice-policies.collection.get", "circulation-storage.patron-notice-policies.item.get", "circulation-storage.request-preferences.item.post", "circulation-storage.request-preferences.item.put", "circulation-storage.request-preferences.item.delete", "circulation-storage.request-preferences.collection.get", "circulation-storage.request-preferences.item.get", "circulation-storage.request-policies.collection.get", "circulation-storage.request-policies.item.get", "circulation-storage.request-policies.collection.delete", "circulation-storage.request-policies.item.delete", "circulation-storage.request-policies.item.post", "circulation-storage.request-policies.item.put", "circulation-storage.request-batch.item.post", "scheduled-notice-storage.scheduled-notices.collection.get", "scheduled-notice-storage.scheduled-notices.item.get", "scheduled-notice-storage.scheduled-notices.item.post", "scheduled-notice-storage.scheduled-notices.item.put", "scheduled-notice-storage.scheduled-notices.item.delete", "scheduled-notice-storage.scheduled-notices.collection.delete", "anonymize-storage-loans.post", "patron-action-session-storage.patron-action-sessions.collection.get", "patron-action-session-storage.patron-action-sessions.item.get", "patron-action-session-storage.patron-action-sessions.item.post", "patron-action-session-storage.patron-action-sessions.item.put", "patron-action-session-storage.patron-action-sessions.item.delete", "patron-action-session-storage.expired-session-patron-ids.collection.get", "check-in-storage.check-ins.collection.get", "check-in-storage.check-ins.item.post", "check-in-storage.check-ins.item.get" ]
+  }, {
+    "permissionName" : "circulation-storage.request-policies.collection.get",
+    "displayName" : "Circulation storage - get request policy collection",
+    "description" : "Get request policy collection from storage"
+  }, {
+    "permissionName" : "circulation-storage.request-policies.collection.delete",
+    "displayName" : "Circulation storage - delete entire request policy collection",
+    "description" : "Delete entire request policy collection from storage"
+  }, {
+    "permissionName" : "circulation-storage.request-policies.item.get",
+    "displayName" : "Circulation storage - get individual request policy",
+    "description" : "Get individual request policy from storage"
+  }, {
+    "permissionName" : "circulation-storage.request-policies.item.post",
+    "displayName" : "Circulation storage - create individual request policy",
+    "description" : "Create individual request policy in storage"
+  }, {
+    "permissionName" : "circulation-storage.request-policies.item.put",
+    "displayName" : "Circulation storage - modify individual request policy",
+    "description" : "Modify request policy in storage"
+  }, {
+    "permissionName" : "circulation-storage.request-policies.item.delete",
+    "displayName" : "Circulation storage - delete individual request policy",
+    "description" : "Delete individual request policy from storage"
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-circulation-storage:12.0.3",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    }, {
+      "name" : "DB_HOST",
+      "value" : "postgres"
+    }, {
+      "name" : "DB_PORT",
+      "value" : "5432"
+    }, {
+      "name" : "DB_USERNAME",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_PASSWORD",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_DATABASE",
+      "value" : "okapi_modules"
+    }, {
+      "name" : "DB_QUERYTIMEOUT",
+      "value" : "60000"
+    }, {
+      "name" : "DB_CHARSET",
+      "value" : "UTF-8"
+    }, {
+      "name" : "DB_MAXPOOLSIZE",
+      "value" : "5"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 536870912,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-codex-ekb-1.6.0",
+  "name" : "EBSCO Knowledge Base Codex",
+  "requires" : [ {
+    "id" : "configuration",
+    "version" : "2.0"
+  } ],
+  "provides" : [ {
+    "id" : "codex",
+    "version" : "3.1",
+    "interfaceType" : "multiple",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/codex-instances",
+      "permissionsRequired" : [ "codex-ekb.instances.collection.get" ],
+      "modulePermissions" : [ "kb-ebsco.user-kb-credential.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/codex-instances/{id}",
+      "permissionsRequired" : [ "codex-ekb.instances.item.get" ],
+      "modulePermissions" : [ "kb-ebsco.user-kb-credential.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/codex-instances-sources",
+      "permissionsRequired" : [ "codex-ekb.instances-sources.collection.get" ]
+    } ]
+  }, {
+    "id" : "codex-packages",
+    "version" : "1.0",
+    "interfaceType" : "multiple",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/codex-packages",
+      "permissionsRequired" : [ "codex-ekb.packages.collection.get" ],
+      "modulePermissions" : [ "kb-ebsco.user-kb-credential.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/codex-packages/{id}",
+      "permissionsRequired" : [ "codex-ekb.packages.item.get" ],
+      "modulePermissions" : [ "kb-ebsco.user-kb-credential.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/codex-packages-sources",
+      "permissionsRequired" : [ "codex-ekb.packages-sources.collection.get" ]
+    } ]
+  }, {
+    "id" : "_jsonSchemas",
+    "version" : "1.0",
+    "interfaceType" : "multiple",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/_/jsonSchemas",
+      "permissionsRequired" : [ ]
+    } ]
+  }, {
+    "id" : "_ramls",
+    "version" : "1.0",
+    "interfaceType" : "multiple",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/_/ramls",
+      "permissionsRequired" : [ ]
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "codex-ekb.instances.collection.get",
+    "displayName" : "Codex - get instances",
+    "description" : "Get instance collection"
+  }, {
+    "permissionName" : "codex-ekb.instances.item.get",
+    "displayName" : "Codex - get individual instance",
+    "description" : "Get individual instance"
+  }, {
+    "permissionName" : "codex-ekb.instances-sources.collection.get",
+    "displayName" : "get codex instances sources",
+    "description" : "Get codex instances sources"
+  }, {
+    "permissionName" : "codex-ekb.packages.collection.get",
+    "displayName" : "Codex - get packages",
+    "description" : "Get package collection"
+  }, {
+    "permissionName" : "codex-ekb.packages.item.get",
+    "displayName" : "Codex - get individual package",
+    "description" : "Get individual package"
+  }, {
+    "permissionName" : "codex-ekb.packages-sources.collection.get",
+    "displayName" : "get codex package sources",
+    "description" : "Get codex package sources"
+  }, {
+    "permissionName" : "codex-ekb.all",
+    "displayName" : "Codex - all permissions",
+    "description" : "Entire set of permissions needed to use the codex module",
+    "subPermissions" : [ "codex-ekb.instances.collection.get", "codex-ekb.instances.item.get", "codex-ekb.instances-sources.collection.get", "codex-ekb.packages.collection.get", "codex-ekb.packages.item.get", "codex-ekb.packages-sources.collection.get" ]
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-codex-ekb:1.6.0",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-codex-inventory-1.7.0",
+  "name" : "Codex wrapper for Inventory",
+  "requires" : [ {
+    "id" : "instance-storage",
+    "version" : "7.0"
+  }, {
+    "id" : "contributor-name-types",
+    "version" : "1.0"
+  }, {
+    "id" : "instance-types",
+    "version" : "1.0 2.0"
+  }, {
+    "id" : "instance-formats",
+    "version" : "1.0 2.0"
+  }, {
+    "id" : "identifier-types",
+    "version" : "1.0"
+  }, {
+    "id" : "locations",
+    "version" : "2.1 3.0"
+  } ],
+  "provides" : [ {
+    "id" : "codex",
+    "version" : "3.2",
+    "interfaceType" : "multiple",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/codex-instances",
+      "permissionsRequired" : [ ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/codex-instances/{id}",
+      "permissionsRequired" : [ ]
+    } ]
+  } ],
+  "permissionSets" : [ ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-codex-inventory:1.7.0",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-codex-mux-2.8.0",
+  "name" : "Codex Multiplexer",
+  "requires" : [ ],
+  "provides" : [ {
+    "id" : "codex",
+    "version" : "3.3",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/codex-instances",
+      "permissionsRequired" : [ "codex-mux.instances.collection.get" ],
+      "modulePermissions" : [ "codex-ekb.instances.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/codex-instances/{id}",
+      "permissionsRequired" : [ "codex-mux.instances.item.get" ],
+      "modulePermissions" : [ "codex-ekb.instances.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/codex-instances-sources",
+      "permissionsRequired" : [ "codex-mux.instances-sources.collection.get" ],
+      "modulePermissions" : [ "codex-ekb.instances-sources.collection.get" ]
+    } ]
+  }, {
+    "id" : "codex-packages",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/codex-packages",
+      "permissionsRequired" : [ "codex-mux.packages.collection.get" ],
+      "modulePermissions" : [ "codex-ekb.packages.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/codex-packages/{id}",
+      "permissionsRequired" : [ "codex-mux.packages.item.get" ],
+      "modulePermissions" : [ "codex-ekb.packages.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/codex-packages-sources",
+      "permissionsRequired" : [ "codex-mux.packages-sources.collection.get" ],
+      "modulePermissions" : [ "codex-ekb.packages-sources.collection.get" ]
+    } ]
+  }, {
+    "id" : "_jsonSchemas",
+    "version" : "1.0",
+    "interfaceType" : "multiple",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/_/jsonSchemas",
+      "permissionsRequired" : [ ]
+    } ]
+  }, {
+    "id" : "_ramls",
+    "version" : "1.0",
+    "interfaceType" : "multiple",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/_/ramls",
+      "permissionsRequired" : [ ]
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "codex-mux.instances.collection.get",
+    "displayName" : "get codex instances",
+    "description" : "Get codex instances"
+  }, {
+    "permissionName" : "codex-mux.instances.item.get",
+    "displayName" : "get codex instance",
+    "description" : "Get codex instance"
+  }, {
+    "permissionName" : "codex-mux.instances-sources.collection.get",
+    "displayName" : "get codex instances sources",
+    "description" : "Get codex instances sources"
+  }, {
+    "permissionName" : "codex-mux.packages.collection.get",
+    "displayName" : "get codex packages",
+    "description" : "Get codex packages"
+  }, {
+    "permissionName" : "codex-mux.packages.item.get",
+    "displayName" : "get codex package",
+    "description" : "Get codex package"
+  }, {
+    "permissionName" : "codex-mux.packages-sources.collection.get",
+    "displayName" : "get codex package sources",
+    "description" : "Get codex package sources"
+  }, {
+    "permissionName" : "codex-mux.all",
+    "displayName" : "Codex Multiplexer - all permissions",
+    "description" : "All permissions for Codex Multiplexer",
+    "subPermissions" : [ "codex-mux.instances.collection.get", "codex-mux.instances.item.get", "codex-mux.instances-sources.collection.get", "codex-mux.packages.collection.get", "codex-mux.packages.item.get", "codex-mux.packages-sources.collection.get" ]
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-codex-mux:2.8.0",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-configuration-5.4.4",
+  "name" : "Configuration",
+  "provides" : [ {
+    "id" : "configuration",
+    "version" : "2.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/configurations/entries",
+      "permissionsRequired" : [ "configuration.entries.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/configurations/entries/{id}",
+      "permissionsRequired" : [ "configuration.entries.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/configurations/entries",
+      "permissionsRequired" : [ "configuration.entries.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/configurations/entries/{id}",
+      "permissionsRequired" : [ "configuration.entries.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/configurations/entries/{id}",
+      "permissionsRequired" : [ "configuration.entries.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/configurations/audit",
+      "permissionsRequired" : [ "configuration.audit.collection.get" ]
+    } ]
+  }, {
+    "id" : "_tenant",
+    "version" : "1.2",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/_/tenant"
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/_/tenant"
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "configuration.entries.collection.get",
+    "displayName" : "configuration - get configuration entries collection",
+    "description" : "get configuration entries from storage"
+  }, {
+    "permissionName" : "configuration.entries.item.get",
+    "displayName" : "configuration - get configuration entry",
+    "description" : "get individual configuration entry from storage"
+  }, {
+    "permissionName" : "configuration.entries.item.post",
+    "displayName" : "configuration - create configuration entry",
+    "description" : "create individual configuration entry in storage"
+  }, {
+    "permissionName" : "configuration.entries.item.put",
+    "displayName" : "configuration - modify configuration entry",
+    "description" : "modify individual configuration entry in storage"
+  }, {
+    "permissionName" : "configuration.entries.item.delete",
+    "displayName" : "configuration - delete configuration entry",
+    "description" : "delete individual configuration entry in storage"
+  }, {
+    "permissionName" : "configuration.audit.collection.get",
+    "displayName" : "configuration - get configuration audit entries collection",
+    "description" : "get configuration audit entries from storage"
+  }, {
+    "permissionName" : "configuration.all",
+    "displayName" : "configuration module - all permissions",
+    "description" : "entire set of permissions needed to use the configuration module",
+    "subPermissions" : [ "configuration.entries.collection.get", "configuration.entries.item.get", "configuration.entries.item.post", "configuration.entries.item.put", "configuration.entries.item.delete", "configuration.audit.collection.get" ]
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-configuration:5.4.4",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    }, {
+      "name" : "DB_HOST",
+      "value" : "postgres"
+    }, {
+      "name" : "DB_PORT",
+      "value" : "5432"
+    }, {
+      "name" : "DB_USERNAME",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_PASSWORD",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_DATABASE",
+      "value" : "okapi_modules"
+    }, {
+      "name" : "DB_QUERYTIMEOUT",
+      "value" : "60000"
+    }, {
+      "name" : "DB_CHARSET",
+      "value" : "UTF-8"
+    }, {
+      "name" : "DB_MAXPOOLSIZE",
+      "value" : "5"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-courses-1.0.7",
+  "name" : "Courses Storage Module",
+  "requires" : [ {
+    "id" : "item-storage",
+    "version" : "7.0 8.0"
+  }, {
+    "id" : "instance-storage",
+    "version" : "7.2"
+  }, {
+    "id" : "holdings-storage",
+    "version" : "2.0 3.0 4.0"
+  }, {
+    "id" : "locations",
+    "version" : "2.0 3.0"
+  }, {
+    "id" : "service-points",
+    "version" : "3.0"
+  }, {
+    "id" : "loan-types",
+    "version" : "2.0"
+  } ],
+  "provides" : [ {
+    "id" : "course-reserves-storage",
+    "version" : "0.3",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/coursereserves/courselistings",
+      "permissionsRequired" : [ "course-reserves-storage.courselistings.collection.get" ],
+      "modulePermissions" : [ "inventory-storage.locations.item.get", "inventory-storage.service-points.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/coursereserves/courselistings",
+      "permissionsRequired" : [ "course-reserves-storage.courselistings.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/coursereserves/courselistings/{id}",
+      "permissionsRequired" : [ "course-reserves-storage.courselistings.item.get" ],
+      "modulePermissions" : [ "inventory-storage.locations.item.get", "inventory-storage.service-points.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/coursereserves/courselistings/{id}",
+      "permissionsRequired" : [ "course-reserves-storage.courselistings.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/coursereserves/courselistings/{id}",
+      "permissionsRequired" : [ "course-reserves-storage.courselistings.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/coursereserves/courselistings/{id}/courses",
+      "permissionsRequired" : [ "course-reserves-storage.courselistings.courses.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/coursereserves/courselistings/{id}/courses",
+      "permissionsRequired" : [ "course-reserves-storage.courselisting.courses.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/coursereserves/courselistings/{id}/courses/{c_id}",
+      "permissionsRequired" : [ "course-reserves-storage.courselistings.courses.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/coursereserves/courselistings/{id}/courses/{c_id}",
+      "permissionsRequired" : [ "course-reserves-storage.courselistings.courses.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/coursereserves/courselistings/{id}/courses/{c_id}",
+      "permissionsRequired" : [ "course-reserves-storage.courselistings.courses.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/coursereserves/courselistings/{id}/instructors",
+      "permissionsRequired" : [ "course-reserves-storage.courselistings.instructors.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/coursereserves/courselistings/{id}/instructors",
+      "permissionsRequired" : [ "course-reserves-storage.courselistings.instructors.item.post" ],
+      "modulePermissions" : [ "users.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/coursereserves/courselistings/{id}/instructors/{i_id}",
+      "permissionsRequired" : [ "course-reserves-storage.courselistings.instructors.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/coursereserves/courselistings/{id}/instructors/{i_id}",
+      "permissionsRequired" : [ "course-reserves-storage.courselistings.instructors.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/coursereserves/courselistings/{id}/instructors/{i_id}",
+      "permissionsRequired" : [ "course-reserves-storage.courselistings.instructors.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/coursereserves/courselistings/{id}/reserves",
+      "permissionsRequired" : [ "course-reserves-storage.courselistings.reserves.collection.get" ],
+      "modulePermissions" : [ "inventory-storage.locations.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/coursereserves/courselistings/{id}/reserves",
+      "permissionsRequired" : [ "course-reserves-storage.courselistings.reserves.item.post" ],
+      "modulePermissions" : [ "inventory-storage.items.item.put", "inventory-storage.items.item.get", "inventory-storage.items.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.instances.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/coursereserves/courselistings/{id}/reserves/{r_id}",
+      "permissionsRequired" : [ "course-reserves-storage.courselistings.reserves.item.get" ],
+      "modulePermissions" : [ "inventory-storage.locations.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/coursereserves/courselistings/{id}/reserves/{r_id}",
+      "permissionsRequired" : [ "course-reserves-storage.courselistings.reserves.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/coursereserves/courselistings/{id}/reserves/{r_id}",
+      "permissionsRequired" : [ "course-reserves-storage.courselistings.reserves.item.delete" ]
+    } ]
+  }, {
+    "id" : "term-storage",
+    "version" : "0.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/coursereserves/terms",
+      "permissionsRequired" : [ "course-reserves-storage.terms.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/coursereserves/terms",
+      "permissionsRequired" : [ "course-reserves-storage.terms.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/coursereserves/terms/{id}",
+      "permissionsRequired" : [ "course-reserves-storage.terms.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/coursereserves/terms/{id}",
+      "permissionsRequired" : [ "course-reserves-storage.terms.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/coursereserves/terms/{id}",
+      "permissionsRequired" : [ "course-reserves-storage.terms.item.delete" ]
+    } ]
+  }, {
+    "id" : "department-storage",
+    "version" : "0.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/coursereserves/departments",
+      "permissionsRequired" : [ "course-reserves-storage.departments.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/coursereserves/departments",
+      "permissionsRequired" : [ "course-reserves-storage.departments.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/coursereserves/departments/{id}",
+      "permissionsRequired" : [ "course-reserves-storage.departments.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/coursereserves/departments/{id}",
+      "permissionsRequired" : [ "course-reserves-storage.departments.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/coursereserves/departments/{id}",
+      "permissionsRequired" : [ "course-reserves-storage.departments.item.delete" ]
+    } ]
+  }, {
+    "id" : "course-type-storage",
+    "version" : "0.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/coursereserves/coursetypes",
+      "permissionsRequired" : [ "course-reserves-storage.course-types.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/coursereserves/coursetypes",
+      "permissionsRequired" : [ "course-reserves-storage.course-types.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/coursereserves/coursetypes/{id}",
+      "permissionsRequired" : [ "course-reserves-storage.course-types.item.put" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/coursereserves/coursetypes/{id}",
+      "permissionsRequired" : [ "course-reserves-storage.course-types.item.get" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/coursereserves/coursetypes/{id}",
+      "permissionsRequired" : [ "course-reserves-storage.course-types.item.delete" ]
+    } ]
+  }, {
+    "id" : "processing-status-storage",
+    "version" : "0.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/coursereserves/processingstatuses",
+      "permissionsRequired" : [ "course-reserves-storage.processing-statuses.collection.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/coursereserves/processingstatuses/{id}",
+      "permissionsRequired" : [ "course-reserves-storage.processing-statuses.item.put" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/coursereserves/processingstatuses",
+      "permissionsRequired" : [ "course-reserves-storage.processing-statuses.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/coursereserves/processingstatuses/{id}",
+      "permissionsRequired" : [ "course-reserves-storage.processing-statuses.item.get" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/coursereserves/processingstatuses/{id}",
+      "permissionsRequired" : [ "course-reserves-storage.processing-statuses.item.delete" ]
+    } ]
+  }, {
+    "id" : "copyright-status-storage",
+    "version" : "0.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/coursereserves/copyrightstatuses",
+      "permissionsRequired" : [ "course-reserves-storage.copyright-statuses.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/coursereserves/copyrightstatuses",
+      "permissionsRequired" : [ "course-reserves-storage.copyright-statuses.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/coursereserves/copyrightstatuses/{id}",
+      "permissionsRequired" : [ "course-reserves-storage.copyright-statuses.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/coursereserves/copyrightstatuses/{id}",
+      "permissionsRequired" : [ "course-reserves-storage.copyright-statuses.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/coursereserves/copyrightstatuses/{id}",
+      "permissionsRequired" : [ "course-reserves-storage.copyright-statuses.item.delete" ]
+    } ]
+  }, {
+    "id" : "role-storage",
+    "version" : "0.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/coursereserves/roles",
+      "permissionsRequired" : [ "course-reserves-storage.roles.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/coursereserves/roles",
+      "permissionsRequired" : [ "course-reserves-storage.roles.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/coursereserves/roles/{id}",
+      "permissionsRequired" : [ "course-reserves-storage.roles.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/coursereserves/roles/{id}",
+      "permissionsRequired" : [ "course-reserves-storage.roles.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/coursereserves/roles/{id}",
+      "permissionsRequired" : [ "course-reserves-storage.roles.item.delete" ]
+    } ]
+  }, {
+    "id" : "course-storage",
+    "version" : "0.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/coursereserves/courses",
+      "permissionsRequired" : [ "course-reserves-storage.courses.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/coursereserves/courses",
+      "permissionsRequired" : [ "course-reserves-storage.courses.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/coursereserves/courses/{id}",
+      "permissionsRequired" : [ "course-reserves-storage.courses.item.get" ],
+      "modulePermissions" : [ "inventory-storage.locations.item.get", "inventory-storage.service-points.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/coursereserves/courses/{id}",
+      "permissionsRequired" : [ "course-reserves-storage.courses.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/coursereserves/courses/{id}",
+      "permissionsRequired" : [ "course-reserves-storage.courses.item.delete" ]
+    } ]
+  }, {
+    "id" : "reserves-storage",
+    "version" : "0.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/coursereserves/reserves",
+      "permissionsRequired" : [ "course-reserves-storage.reserves.collection.get" ],
+      "modulePermissions" : [ "inventory-storage.locations.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/coursereserves/reserves",
+      "permissionsRequired" : [ "course-reserves-storage.reserves.item.post" ],
+      "modulePermissions" : [ "inventory-storage.items.item.put", "inventory-storage.items.item.get", "inventory-storage.items.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.instances.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/coursereserves/reserves/{id}",
+      "permissionsRequired" : [ "course-reserves-storage.reserves.item.get" ],
+      "modulePermissions" : [ "inventory-storage.locations.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/coursereserves/reserves/{id}",
+      "permissionsRequired" : [ "course-reserves-storage.reserves.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/coursereserves/reserves/{id}",
+      "permissionsRequired" : [ "course-reserves-storage.reserves.item.delete" ]
+    } ]
+  }, {
+    "id" : "_tenant",
+    "version" : "1.2",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/_/tenant",
+      "modulePermissions" : [ "inventory-storage.items.item.put", "inventory-storage.items.item.get", "inventory-storage.items.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.instances.item.get", "users.item.get" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/_/tenant"
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "course-reserves-storage.courselistings.collection.get",
+    "displayName" : "course reserves get courselistings collection",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.courselistings.item.post",
+    "displayName" : "course reserves post courselistings item",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.courselistings.item.get",
+    "displayName" : "course reserves get courselisting item",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.courselistings.item.put",
+    "displayName" : "course reserves put courselisting item",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.courselistings.item.delete",
+    "displayName" : "course reserves delete courselisting item",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.courselistings.courses.collection.get",
+    "displayName" : "course reserves get courses collection for courselisting",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.courselisting.courses.item.post",
+    "displayName" : "course reserves post course item for courselisting",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.courselistings.courses.item.get",
+    "displayName" : "course reserves get course item for courselisting",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.courselistings.courses.item.put",
+    "displayName" : "course reserves put course item for courselisting",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.courselistings.courses.item.delete",
+    "displayName" : "course reserves delete course item for courselisting",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.courselistings.instructors.collection.get",
+    "displayName" : "course reserves get instructors collection for courselisting",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.courselistings.instructors.item.post",
+    "displayName" : "course reserves post instructors item for courselisting",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.courselistings.instructors.item.get",
+    "displayName" : "course reserves get instructors item for courselisting",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.courselistings.instructors.item.put",
+    "displayName" : "course reserves put instructors item for courselisting",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.courselistings.instructors.item.delete",
+    "displayName" : "course reserves delete instructors item for courselisting",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.courselistings.reserves.collection.get",
+    "displayName" : "course reserves get reserves collection for courselisting",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.courselistings.reserves.item.post",
+    "displayName" : "course reserves post reserves item for courselisting",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.courselistings.reserves.item.get",
+    "displayName" : "course reserves get reserves item for courselisting",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.courselistings.reserves.item.put",
+    "displayName" : "course reserves put reserves item for courselisting",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.courselistings.reserves.item.delete",
+    "displayName" : "course reserves delete reserves item for courselisting",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.courselistings.read",
+    "displayName" : "read permissions for coursereserves courselisting",
+    "description" : "pending",
+    "subPermissions" : [ "course-reserves-storage.courselistings.collection.get", "course-reserves-storage.courselistings.item.get", "course-reserves-storage.courselistings.courses.collection.get", "course-reserves-storage.courselistings.courses.item.get", "course-reserves-storage.courselistings.instructors.collection.get", "course-reserves-storage.courselistings.instructors.item.get", "course-reserves-storage.courselistings.reserves.collection.get", "course-reserves-storage.courselistings.reserves.item.get" ]
+  }, {
+    "permissionName" : "course-reserves-storage.courselistings.write",
+    "displayName" : "write permissions for coursereserves courselisting",
+    "description" : "pending",
+    "subPermissions" : [ "course-reserves-storage.courselistings.read", "course-reserves-storage.courselistings.item.post", "course-reserves-storage.courselistings.item.put", "course-reserves-storage.courselistings.item.delete", "course-reserves-storage.courselisting.courses.item.post", "course-reserves-storage.courselistings.courses.item.put", "course-reserves-storage.courselistings.courses.item.delete", "course-reserves-storage.courselistings.instructors.item.post", "course-reserves-storage.courselistings.instructors.item.put", "course-reserves-storage.courselistings.instructors.item.delete", "course-reserves-storage.courselistings.reserves.item.post", "course-reserves-storage.courselistings.reserves.item.put", "course-reserves-storage.courselistings.reserves.item.delete" ]
+  }, {
+    "permissionName" : "course-reserves-storage.terms.collection.get",
+    "displayName" : "course reserves get terms collection",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.terms.item.post",
+    "displayName" : "course reserves post terms item",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.terms.item.get",
+    "displayName" : "course reserves get terms item",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.terms.item.put",
+    "displayName" : "course reserves put terms item",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.terms.item.delete",
+    "displayName" : "course reserves delete terms item",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.terms.read",
+    "displayName" : "course reserves terms read permissions",
+    "description" : "pending",
+    "subPermissions" : [ "course-reserves-storage.terms.collection.get", "course-reserves-storage.terms.item.get" ]
+  }, {
+    "permissionName" : "course-reserves-storage.terms.write",
+    "displayName" : "course reserves terms write permissions",
+    "description" : "pending",
+    "subPermissions" : [ "course-reserves-storage.terms.read", "course-reserves-storage.terms.item.post", "course-reserves-storage.terms.item.put", "course-reserves-storage.terms.item.put", "course-reserves-storage.terms.item.delete" ]
+  }, {
+    "permissionName" : "course-reserves-storage.departments.collection.get",
+    "displayName" : "course reserves get departments collection",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.departments.item.post",
+    "displayName" : "course reserves post departments item",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.departments.item.get",
+    "displayName" : "course reserves get departments item",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.departments.item.put",
+    "displayName" : "course reserves put departments item",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.departments.item.delete",
+    "displayName" : "course reserves delete departments item",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.departments.read",
+    "displayName" : "course reserves departments read permissions",
+    "description" : "pending",
+    "subPermissions" : [ "course-reserves-storage.departments.collection.get", "course-reserves-storage.departments.item.get" ]
+  }, {
+    "permissionName" : "course-reserves-storage.departments.write",
+    "displayName" : "course reserves departments write permissions",
+    "description" : "pending",
+    "subPermissions" : [ "course-reserves-storage.departments.read", "course-reserves-storage.departments.item.post", "course-reserves-storage.departments.item.put", "course-reserves-storage.departments.item.delete" ]
+  }, {
+    "permissionName" : "course-reserves-storage.course-types.collection.get",
+    "displayName" : "course reserves get course types collection",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.course-types.item.post",
+    "displayName" : "course reserves post course types item",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.course-types.item.put",
+    "displayName" : "course reserves put course types item",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.course-types.item.get",
+    "displayName" : "course reserves get course types item",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.course-types.item.delete",
+    "displayName" : "course reserves delete course types item",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.course-types.read",
+    "displayName" : "course reserves course storage read permissions",
+    "description" : "pending",
+    "subPermissions" : [ "course-reserves-storage.course-types.collection.get", "course-reserves-storage.course-types.item.get" ]
+  }, {
+    "permissionName" : "course-reserves-storage.course-types.write",
+    "displayName" : "course reserves course storage write permissions",
+    "description" : "pending",
+    "subPermissions" : [ "course-reserves-storage.course-types.read", "course-reserves-storage.course-types.item.post", "course-reserves-storage.course-types.item.put", "course-reserves-storage.course-types.item.delete" ]
+  }, {
+    "permissionName" : "course-reserves-storage.processing-statuses.collection.get",
+    "displayName" : "course reserves get processing statuses collection",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.processing-statuses.item.put",
+    "displayName" : "course reserves put processing statuses item",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.processing-statuses.item.post",
+    "displayName" : "course reserves post processing statuses item",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.processing-statuses.item.get",
+    "displayName" : "course reserves get processing statuses item",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.processing-statuses.item.delete",
+    "displayName" : "course reserves delete processing statuses item",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.processing-statuses.read",
+    "displayName" : "course reserves processing statuses read permissions",
+    "description" : "pending",
+    "subPermissions" : [ "course-reserves-storage.processing-statuses.collection.get", "course-reserves-storage.processing-statuses.item.get" ]
+  }, {
+    "permissionName" : "course-reserves-storage.processing-statuses.write",
+    "displayName" : "course reserves processing statuses write permissions",
+    "description" : "pending",
+    "subPermissions" : [ "course-reserves-storage.processing-statuses.read", "course-reserves-storage.processing-statuses.item.put", "course-reserves-storage.processing-statuses.item.post", "course-reserves-storage.processing-statuses.item.delete" ]
+  }, {
+    "permissionName" : "course-reserves-storage.copyright-statuses.collection.get",
+    "displayName" : "course reserves get copyright statuses collection",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.copyright-statuses.item.put",
+    "displayName" : "course reserves put copyright statuses item",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.copyright-statuses.item.post",
+    "displayName" : "course reserves post copyright statuses item",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.copyright-statuses.item.get",
+    "displayName" : "course reserves get copyright statuses item",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.copyright-statuses.item.delete",
+    "displayName" : "course reserves delete copyright statuses item",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.copyright-statuses.read",
+    "displayName" : "course reserves copyright statuses read permissions",
+    "description" : "pending",
+    "subPermissions" : [ "course-reserves-storage.copyright-statuses.collection.get", "course-reserves-storage.copyright-statuses.item.get" ]
+  }, {
+    "permissionName" : "course-reserves-storage.copyright-statuses.write",
+    "displayName" : "course reserves copyright statuses write permissions",
+    "description" : "pending",
+    "subPermissions" : [ "course-reserves-storage.copyright-statuses.read", "course-reserves-storage.copyright-statuses.item.put", "course-reserves-storage.copyright-statuses.item.post", "course-reserves-storage.copyright-statuses.item.delete" ]
+  }, {
+    "permissionName" : "course-reserves-storage.roles.collection.get",
+    "displayName" : "course reserves get roles collection",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.roles.item.post",
+    "displayName" : "course reserves post roles item",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.roles.item.get",
+    "displayName" : "course reserves get roles item",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.roles.item.put",
+    "displayName" : "course reserves put roles item",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.roles.item.delete",
+    "displayName" : "course reserves delete roles item",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.roles.read",
+    "displayName" : "course reserves roles read permissions",
+    "description" : "pending",
+    "subPermissions" : [ "course-reserves-storage.roles.collection.get", "course-reserves-storage.roles.item.get" ]
+  }, {
+    "permissionName" : "course-reserves-storage.roles.write",
+    "displayName" : "course reserves roles write permissions",
+    "description" : "pending",
+    "subPermissions" : [ "course-reserves-storage.roles.read", "course-reserves-storage.roles.item.post", "course-reserves-storage.roles.item.put", "course-reserves-storage.roles.item.delete" ]
+  }, {
+    "permissionName" : "course-reserves-storage.courses.collection.get",
+    "displayName" : "course reserves get course listing",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.courses.item.post",
+    "displayName" : "course reserves post course item",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.courses.item.get",
+    "displayName" : "course reserves get course item",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.courses.item.put",
+    "displayName" : "course reserves put course item",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.courses.item.delete",
+    "displayName" : "course reserves delete course item",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.courses.read",
+    "displayName" : "course reserves courses read permissions",
+    "description" : "pending",
+    "subPermissions" : [ "course-reserves-storage.courses.collection.get", "course-reserves-storage.courses.item.get" ]
+  }, {
+    "permissionName" : "course-reserves-storage.courses.write",
+    "displayName" : "course reserves courses write permissions",
+    "description" : "pending",
+    "subPermissions" : [ "course-reserves-storage.courses.read", "course-reserves-storage.courses.item.post", "course-reserves-storage.courses.item.put", "course-reserves-storage.courses.item.delete" ]
+  }, {
+    "permissionName" : "course-reserves-storage.reserves.collection.get",
+    "displayName" : "course reserves get reserve listing",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.reserves.item.post",
+    "displayName" : "course reserves post reserve item",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.reserves.item.get",
+    "displayName" : "course reserves get reserve item",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.reserves.item.put",
+    "displayName" : "course reserves put reserve item",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.reserves.item.delete",
+    "displayName" : "course reserves delete reserve item",
+    "description" : "pending"
+  }, {
+    "permissionName" : "course-reserves-storage.reserves.read",
+    "displayName" : "course reserves reserves read permissions",
+    "description" : "pending",
+    "subPermissions" : [ "course-reserves-storage.reserves.collection.get", "course-reserves-storage.reserves.item.get" ]
+  }, {
+    "permissionName" : "course-reserves-storage.reserves.write",
+    "displayName" : "course reserves reserves write permissions",
+    "description" : "pending",
+    "subPermissions" : [ "course-reserves-storage.reserves.read", "course-reserves-storage.reserves.item.post", "course-reserves-storage.reserves.item.put", "course-reserves-storage.reserves.item.delete" ]
+  }, {
+    "permissionName" : "course-reserves-storage.all",
+    "displayName" : "course reserves all permissions",
+    "description" : "pending",
+    "subPermissions" : [ "course-reserves-storage.terms.write", "course-reserves-storage.courselistings.write", "course-reserves-storage.roles.write", "course-reserves-storage.departments.write", "course-reserves-storage.course-types.write", "course-reserves-storage.processing-statuses.write", "course-reserves-storage.copyright-statuses.write", "course-reserves-storage.courses.write", "course-reserves-storage.reserves.write" ]
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-courses:1.0.7",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    }, {
+      "name" : "DB_HOST",
+      "value" : "postgres"
+    }, {
+      "name" : "DB_PORT",
+      "value" : "5432"
+    }, {
+      "name" : "DB_USERNAME",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_PASSWORD",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_DATABASE",
+      "value" : "okapi_modules"
+    }, {
+      "name" : "DB_QUERYTIMEOUT",
+      "value" : "60000"
+    }, {
+      "name" : "DB_CHARSET",
+      "value" : "UTF-8"
+    }, {
+      "name" : "DB_MAXPOOLSIZE",
+      "value" : "5"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-data-export-2.1.4",
+  "name" : "Data Export Module",
+  "requires" : [ {
+    "id" : "source-storage-source-records",
+    "version" : "2.0"
+  }, {
+    "id" : "users",
+    "version" : "15.1"
+  }, {
+    "id" : "instance-storage",
+    "version" : "7.4"
+  }, {
+    "id" : "holdings-storage",
+    "version" : "4.2"
+  }, {
+    "id" : "item-storage",
+    "version" : "8.4"
+  }, {
+    "id" : "nature-of-content-terms",
+    "version" : "1.0"
+  }, {
+    "id" : "identifier-types",
+    "version" : "1.2"
+  }, {
+    "id" : "contributor-name-types",
+    "version" : "1.2"
+  }, {
+    "id" : "locations",
+    "version" : "3.0"
+  }, {
+    "id" : "material-types",
+    "version" : "2.2"
+  }, {
+    "id" : "instance-types",
+    "version" : "2.0"
+  }, {
+    "id" : "instance-formats",
+    "version" : "2.0"
+  }, {
+    "id" : "configuration",
+    "version" : "2.0"
+  } ],
+  "provides" : [ {
+    "id" : "data-export",
+    "version" : "2.0",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/data-export/export",
+      "permissionsRequired" : [ "data-export.export.post" ],
+      "modulePermissions" : [ "users.item.get", "source-storage.sourceRecords.get", "inventory-storage.instances.collection.get", "inventory-storage.holdings.collection.get", "inventory-storage.items.collection.get", "inventory-storage.nature-of-content-terms.collection.get", "inventory-storage.identifier-types.collection.get", "inventory-storage.contributor-name-types.collection.get", "inventory-storage.locations.collection.get", "inventory-storage.material-types.collection.get", "inventory-storage.instance-types.collection.get", "inventory-storage.instance-formats.collection.get", "configuration.entries.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/data-export/fileDefinitions/{fileDefinitionId}",
+      "permissionsRequired" : [ "data-export.file-definitions.item.get" ],
+      "modulePermissions" : [ ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/data-export/fileDefinitions",
+      "permissionsRequired" : [ "data-export.file-definitions.item.post" ],
+      "modulePermissions" : [ ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/data-export/fileDefinitions/{fileDefinitionId}/upload",
+      "permissionsRequired" : [ "data-export.file-definitions.upload.post" ],
+      "modulePermissions" : [ ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/data-export/jobExecutions",
+      "permissionsRequired" : [ "data-export.job-executions.items.get" ],
+      "modulePermissions" : [ ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/data-export/jobExecutions/{jobId}/download/{fileId}",
+      "permissionsRequired" : [ "data-export.job-executions.items.download.get" ],
+      "modulePermissions" : [ ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/data-export/jobProfiles",
+      "permissionsRequired" : [ "data-export.job-profiles.item.post" ],
+      "modulePermissions" : [ "users.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/data-export/jobProfiles",
+      "permissionsRequired" : [ "data-export.job-profiles.collection.get" ],
+      "modulePermissions" : [ ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/data-export/jobProfiles/{jobProfileId}",
+      "permissionsRequired" : [ "data-export.job-profiles.item.get" ],
+      "modulePermissions" : [ ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/data-export/jobProfiles/{jobProfileId}",
+      "permissionsRequired" : [ "data-export.job-profiles.item.put" ],
+      "modulePermissions" : [ "users.item.get" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/data-export/jobProfiles/{jobProfileId}",
+      "permissionsRequired" : [ "data-export.job-profiles.item.delete" ],
+      "modulePermissions" : [ ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/data-export/mappingProfiles",
+      "permissionsRequired" : [ "data-export.mapping-profiles.item.post" ],
+      "modulePermissions" : [ "users.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/data-export/mappingProfiles",
+      "permissionsRequired" : [ "data-export.mapping-profiles.collection.get" ],
+      "modulePermissions" : [ ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/data-export/mappingProfiles/{mappingProfileId}",
+      "permissionsRequired" : [ "data-export.mapping-profiles.item.get" ],
+      "modulePermissions" : [ ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/data-export/mappingProfiles/{mappingProfileId}",
+      "permissionsRequired" : [ "data-export.mapping-profiles.item.put" ],
+      "modulePermissions" : [ "users.item.get" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/data-export/mappingProfiles/{mappingProfileId}",
+      "permissionsRequired" : [ "data-export.mapping-profiles.item.delete" ],
+      "modulePermissions" : [ ]
+    } ]
+  }, {
+    "id" : "_tenant",
+    "version" : "1.2",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/_/tenant"
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/_/tenant"
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "data-export.export.post",
+    "displayName" : "Starts export process",
+    "description" : "Entry point to start export for the given file definition using job profile"
+  }, {
+    "permissionName" : "data-export.file-definitions.item.get",
+    "displayName" : "Data Export - get file definition by id",
+    "description" : "Entry point to get File Definition by id"
+  }, {
+    "permissionName" : "data-export.job-executions.collection.get",
+    "displayName" : "Data Export - get job execution collection by query",
+    "description" : "Entry point to get Job Executions by query"
+  }, {
+    "permissionName" : "data-export.file-definitions.upload.post",
+    "displayName" : "Data Export - upload file",
+    "description" : "Entry point to upload file"
+  }, {
+    "permissionName" : "data-export.file-definitions.item.post",
+    "displayName" : "Data Export - create new file definition",
+    "description" : "Entry point to post File Definition"
+  }, {
+    "permissionName" : "data-export.job-executions.items.download.get",
+    "displayName" : "Data Export - get download link for job and a file",
+    "description" : "Entry point to get link to download exported files"
+  }, {
+    "permissionName" : "data-export.job-profiles.item.post",
+    "displayName" : "Data Export - create new job profile",
+    "description" : "Entry point to post Job Profile"
+  }, {
+    "permissionName" : "data-export.job-profiles.collection.get",
+    "displayName" : "Data Export - get job profiles collection by query",
+    "description" : "Entry point to get Job Profiles by query"
+  }, {
+    "permissionName" : "data-export.job-profiles.item.get",
+    "displayName" : "Data Export - get job profile by id",
+    "description" : "Entry point to get Job Profiles by id"
+  }, {
+    "permissionName" : "data-export.job-profiles.item.put",
+    "displayName" : "Data Export - update existing job profile by id",
+    "description" : "Entry point to update Job Profile"
+  }, {
+    "permissionName" : "data-export.job-profiles.item.delete",
+    "displayName" : "Data Export - delete job profile by id",
+    "description" : "Entry point to delete Job Profile by id"
+  }, {
+    "permissionName" : "data-export.mapping-profiles.item.post",
+    "displayName" : "Data Export - create new mapping profile",
+    "description" : "Entry point to post Mapping Profile"
+  }, {
+    "permissionName" : "data-export.mapping-profiles.items.get",
+    "displayName" : "Data Export - get mapping profiles collection by query",
+    "description" : "Entry point to get Mapping Profiles by query"
+  }, {
+    "permissionName" : "data-export.mapping-profiles.item.get",
+    "displayName" : "Data Export - get mapping profile by id",
+    "description" : "Entry point to get Mapping Profiles by id"
+  }, {
+    "permissionName" : "data-export.mapping-profiles.item.put",
+    "displayName" : "Data Export - update existing mapping profile by id",
+    "description" : "Entry point to update Mapping Profile"
+  }, {
+    "permissionName" : "data-export.mapping-profiles.item.delete",
+    "displayName" : "Data Export - delete mapping profile by id",
+    "description" : "Entry point to delete Mapping Profile by id"
+  }, {
+    "permissionName" : "data-export.all",
+    "displayName" : "Data Export - all permissions",
+    "description" : "Entire set of permissions needed to use the Data Export",
+    "subPermissions" : [ "data-export.export.post", "data-export.file-definitions.item.get", "data-export.file-definitions.item.post", "data-export.file-definitions.upload.post", "data-export.job-executions.items.get", "data-export.job-executions.items.download.get", "data-export.job-profiles.item.post", "data-export.job-profiles.collection.get", "data-export.job-profiles.item.get", "data-export.job-profiles.item.put", "data-export.job-profiles.item.delete", "data-export.mapping-profiles.item.post", "data-export.mapping-profiles.collection.get", "data-export.mapping-profiles.item.get", "data-export.mapping-profiles.item.put", "data-export.mapping-profiles.item.delete" ],
+    "visible" : false
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-data-export:2.1.4",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    }, {
+      "name" : "DB_HOST",
+      "value" : "postgres"
+    }, {
+      "name" : "DB_PORT",
+      "value" : "5432"
+    }, {
+      "name" : "DB_USERNAME",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_PASSWORD",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_DATABASE",
+      "value" : "okapi_modules"
+    }, {
+      "name" : "DB_QUERYTIMEOUT",
+      "value" : "60000"
+    }, {
+      "name" : "DB_CHARSET",
+      "value" : "UTF-8"
+    }, {
+      "name" : "DB_MAXPOOLSIZE",
+      "value" : "5"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 542293850,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-data-import-1.10.2",
+  "name" : "Data Import Module",
+  "requires" : [ {
+    "id" : "source-manager-job-executions",
+    "version" : "1.0"
+  }, {
+    "id" : "source-manager-records",
+    "version" : "1.0"
+  }, {
+    "id" : "users",
+    "version" : "15.0"
+  } ],
+  "provides" : [ {
+    "id" : "data-import",
+    "version" : "3.0",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/data-import/uploadDefinitions",
+      "permissionsRequired" : [ "data-import.uploaddefinitions.post" ],
+      "modulePermissions" : [ "configuration.entries.collection.get", "change-manager.jobexecutions.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/data-import/uploadDefinitions",
+      "permissionsRequired" : [ "data-import.uploaddefinitions.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/data-import/uploadDefinitions/{uploadDefinitionId}",
+      "permissionsRequired" : [ "data-import.uploaddefinitions.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/data-import/uploadDefinitions/{uploadDefinitionId}",
+      "permissionsRequired" : [ "data-import.uploaddefinitions.put" ],
+      "modulePermissions" : [ "configuration.entries.collection.get" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/data-import/uploadDefinitions/{uploadDefinitionId}",
+      "permissionsRequired" : [ "data-import.uploaddefinitions.delete" ],
+      "modulePermissions" : [ "change-manager.jobexecutions.get", "change-manager.jobexecutions.put" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/data-import/uploadDefinitions/{uploadDefinitionId}/files/{fileId}",
+      "permissionsRequired" : [ "data-import.upload.file.post" ],
+      "modulePermissions" : [ "configuration.entries.collection.get", "change-manager.jobexecutions.post", "change-manager.jobexecutions.put" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/data-import/uploadDefinitions/{uploadDefinitionId}/files",
+      "permissionsRequired" : [ "data-import.uploaddefinitions.files.post" ],
+      "modulePermissions" : [ "configuration.entries.collection.get", "change-manager.jobexecutions.post" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/data-import/uploadDefinitions/{uploadDefinitionId}/files/{fileId}",
+      "permissionsRequired" : [ "data-import.uploaddefinitions.files.delete" ],
+      "modulePermissions" : [ "configuration.entries.collection.get", "change-manager.jobexecutions.put" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/data-import/uploadDefinitions/{uploadDefinitionId}/processFiles",
+      "permissionsRequired" : [ "data-import.uploaddefinitions.files.post" ],
+      "modulePermissions" : [ "change-manager.jobexecutions.get", "change-manager.jobexecutions.put", "change-manager.records.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/data-import/fileExtensions",
+      "permissionsRequired" : [ "data-import.fileExtensions.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/data-import/fileExtensions",
+      "permissionsRequired" : [ "data-import.fileExtensions.post" ],
+      "modulePermissions" : [ "users.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/data-import/fileExtensions/{id}",
+      "permissionsRequired" : [ "data-import.fileExtensions.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/data-import/fileExtensions/{id}",
+      "permissionsRequired" : [ "data-import.fileExtensions.put" ],
+      "modulePermissions" : [ "users.item.get" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/data-import/fileExtensions/{id}",
+      "permissionsRequired" : [ "data-import.fileExtensions.delete" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/data-import/fileExtensions/restore/default",
+      "permissionsRequired" : [ "data-import.fileExtensions.default" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/data-import/dataTypes",
+      "permissionsRequired" : [ "data-import.datatypes.get" ]
+    } ]
+  }, {
+    "id" : "_tenant",
+    "version" : "1.2",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/_/tenant"
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/_/tenant"
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "data-import.uploaddefinitions.post",
+    "displayName" : "Data Import - create new upload definition",
+    "description" : "Post Upload Definition"
+  }, {
+    "permissionName" : "data-import.uploaddefinitions.get",
+    "displayName" : "Data Import - get upload definition",
+    "description" : "Get Upload Definition"
+  }, {
+    "permissionName" : "data-import.uploaddefinitions.put",
+    "displayName" : "Data Import - update upload definition",
+    "description" : "Put Upload Definition"
+  }, {
+    "permissionName" : "data-import.uploaddefinitions.delete",
+    "displayName" : "Data Import - delete upload definition",
+    "description" : "Delete Upload Definition"
+  }, {
+    "permissionName" : "data-import.upload.file.post",
+    "displayName" : "Data Import - upload file into the storage",
+    "description" : "Upload file"
+  }, {
+    "permissionName" : "data-import.uploaddefinitions.files.delete",
+    "displayName" : "Data Import - delete file from upload definition and storage",
+    "description" : "Delete file"
+  }, {
+    "permissionName" : "data-import.uploaddefinitions.files.post",
+    "displayName" : "Data Import - Create new File Definition",
+    "description" : "Create and handle File Definition"
+  }, {
+    "permissionName" : "data-import.fileExtensions.get",
+    "displayName" : "Data Import - get file extension(s)",
+    "description" : "Get FileExtension(s)"
+  }, {
+    "permissionName" : "data-import.fileExtensions.post",
+    "displayName" : "Data Import - create new file extension",
+    "description" : "Post FileExtension"
+  }, {
+    "permissionName" : "data-import.fileExtensions.put",
+    "displayName" : "Data Import - update file extension",
+    "description" : "Put FileExtension"
+  }, {
+    "permissionName" : "data-import.fileExtensions.delete",
+    "displayName" : "Data Import - delete file extension",
+    "description" : "Delete FileExtension"
+  }, {
+    "permissionName" : "data-import.fileExtensions.default",
+    "displayName" : "Data Import - restore file extensions to default",
+    "description" : "Restore FileExtension to default"
+  }, {
+    "permissionName" : "data-import.datatypes.get",
+    "displayName" : "Data Import - get data types",
+    "description" : "Get DataTypes"
+  }, {
+    "permissionName" : "data-import.upload.all",
+    "displayName" : "Data Import File Upload - all permissions",
+    "description" : "Entire set of permissions needed to use file uploads",
+    "subPermissions" : [ "data-import.upload.file.post", "data-import.uploaddefinitions.post", "data-import.uploaddefinitions.get", "data-import.uploaddefinitions.put", "data-import.uploaddefinitions.delete", "data-import.uploaddefinitions.files.delete", "data-import.uploaddefinitions.files.post", "data-import.fileExtensions.get", "data-import.fileExtensions.post", "data-import.fileExtensions.put", "data-import.fileExtensions.delete", "data-import.fileExtensions.default", "data-import.datatypes.get" ],
+    "visible" : false
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-data-import:1.10.2",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    }, {
+      "name" : "DB_HOST",
+      "value" : "postgres"
+    }, {
+      "name" : "DB_PORT",
+      "value" : "5432"
+    }, {
+      "name" : "DB_USERNAME",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_PASSWORD",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_DATABASE",
+      "value" : "okapi_modules"
+    }, {
+      "name" : "DB_QUERYTIMEOUT",
+      "value" : "60000"
+    }, {
+      "name" : "DB_CHARSET",
+      "value" : "UTF-8"
+    }, {
+      "name" : "DB_MAXPOOLSIZE",
+      "value" : "5"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 542293850,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-data-import-converter-storage-1.8.3",
+  "name" : "Data Import Converter Storage",
+  "requires" : [ ],
+  "provides" : [ {
+    "id" : "data-import-converter-storage",
+    "version" : "1.2",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/data-import-profiles/jobProfiles",
+      "permissionsRequired" : [ "converter-storage.jobprofile.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/data-import-profiles/jobProfiles",
+      "permissionsRequired" : [ "converter-storage.jobprofile.post" ],
+      "modulePermissions" : [ "users.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/data-import-profiles/jobProfiles/{id}",
+      "permissionsRequired" : [ "converter-storage.jobprofile.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/data-import-profiles/jobProfiles/{id}",
+      "permissionsRequired" : [ "converter-storage.jobprofile.put" ],
+      "modulePermissions" : [ "users.item.get" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/data-import-profiles/jobProfiles/{id}",
+      "permissionsRequired" : [ "converter-storage.jobprofile.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/data-import-profiles/matchProfiles",
+      "permissionsRequired" : [ "converter-storage.matchprofile.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/data-import-profiles/matchProfiles",
+      "permissionsRequired" : [ "converter-storage.matchprofile.post" ],
+      "modulePermissions" : [ "users.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/data-import-profiles/matchProfiles/{id}",
+      "permissionsRequired" : [ "converter-storage.matchprofile.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/data-import-profiles/matchProfiles/{id}",
+      "permissionsRequired" : [ "converter-storage.matchprofile.put" ],
+      "modulePermissions" : [ "users.item.get" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/data-import-profiles/matchProfiles/{id}",
+      "permissionsRequired" : [ "converter-storage.matchprofile.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/data-import-profiles/actionProfiles",
+      "permissionsRequired" : [ "converter-storage.actionprofile.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/data-import-profiles/actionProfiles",
+      "permissionsRequired" : [ "converter-storage.actionprofile.post" ],
+      "modulePermissions" : [ "users.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/data-import-profiles/actionProfiles/{id}",
+      "permissionsRequired" : [ "converter-storage.actionprofile.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/data-import-profiles/actionProfiles/{id}",
+      "permissionsRequired" : [ "converter-storage.actionprofile.put" ],
+      "modulePermissions" : [ "users.item.get" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/data-import-profiles/actionProfiles/{id}",
+      "permissionsRequired" : [ "converter-storage.actionprofile.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/data-import-profiles/mappingProfiles",
+      "permissionsRequired" : [ "converter-storage.mappingprofile.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/data-import-profiles/mappingProfiles",
+      "permissionsRequired" : [ "converter-storage.mappingprofile.post" ],
+      "modulePermissions" : [ "users.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/data-import-profiles/mappingProfiles/{id}",
+      "permissionsRequired" : [ "converter-storage.mappingprofile.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/data-import-profiles/mappingProfiles/{id}",
+      "permissionsRequired" : [ "converter-storage.mappingprofile.put" ],
+      "modulePermissions" : [ "users.item.get" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/data-import-profiles/mappingProfiles/{id}",
+      "permissionsRequired" : [ "converter-storage.mappingprofile.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/data-import-profiles/profileAssociations",
+      "permissionsRequired" : [ "converter-storage.profileassociation.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/data-import-profiles/profileAssociations",
+      "permissionsRequired" : [ "converter-storage.profileassociation.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/data-import-profiles/profileAssociations/{id}",
+      "permissionsRequired" : [ "converter-storage.profileassociation.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/data-import-profiles/profileAssociations/{id}",
+      "permissionsRequired" : [ "converter-storage.profileassociation.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/data-import-profiles/profileAssociations/{id}",
+      "permissionsRequired" : [ "converter-storage.profileassociation.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/data-import-profiles/profileAssociations/{masterId}/details",
+      "permissionsRequired" : [ "converter-storage.profileassociation.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/data-import-profiles/profileAssociations/{detailId}/masters",
+      "permissionsRequired" : [ "converter-storage.profileassociation.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/data-import-profiles/jobProfileSnapshots/{id}",
+      "permissionsRequired" : [ "converter-storage.jobprofilesnapshots.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/data-import-profiles/jobProfileSnapshots/{id}",
+      "permissionsRequired" : [ "converter-storage.jobprofilesnapshots.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/data-import-profiles/entityTypes",
+      "permissionsRequired" : [ "converter-storage.entitytypes.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/data-import-profiles/profileSnapshots/{profileId}",
+      "permissionsRequired" : [ "converter-storage.profileSnapshots.get" ]
+    } ]
+  }, {
+    "id" : "converter-storage-forms-configs",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/converter-storage/forms/configs",
+      "permissionsRequired" : [ "converter-storage.forms-configs.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/converter-storage/forms/configs",
+      "permissionsRequired" : [ "converter-storage.forms-configs.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/converter-storage/forms/configs/{formName}",
+      "permissionsRequired" : [ "converter-storage.forms-configs.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/converter-storage/forms/configs/{formName}",
+      "permissionsRequired" : [ "converter-storage.forms-configs.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/converter-storage/forms/configs/{formName}",
+      "permissionsRequired" : [ "converter-storage.forms-configs.delete" ]
+    } ]
+  }, {
+    "id" : "_tenant",
+    "version" : "1.2",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/_/tenant"
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/_/tenant"
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "converter-storage.jobprofile.get",
+    "displayName" : "Data Import Converter Storage - get Job Profile(s)",
+    "description" : "Get Job Profile(s)"
+  }, {
+    "permissionName" : "converter-storage.jobprofile.post",
+    "displayName" : "Data Import Converter Storage - create Job Profile",
+    "description" : "Post Job Profile"
+  }, {
+    "permissionName" : "converter-storage.jobprofile.put",
+    "displayName" : "Data Import Converter Storage - update Job Profile",
+    "description" : "Put Job Profile"
+  }, {
+    "permissionName" : "converter-storage.jobprofile.delete",
+    "displayName" : "Data Import Converter Storage - delete Job Profile",
+    "description" : "Delete Job Profile"
+  }, {
+    "permissionName" : "converter-storage.matchprofile.get",
+    "displayName" : "Data Import Converter Storage - get Match Profile(s)",
+    "description" : "Get Match Profile(s)"
+  }, {
+    "permissionName" : "converter-storage.matchprofile.post",
+    "displayName" : "Data Import Converter Storage - create Match Profile",
+    "description" : "Post Match Profile"
+  }, {
+    "permissionName" : "converter-storage.matchprofile.put",
+    "displayName" : "Data Import Converter Storage - update Match Profile",
+    "description" : "Put Match Profile"
+  }, {
+    "permissionName" : "converter-storage.matchprofile.delete",
+    "displayName" : "Data Import Converter Storage - delete Match Profile",
+    "description" : "Delete Match Profile"
+  }, {
+    "permissionName" : "converter-storage.actionprofile.get",
+    "displayName" : "Data Import Converter Storage - get Action Profile(s)",
+    "description" : "Get Action Profile(s)"
+  }, {
+    "permissionName" : "converter-storage.actionprofile.post",
+    "displayName" : "Data Import Converter Storage - create Action Profile",
+    "description" : "Post Action Profile"
+  }, {
+    "permissionName" : "converter-storage.actionprofile.put",
+    "displayName" : "Data Import Converter Storage - update Action Profile",
+    "description" : "Put Action Profile"
+  }, {
+    "permissionName" : "converter-storage.actionprofile.delete",
+    "displayName" : "Data Import Converter Storage - delete Action Profile",
+    "description" : "Delete Action Profile"
+  }, {
+    "permissionName" : "converter-storage.mappingprofile.get",
+    "displayName" : "Data Import Converter Storage - get Mapping Profile(s)",
+    "description" : "Get Mapping Profile(s)"
+  }, {
+    "permissionName" : "converter-storage.mappingprofile.post",
+    "displayName" : "Data Import Converter Storage - create Mapping Profile",
+    "description" : "Post Mapping Profile"
+  }, {
+    "permissionName" : "converter-storage.mappingprofile.put",
+    "displayName" : "Data Import Converter Storage - update Mapping Profile",
+    "description" : "Put Mapping Profile"
+  }, {
+    "permissionName" : "converter-storage.mappingprofile.delete",
+    "displayName" : "Data Import Converter Storage - delete Mapping Profile",
+    "description" : "Delete Mapping Profile"
+  }, {
+    "permissionName" : "converter-storage.entitytypes.get",
+    "displayName" : "Data Import Converter Storage - get Entity types",
+    "description" : "Get collection of entity types"
+  }, {
+    "permissionName" : "converter-storage.profileassociation.post",
+    "displayName" : "Data Import Converter Storage - create Profile Association",
+    "description" : "Post Profile Association"
+  }, {
+    "permissionName" : "converter-storage.profileassociation.get",
+    "displayName" : "Data Import Converter Storage - get Profile Association(s)",
+    "description" : "Get Profile Association(s)"
+  }, {
+    "permissionName" : "converter-storage.profileassociation.put",
+    "displayName" : "Data Import Converter Storage - update Profile Association",
+    "description" : "Put Profile Association"
+  }, {
+    "permissionName" : "converter-storage.profileassociation.delete",
+    "displayName" : "Data Import Converter Storage - delete Profile Association",
+    "description" : "Delete Profile Association"
+  }, {
+    "permissionName" : "converter-storage.jobprofilesnapshots.get",
+    "displayName" : "Data Import Converter Storage - get Job Profile Snapshot",
+    "description" : "Get Job Profile Snapshot"
+  }, {
+    "permissionName" : "converter-storage.jobprofilesnapshots.post",
+    "displayName" : "Data Import Converter Storage - create Job Profile Snapshot",
+    "description" : "Post Job Profile Snapshot"
+  }, {
+    "permissionName" : "converter-storage.profileSnapshots.get",
+    "displayName" : "Data Import Converter Storage - get Profile Snapshot",
+    "description" : "Get Profile Snapshot"
+  }, {
+    "permissionName" : "converter-storage.forms-configs.get",
+    "displayName" : "Data Import Converter Storage - get Form Config",
+    "description" : "Get Form Config"
+  }, {
+    "permissionName" : "converter-storage.forms-configs.post",
+    "displayName" : "Data Import Converter Storage - create Form Config",
+    "description" : "Post Form Config"
+  }, {
+    "permissionName" : "converter-storage.forms-configs.put",
+    "displayName" : "Data Import Converter Storage - update Form Config",
+    "description" : "Put Form Config"
+  }, {
+    "permissionName" : "converter-storage.forms-configs.delete",
+    "displayName" : "Data Import Converter Storage - delete Form Config",
+    "description" : "Delete Form Config"
+  }, {
+    "permissionName" : "converter-storage.all",
+    "displayName" : "Data Import Converter Storage - all permissions",
+    "description" : "Entire set of permissions needed to manage Profiles",
+    "subPermissions" : [ "converter-storage.jobprofile.get", "converter-storage.jobprofile.post", "converter-storage.jobprofile.put", "converter-storage.jobprofile.delete", "converter-storage.matchprofile.get", "converter-storage.matchprofile.post", "converter-storage.matchprofile.put", "converter-storage.matchprofile.delete", "converter-storage.actionprofile.get", "converter-storage.actionprofile.post", "converter-storage.actionprofile.put", "converter-storage.actionprofile.delete", "converter-storage.mappingprofile.get", "converter-storage.mappingprofile.post", "converter-storage.mappingprofile.put", "converter-storage.mappingprofile.delete", "converter-storage.profileassociation.post", "converter-storage.profileassociation.get", "converter-storage.profileassociation.put", "converter-storage.profileassociation.delete", "converter-storage.jobprofilesnapshots.get", "converter-storage.jobprofilesnapshots.post", "converter-storage.entitytypes.get", "converter-storage.profileSnapshots.get", "converter-storage.forms-configs.get", "converter-storage.forms-configs.post", "converter-storage.forms-configs.put", "converter-storage.forms-configs.delete" ],
+    "visible" : false
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-data-import-converter-storage:1.8.3",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    }, {
+      "name" : "DB_HOST",
+      "value" : "postgres"
+    }, {
+      "name" : "DB_PORT",
+      "value" : "5432"
+    }, {
+      "name" : "DB_USERNAME",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_PASSWORD",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_DATABASE",
+      "value" : "okapi_modules"
+    }, {
+      "name" : "DB_QUERYTIMEOUT",
+      "value" : "60000"
+    }, {
+      "name" : "DB_CHARSET",
+      "value" : "UTF-8"
+    }, {
+      "name" : "DB_MAXPOOLSIZE",
+      "value" : "5"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-email-1.8.0",
+  "name" : "email",
+  "requires" : [ {
+    "id" : "configuration",
+    "version" : "2.0"
+  } ],
+  "provides" : [ {
+    "id" : "email",
+    "version" : "1.1",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/email",
+      "permissionsRequired" : [ "email.message.post" ],
+      "modulePermissions" : [ "configuration.entries.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/email",
+      "permissionsRequired" : [ "email.message.collection.get" ]
+    } ]
+  }, {
+    "id" : "delayedTasks",
+    "version" : "2.0",
+    "handlers" : [ {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/delayedTask/expiredMessages",
+      "permissionsRequired" : [ "email.message.delete" ]
+    } ]
+  }, {
+    "id" : "_tenant",
+    "version" : "1.2",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/_/tenant"
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/_/tenant"
+    } ]
+  }, {
+    "id" : "_timer",
+    "version" : "1.0",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/delayedTask/expiredMessages",
+      "unit" : "minute",
+      "delay" : "30"
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "email.message.post",
+    "displayName" : "message - send email notifications",
+    "description" : "send email notifications"
+  }, {
+    "permissionName" : "email.message.collection.get",
+    "displayName" : "get email messages",
+    "description" : "get all email messages by query"
+  }, {
+    "permissionName" : "email.message.delete",
+    "displayName" : "delete email message",
+    "description" : "delete email messages by expiration date or status"
+  }, {
+    "permissionName" : "email.message.all",
+    "displayName" : "email entries - all permissions",
+    "description" : "Entire set of permissions needed to use the email module",
+    "subPermissions" : [ "email.message.post", "email.message.collection.get", "email.message.delete" ],
+    "visible" : false
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-email:1.8.0",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    }, {
+      "name" : "DB_HOST",
+      "value" : "postgres"
+    }, {
+      "name" : "DB_PORT",
+      "value" : "5432"
+    }, {
+      "name" : "DB_USERNAME",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_PASSWORD",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_DATABASE",
+      "value" : "okapi_modules"
+    }, {
+      "name" : "DB_QUERYTIMEOUT",
+      "value" : "60000"
+    }, {
+      "name" : "DB_CHARSET",
+      "value" : "UTF-8"
+    }, {
+      "name" : "DB_MAXPOOLSIZE",
+      "value" : "5"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-erm-usage-2.9.0",
+  "name" : "erm-usage",
+  "provides" : [ {
+    "id" : "usage-data-providers",
+    "version" : "2.4",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/usage-data-providers",
+      "permissionsRequired" : [ "usagedataproviders.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/usage-data-providers/{id}",
+      "permissionsRequired" : [ "usagedataproviders.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/usage-data-providers",
+      "permissionsRequired" : [ "usagedataproviders.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/usage-data-providers/{id}",
+      "permissionsRequired" : [ "usagedataproviders.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/usage-data-providers/{id}",
+      "permissionsRequired" : [ "usagedataproviders.item.delete" ]
+    } ]
+  }, {
+    "id" : "aggregator-settings",
+    "version" : "1.2",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/aggregator-settings",
+      "permissionsRequired" : [ "aggregatorsettings.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/aggregator-settings/{id}",
+      "permissionsRequired" : [ "aggregatorsettings.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/aggregator-settings",
+      "permissionsRequired" : [ "aggregatorsettings.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/aggregator-settings/{id}",
+      "permissionsRequired" : [ "aggregatorsettings.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/aggregator-settings/{id}",
+      "permissionsRequired" : [ "aggregatorsettings.item.delete" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/aggregator-settings/{id}",
+      "permissionsRequired" : [ "aggregatorsettings.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/aggregator-settings/{id}/exportcredentials",
+      "permissionsRequired" : [ "usagedataproviders.item.get", "aggregatorsettings.item.get" ]
+    } ]
+  }, {
+    "id" : "counter-reports",
+    "version" : "1.5",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/counter-reports",
+      "permissionsRequired" : [ "counterreports.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/counter-reports/{id}",
+      "permissionsRequired" : [ "counterreports.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/counter-reports",
+      "permissionsRequired" : [ "counterreports.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/counter-reports/{id}",
+      "permissionsRequired" : [ "counterreports.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/counter-reports/{id}",
+      "permissionsRequired" : [ "counterreports.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/counter-reports/csv/{id}",
+      "permissionsRequired" : [ "counterreports.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/counter-reports/sorted/{udpId}",
+      "permissionsRequired" : [ "counterreports.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/counter-reports/csv/provider/{id}/report/{name}/version/{version}/from/{begin}/to/{end}",
+      "permissionsRequired" : [ "counterreports.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/counter-reports/export/{id}",
+      "permissionsRequired" : [ "counterreports.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/counter-reports/export/provider/{id}/report/{name}/version/{version}/from/{begin}/to/{end}",
+      "permissionsRequired" : [ "counterreports.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/counter-reports/upload/provider/{id}",
+      "permissionsRequired" : [ "counterreports.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/counter-reports/errors/codes",
+      "permissionsRequired" : [ "counterreports.collection.get" ]
+    } ]
+  }, {
+    "id" : "erm-usage/files",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm-usage/files/{id}",
+      "permissionsRequired" : [ "erm-usage.files.item.get" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/erm-usage/files/{id}",
+      "permissionsRequired" : [ "erm-usage.files.item.delete" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/erm-usage/files",
+      "permissionsRequired" : [ "erm-usage.files.item.post" ]
+    } ]
+  }, {
+    "id" : "_tenant",
+    "version" : "1.2",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST", "DELETE" ],
+      "pathPattern" : "/_/tenant"
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "usagedataproviders.collection.get",
+    "displayName" : "usage data providers collection get",
+    "description" : "Get a collection of usage data providers"
+  }, {
+    "permissionName" : "usagedataproviders.item.get",
+    "displayName" : "usage data providers item get",
+    "description" : "Get a single usage data provider"
+  }, {
+    "permissionName" : "usagedataproviders.item.post",
+    "displayName" : "usage data providers item post",
+    "description" : "Create a new usage data provider"
+  }, {
+    "permissionName" : "usagedataproviders.item.put",
+    "displayName" : "usage data providers item get",
+    "description" : "Edit an usage data provider"
+  }, {
+    "permissionName" : "usagedataproviders.item.delete",
+    "displayName" : "usage data providers item get",
+    "description" : "Delete an usage data provider"
+  }, {
+    "permissionName" : "aggregatorsettings.collection.get",
+    "displayName" : "aggregator settings collection get",
+    "description" : "Get a collection of aggregator setting"
+  }, {
+    "permissionName" : "aggregatorsettings.item.get",
+    "displayName" : "aggregator settings item get",
+    "description" : "Get a single aggregator setting"
+  }, {
+    "permissionName" : "aggregatorsettings.item.post",
+    "displayName" : "aggregator settings item post",
+    "description" : "Create a new aggregator setting"
+  }, {
+    "permissionName" : "aggregatorsettings.item.put",
+    "displayName" : "aggregator settings item get",
+    "description" : "Edit an aggregator setting"
+  }, {
+    "permissionName" : "aggregatorsettings.item.delete",
+    "displayName" : "aggregator settings item get",
+    "description" : "Delete an aggregator setting"
+  }, {
+    "permissionName" : "counterreports.collection.get",
+    "displayName" : "counter reports collection get",
+    "description" : "Get a collection of counter reports"
+  }, {
+    "permissionName" : "counterreports.item.get",
+    "displayName" : "counter reports item get",
+    "description" : "Get a single counter report"
+  }, {
+    "permissionName" : "counterreports.item.post",
+    "displayName" : "counter reports item post",
+    "description" : "Create a new counter report"
+  }, {
+    "permissionName" : "counterreports.item.put",
+    "displayName" : "counter reports item get",
+    "description" : "Edit an counter report"
+  }, {
+    "permissionName" : "counterreports.item.delete",
+    "displayName" : "counter reports item get",
+    "description" : "Delete an counter report"
+  }, {
+    "permissionName" : "erm-usage.files.item.get",
+    "displayName" : "erm-usage files item get",
+    "description" : "Get a single file"
+  }, {
+    "permissionName" : "erm-usage.files.item.post",
+    "displayName" : "erm-usage files item post",
+    "description" : "Post a single file"
+  }, {
+    "permissionName" : "erm-usage.files.item.delete",
+    "displayName" : "erm-usage files item delete",
+    "description" : "Delete a single file"
+  }, {
+    "permissionName" : "eusage.all",
+    "displayName" : "eusage all",
+    "description" : "All permissions for the mod-erm-usage module. An admin should get all permission, e.g. to edit aggregators.",
+    "subPermissions" : [ "usagedataproviders.collection.get", "usagedataproviders.item.get", "usagedataproviders.item.post", "usagedataproviders.item.put", "usagedataproviders.item.delete", "aggregatorsettings.collection.get", "aggregatorsettings.item.get", "aggregatorsettings.item.post", "aggregatorsettings.item.put", "aggregatorsettings.item.delete", "counterreports.collection.get", "counterreports.item.get", "counterreports.item.post", "counterreports.item.put", "counterreports.item.delete", "erm-usage.files.item.get", "erm-usage.files.item.post", "erm-usage.files.item.delete" ]
+  }, {
+    "permissionName" : "eusage.user",
+    "displayName" : "eusage user",
+    "description" : "Permission set for a standard erm user. Cannot edit aggregator settings.",
+    "subPermissions" : [ "usagedataproviders.collection.get", "usagedataproviders.item.get", "usagedataproviders.item.post", "usagedataproviders.item.put", "usagedataproviders.item.delete", "aggregatorsettings.collection.get", "aggregatorsettings.item.get", "counterreports.collection.get", "counterreports.item.get", "counterreports.item.post", "counterreports.item.put", "counterreports.item.delete", "erm-usage.files.item.get", "erm-usage.files.item.post", "erm-usage.files.item.delete" ]
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-erm-usage:2.9.0",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    }, {
+      "name" : "DB_HOST",
+      "value" : "postgres"
+    }, {
+      "name" : "DB_PORT",
+      "value" : "5432"
+    }, {
+      "name" : "DB_USERNAME",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_PASSWORD",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_DATABASE",
+      "value" : "okapi_modules"
+    }, {
+      "name" : "DB_QUERYTIMEOUT",
+      "value" : "60000"
+    }, {
+      "name" : "DB_CHARSET",
+      "value" : "UTF-8"
+    }, {
+      "name" : "DB_MAXPOOLSIZE",
+      "value" : "5"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-erm-usage-harvester-1.7.2",
+  "name" : "erm-usage-harvester",
+  "requires" : [ {
+    "id" : "usage-data-providers",
+    "version" : "2.4"
+  }, {
+    "id" : "aggregator-settings",
+    "version" : "1.1"
+  }, {
+    "id" : "counter-reports",
+    "version" : "1.3"
+  } ],
+  "provides" : [ {
+    "id" : "erm-usage-harvester",
+    "version" : "1.2",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm-usage-harvester/start",
+      "permissionsRequired" : [ ],
+      "modulePermissions" : [ "usagedataproviders.collection.get", "usagedataproviders.item.get", "aggregatorsettings.collection.get", "aggregatorsettings.item.get", "counterreports.collection.get", "counterreports.item.get", "counterreports.item.post", "counterreports.item.put", "counterreports.item.delete", "configuration.entries.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm-usage-harvester/start/{id}",
+      "permissionsRequired" : [ ],
+      "modulePermissions" : [ "usagedataproviders.collection.get", "usagedataproviders.item.get", "aggregatorsettings.collection.get", "aggregatorsettings.item.get", "counterreports.collection.get", "counterreports.item.get", "counterreports.item.post", "counterreports.item.put", "counterreports.item.delete", "configuration.entries.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/erm-usage-harvester/impl",
+      "permissionsRequired" : [ ]
+    }, {
+      "methods" : [ "GET", "POST", "DELETE" ],
+      "pathPattern" : "/erm-usage-harvester/periodic",
+      "permissionsRequired" : [ ]
+    } ]
+  }, {
+    "id" : "_start",
+    "version" : "1.0",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/_/start",
+      "modulePermissions" : [ "usagedataproviders.collection.get", "usagedataproviders.item.get", "aggregatorsettings.collection.get", "aggregatorsettings.item.get", "counterreports.collection.get", "counterreports.item.get", "counterreports.item.post", "counterreports.item.put", "counterreports.item.delete", "configuration.entries.collection.get" ]
+    } ]
+  }, {
+    "id" : "_tenant",
+    "version" : "1.0",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST", "DELETE" ],
+      "pathPattern" : "/_/tenant"
+    } ]
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-erm-usage-harvester:1.7.2",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    }, {
+      "name" : "DB_HOST",
+      "value" : "postgres"
+    }, {
+      "name" : "DB_PORT",
+      "value" : "5432"
+    }, {
+      "name" : "DB_USERNAME",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_PASSWORD",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_DATABASE",
+      "value" : "okapi_modules"
+    }, {
+      "name" : "DB_QUERYTIMEOUT",
+      "value" : "60000"
+    }, {
+      "name" : "DB_CHARSET",
+      "value" : "UTF-8"
+    }, {
+      "name" : "DB_MAXPOOLSIZE",
+      "value" : "5"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-event-config-1.5.0",
+  "name" : "mod-event-config",
+  "requires" : [ ],
+  "provides" : [ {
+    "id" : "mod-event",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/eventConfig/{id}",
+      "permissionsRequired" : [ "event.config.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/eventConfig",
+      "permissionsRequired" : [ "event.config.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/eventConfig",
+      "permissionsRequired" : [ "event.config.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/eventConfig/{id}",
+      "permissionsRequired" : [ "event.config.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/eventConfig/{id}",
+      "permissionsRequired" : [ "event.config.item.delete" ]
+    } ]
+  }, {
+    "id" : "_tenant",
+    "version" : "1.0",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/_/tenant"
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/_/tenant"
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "event.config.item.get",
+    "displayName" : "Event Config - get event configuration from storage",
+    "description" : "Get individual event configuration"
+  }, {
+    "permissionName" : "event.config.collection.get",
+    "displayName" : "Event Config - get event configuration list",
+    "description" : "Get a list of event configurations"
+  }, {
+    "permissionName" : "event.config.item.post",
+    "displayName" : "Event Config - create event configuration",
+    "description" : "Create event configuration"
+  }, {
+    "permissionName" : "event.config.item.put",
+    "displayName" : "Event Config - modify event configuration",
+    "description" : "Modify event configuration"
+  }, {
+    "permissionName" : "event.config.item.delete",
+    "displayName" : "Event Config - delete event configuration",
+    "description" : "Delete event configuration"
+  }, {
+    "permissionName" : "event.config.all",
+    "displayName" : "Event configuration module - all permissions",
+    "description" : "Entire set of permissions needed to use the event configuration modules",
+    "subPermissions" : [ "event.config.item.get", "event.config.collection.get", "event.config.item.post", "event.config.item.put", "event.config.item.delete" ],
+    "visible" : false
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-event-config:1.5.0",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    }, {
+      "name" : "DB_HOST",
+      "value" : "postgres"
+    }, {
+      "name" : "DB_PORT",
+      "value" : "5432"
+    }, {
+      "name" : "DB_USERNAME",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_PASSWORD",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_DATABASE",
+      "value" : "okapi_modules"
+    }, {
+      "name" : "DB_QUERYTIMEOUT",
+      "value" : "60000"
+    }, {
+      "name" : "DB_CHARSET",
+      "value" : "UTF-8"
+    }, {
+      "name" : "DB_MAXPOOLSIZE",
+      "value" : "5"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-feesfines-15.8.3",
+  "name" : "feesfines",
+  "requires" : [ {
+    "id" : "patron-notice",
+    "version" : "1.0"
+  }, {
+    "id" : "inventory",
+    "version" : "10.2"
+  }, {
+    "id" : "holdings-storage",
+    "version" : "4.2"
+  }, {
+    "id" : "item-storage",
+    "version" : "8.4"
+  }, {
+    "id" : "instance-storage",
+    "version" : "7.4"
+  }, {
+    "id" : "locations",
+    "version" : "3.0"
+  }, {
+    "id" : "location-units",
+    "version" : "2.0"
+  }, {
+    "id" : "users",
+    "version" : "15.1"
+  }, {
+    "id" : "pubsub-event-types",
+    "version" : "0.1"
+  }, {
+    "id" : "pubsub-publishers",
+    "version" : "0.1"
+  }, {
+    "id" : "pubsub-subscribers",
+    "version" : "0.1"
+  }, {
+    "id" : "pubsub-publish",
+    "version" : "0.1"
+  } ],
+  "provides" : [ {
+    "id" : "feesfines",
+    "version" : "15.2",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/feefines",
+      "permissionsRequired" : [ "feefines.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/feefines/{id}",
+      "permissionsRequired" : [ "feefines.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/feefines",
+      "permissionsRequired" : [ "feefines.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/feefines/{id}",
+      "permissionsRequired" : [ "feefines.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/feefines/{id}",
+      "permissionsRequired" : [ "feefines.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/owners",
+      "permissionsRequired" : [ "owners.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/owners/{id}",
+      "permissionsRequired" : [ "owners.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/owners",
+      "permissionsRequired" : [ "owners.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/owners/{id}",
+      "permissionsRequired" : [ "owners.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/owners/{id}",
+      "permissionsRequired" : [ "owners.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/accounts",
+      "permissionsRequired" : [ "accounts.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/accounts/{id}",
+      "permissionsRequired" : [ "accounts.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/accounts",
+      "permissionsRequired" : [ "accounts.item.post" ],
+      "modulePermissions" : [ "patron-notice.post", "pubsub.publish.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/accounts/{id}",
+      "permissionsRequired" : [ "accounts.item.put" ],
+      "modulePermissions" : [ "patron-notice.post", "pubsub.publish.post" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/accounts/{id}",
+      "permissionsRequired" : [ "accounts.item.delete", "pubsub.publish.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/feefineactions",
+      "permissionsRequired" : [ "feefineactions.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/feefineactions/{id}",
+      "permissionsRequired" : [ "feefineactions.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/feefineactions",
+      "permissionsRequired" : [ "feefineactions.item.post" ],
+      "modulePermissions" : [ "patron-notice.post", "inventory-storage.items.item.get", "inventory-storage.items.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.holdings.collection.get", "inventory-storage.instances.item.get", "inventory-storage.instances.collection.get", "inventory-storage.locations.item.get", "inventory-storage.locations.collection.get", "inventory-storage.location-units.libraries.item.get", "inventory-storage.location-units.libraries.collection.get", "inventory-storage.location-units.campuses.item.get", "inventory-storage.location-units.campuses.collection.get", "inventory-storage.location-units.institutions.item.get", "inventory-storage.location-units.institutions.collection.get", "users.item.get", "users.collection.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/feefineactions/{id}",
+      "permissionsRequired" : [ "feefineactions.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/feefineactions/{id}",
+      "permissionsRequired" : [ "feefineactions.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/payments",
+      "permissionsRequired" : [ "payments.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/payments/{id}",
+      "permissionsRequired" : [ "payments.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/payments",
+      "permissionsRequired" : [ "payments.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/payments/{id}",
+      "permissionsRequired" : [ "payments.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/payments/{id}",
+      "permissionsRequired" : [ "payments.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/waives",
+      "permissionsRequired" : [ "waives.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/waives/{id}",
+      "permissionsRequired" : [ "waives.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/waives",
+      "permissionsRequired" : [ "waives.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/waives/{id}",
+      "permissionsRequired" : [ "waives.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/waives/{id}",
+      "permissionsRequired" : [ "waives.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/refunds",
+      "permissionsRequired" : [ "refunds.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/refunds/{id}",
+      "permissionsRequired" : [ "refunds.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/refunds",
+      "permissionsRequired" : [ "refunds.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/refunds/{id}",
+      "permissionsRequired" : [ "refunds.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/refunds/{id}",
+      "permissionsRequired" : [ "refunds.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/transfers",
+      "permissionsRequired" : [ "transfers.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/transfers/{id}",
+      "permissionsRequired" : [ "transfers.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/transfers",
+      "permissionsRequired" : [ "transfers.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/transfers/{id}",
+      "permissionsRequired" : [ "transfers.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/transfers/{id}",
+      "permissionsRequired" : [ "transfers.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/comments",
+      "permissionsRequired" : [ "comments.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/comments/{id}",
+      "permissionsRequired" : [ "comments.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/comments",
+      "permissionsRequired" : [ "comments.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/comments/{id}",
+      "permissionsRequired" : [ "comments.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/comments/{id}",
+      "permissionsRequired" : [ "comments.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/transfer-criterias",
+      "permissionsRequired" : [ "transfer-criterias.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/transfer-criterias/{id}",
+      "permissionsRequired" : [ "transfer-criterias.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/transfer-criterias",
+      "permissionsRequired" : [ "transfer-criterias.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/transfer-criterias/{id}",
+      "permissionsRequired" : [ "transfer-criterias.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/transfer-criterias/{id}",
+      "permissionsRequired" : [ "transfer-criterias.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/manualblocks",
+      "permissionsRequired" : [ "manualblocks.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/manualblocks/{id}",
+      "permissionsRequired" : [ "manualblocks.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/manualblocks",
+      "permissionsRequired" : [ "manualblocks.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/manualblocks/{id}",
+      "permissionsRequired" : [ "manualblocks.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/manualblocks/{id}",
+      "permissionsRequired" : [ "manualblocks.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/overdue-fines-policies",
+      "permissionsRequired" : [ "overdue-fines-policies.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/overdue-fines-policies/{id}",
+      "permissionsRequired" : [ "overdue-fines-policies.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/overdue-fines-policies",
+      "permissionsRequired" : [ "overdue-fines-policies.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/overdue-fines-policies/{id}",
+      "permissionsRequired" : [ "overdue-fines-policies.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/overdue-fines-policies/{id}",
+      "permissionsRequired" : [ "overdue-fines-policies.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/lost-item-fees-policies",
+      "permissionsRequired" : [ "lost-item-fees-policies.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/lost-item-fees-policies/{id}",
+      "permissionsRequired" : [ "lost-item-fees-policies.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/lost-item-fees-policies",
+      "permissionsRequired" : [ "lost-item-fees-policies.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/lost-item-fees-policies/{id}",
+      "permissionsRequired" : [ "lost-item-fees-policies.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/lost-item-fees-policies/{id}",
+      "permissionsRequired" : [ "lost-item-fees-policies.item.delete" ]
+    } ]
+  }, {
+    "id" : "_tenant",
+    "version" : "1.2",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/_/tenant",
+      "modulePermissions" : [ "pubsub.event-types.post", "pubsub.publishers.post", "pubsub.subscribers.post" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/_/tenant"
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "feefines.collection.get",
+    "displayName" : "feefines collection get",
+    "description" : "Get a collection of feefines records"
+  }, {
+    "permissionName" : "feefines.item.get",
+    "displayName" : "feefines item get",
+    "description" : "Read an individual record in the Feefine module"
+  }, {
+    "permissionName" : "feefines.item.post",
+    "displayName" : "feefines item post",
+    "description" : "Create new records in the Feefine module"
+  }, {
+    "permissionName" : "feefines.item.put",
+    "displayName" : "feefines item put",
+    "description" : "Edit existing records in the Feefine module"
+  }, {
+    "permissionName" : "feefines.item.delete",
+    "displayName" : "feefines item delete",
+    "description" : "Delete records from the Feefine module"
+  }, {
+    "permissionName" : "owners.collection.get",
+    "displayName" : "owners collection get",
+    "description" : "Get a list of owner records"
+  }, {
+    "permissionName" : "owners.item.get",
+    "displayName" : "owners item get",
+    "description" : "Get a single owner item"
+  }, {
+    "permissionName" : "owners.item.post",
+    "displayName" : "owners item post",
+    "description" : "Create new Owners"
+  }, {
+    "permissionName" : "owners.item.put",
+    "displayName" : "owners item put",
+    "description" : "Edit existing Owners"
+  }, {
+    "permissionName" : "owners.item.delete",
+    "displayName" : "owners item delete",
+    "description" : "Delete Owners"
+  }, {
+    "permissionName" : "accounts.collection.get",
+    "displayName" : "accounts collection get",
+    "description" : "Get a list of account records"
+  }, {
+    "permissionName" : "accounts.item.get",
+    "displayName" : "accounts item get",
+    "description" : "Get a single account record"
+  }, {
+    "permissionName" : "accounts.item.post",
+    "displayName" : "accounts item post",
+    "description" : "Create a new account record"
+  }, {
+    "permissionName" : "accounts.item.put",
+    "displayName" : "accounts item put",
+    "description" : "Edit an account record"
+  }, {
+    "permissionName" : "accounts.item.delete",
+    "displayName" : "accounts item delete",
+    "description" : "Delete an account record"
+  }, {
+    "permissionName" : "feefineactions.collection.get",
+    "displayName" : "feefineactions collection get",
+    "description" : "Get a list of feefineaction records"
+  }, {
+    "permissionName" : "feefineactions.item.get",
+    "displayName" : "feefineactions item get",
+    "description" : "Get a single feefineaction record"
+  }, {
+    "permissionName" : "feefineactions.item.post",
+    "displayName" : "feefineactions item post",
+    "description" : "Create a new feefineaction record"
+  }, {
+    "permissionName" : "feefineactions.item.put",
+    "displayName" : "feefineactions item put",
+    "description" : "Edit an feefineaction record"
+  }, {
+    "permissionName" : "feefineactions.item.delete",
+    "displayName" : "feefineactions item delete",
+    "description" : "Delete an feefineaction record"
+  }, {
+    "permissionName" : "payments.collection.get",
+    "displayName" : "payments collection get",
+    "description" : "Get a list of payment records"
+  }, {
+    "permissionName" : "payments.item.get",
+    "displayName" : "payments item get",
+    "description" : "Get a single payment record"
+  }, {
+    "permissionName" : "payments.item.post",
+    "displayName" : "payments item post",
+    "description" : "Create a new payment record"
+  }, {
+    "permissionName" : "payments.item.put",
+    "displayName" : "payments item put",
+    "description" : "Edit an payment record"
+  }, {
+    "permissionName" : "payments.item.delete",
+    "displayName" : "payments item delete",
+    "description" : "Delete an payment record"
+  }, {
+    "permissionName" : "waives.collection.get",
+    "displayName" : "waives collection get",
+    "description" : "Get a list of waive records"
+  }, {
+    "permissionName" : "waives.item.get",
+    "displayName" : "waives item get",
+    "description" : "Get a single waive record"
+  }, {
+    "permissionName" : "waives.item.post",
+    "displayName" : "waives item post",
+    "description" : "Create a new waive record"
+  }, {
+    "permissionName" : "waives.item.put",
+    "displayName" : "waives item put",
+    "description" : "Edit an waive record"
+  }, {
+    "permissionName" : "waives.item.delete",
+    "displayName" : "waives item delete",
+    "description" : "Delete an waive record"
+  }, {
+    "permissionName" : "refunds.collection.get",
+    "displayName" : "refunds collection get",
+    "description" : "Get a list of refund records"
+  }, {
+    "permissionName" : "refunds.item.get",
+    "displayName" : "refunds item get",
+    "description" : "Get a single refund record"
+  }, {
+    "permissionName" : "refunds.item.post",
+    "displayName" : "refunds item post",
+    "description" : "Create a new refund record"
+  }, {
+    "permissionName" : "refunds.item.put",
+    "displayName" : "refunds item put",
+    "description" : "Edit an refund record"
+  }, {
+    "permissionName" : "refunds.item.delete",
+    "displayName" : "refunds item delete",
+    "description" : "Delete an refund record"
+  }, {
+    "permissionName" : "transfers.collection.get",
+    "displayName" : "transfers collection get",
+    "description" : "Get a list of transfer records"
+  }, {
+    "permissionName" : "transfers.item.get",
+    "displayName" : "transfers item get",
+    "description" : "Get a single transfer record"
+  }, {
+    "permissionName" : "transfers.item.post",
+    "displayName" : "transfers item post",
+    "description" : "Create a new transfer record"
+  }, {
+    "permissionName" : "transfers.item.put",
+    "displayName" : "transfers item put",
+    "description" : "Edit an transfer record"
+  }, {
+    "permissionName" : "transfers.item.delete",
+    "displayName" : "transfers item delete",
+    "description" : "Delete an transfer record"
+  }, {
+    "permissionName" : "comments.collection.get",
+    "displayName" : "comments collection get",
+    "description" : "Get a list of comment records"
+  }, {
+    "permissionName" : "comments.item.get",
+    "displayName" : "comments item get",
+    "description" : "Get a single comment record"
+  }, {
+    "permissionName" : "comments.item.post",
+    "displayName" : "comments item post",
+    "description" : "Create a new comment record"
+  }, {
+    "permissionName" : "comments.item.put",
+    "displayName" : "comments item put",
+    "description" : "Edit an comment record"
+  }, {
+    "permissionName" : "comments.item.delete",
+    "displayName" : "comments item delete",
+    "description" : "Delete an comment record"
+  }, {
+    "permissionName" : "transfer-criterias.collection.get",
+    "displayName" : "transfer criteria collection get",
+    "description" : "Get a list of transfer criteria records"
+  }, {
+    "permissionName" : "transfer-criterias.item.get",
+    "displayName" : "transfer criteria item get",
+    "description" : "Get a single transfer criteria record"
+  }, {
+    "permissionName" : "transfer-criterias.item.post",
+    "displayName" : "transfer criteria item post",
+    "description" : "Create a new transfer criteria record"
+  }, {
+    "permissionName" : "transfer-criterias.item.put",
+    "displayName" : "transfer criteria item put",
+    "description" : "Edit an transfer criteria record"
+  }, {
+    "permissionName" : "transfer-criterias.item.delete",
+    "displayName" : "transfer criteria item delete",
+    "description" : "Delete an transfer criteria record"
+  }, {
+    "permissionName" : "manualblocks.collection.get",
+    "displayName" : "manualblocks collection get",
+    "description" : "Get a list of manualblock records"
+  }, {
+    "permissionName" : "manualblocks.item.get",
+    "displayName" : "manualblocks item get",
+    "description" : "Get a single manualblock record"
+  }, {
+    "permissionName" : "manualblocks.item.post",
+    "displayName" : "manualblocks item post",
+    "description" : "Create a new manualblock record"
+  }, {
+    "permissionName" : "manualblocks.item.put",
+    "displayName" : "manualblocks item put",
+    "description" : "Edit an manualblock record"
+  }, {
+    "permissionName" : "manualblocks.item.delete",
+    "displayName" : "manualblocks item delete",
+    "description" : "Delete an manualblock record"
+  }, {
+    "permissionName" : "overdue-fines-policies.collection.get",
+    "displayName" : "Overdue-fines-policies collection get",
+    "description" : "Get a list of overdue-fines-policies records"
+  }, {
+    "permissionName" : "overdue-fines-policies.item.get",
+    "displayName" : "Overdue-fines-policies item get",
+    "description" : "Get a single overdue-fines-policies record"
+  }, {
+    "permissionName" : "overdue-fines-policies.item.post",
+    "displayName" : "Overdue-fines-policies item post",
+    "description" : "Create a new overdue-fines-policies record"
+  }, {
+    "permissionName" : "overdue-fines-policies.item.put",
+    "displayName" : "Overdue-fines-policies item put",
+    "description" : "Edit an overdue-fines-policies record"
+  }, {
+    "permissionName" : "overdue-fines-policies.item.delete",
+    "displayName" : "Overdue-fines-policies item delete",
+    "description" : "Delete an overdue-fines-policies record"
+  }, {
+    "permissionName" : "lost-item-fees-policies.collection.get",
+    "displayName" : "Lost-item-fees-policies collection get",
+    "description" : "Get a list of lost-item-fees-policies records"
+  }, {
+    "permissionName" : "lost-item-fees-policies.item.get",
+    "displayName" : "Lost-item-fees-policies item get",
+    "description" : "Get a single lost-item-fees-policies record"
+  }, {
+    "permissionName" : "lost-item-fees-policies.item.post",
+    "displayName" : "Lost-item-fees-policies item post",
+    "description" : "Create a new lost-item-fees-policies record"
+  }, {
+    "permissionName" : "lost-item-fees-policies.item.put",
+    "displayName" : "Lost-item-fees-policies item put",
+    "description" : "Edit an lost-item-fees-policies record"
+  }, {
+    "permissionName" : "lost-item-fees-policies.item.delete",
+    "displayName" : "Lost-item-fees-policies item delete",
+    "description" : "Delete an lost-item-fees-policies record"
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-feesfines:15.8.3",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    }, {
+      "name" : "DB_HOST",
+      "value" : "postgres"
+    }, {
+      "name" : "DB_PORT",
+      "value" : "5432"
+    }, {
+      "name" : "DB_USERNAME",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_PASSWORD",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_DATABASE",
+      "value" : "okapi_modules"
+    }, {
+      "name" : "DB_QUERYTIMEOUT",
+      "value" : "60000"
+    }, {
+      "name" : "DB_CHARSET",
+      "value" : "UTF-8"
+    }, {
+      "name" : "DB_MAXPOOLSIZE",
+      "value" : "5"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-finance-3.0.1",
+  "name" : "Finance business logic module",
+  "requires" : [ {
+    "id" : "finance-storage.budgets",
+    "version" : "2.1"
+  }, {
+    "id" : "finance-storage.fund-types",
+    "version" : "1.0"
+  }, {
+    "id" : "finance-storage.funds",
+    "version" : "3.0"
+  }, {
+    "id" : "finance-storage.fiscal-years",
+    "version" : "2.1"
+  }, {
+    "id" : "finance-storage.groups",
+    "version" : "1.1"
+  }, {
+    "id" : "finance-storage.ledgers",
+    "version" : "2.3"
+  }, {
+    "id" : "finance-storage.transactions",
+    "version" : "3.0"
+  }, {
+    "id" : "configuration",
+    "version" : "2.0"
+  }, {
+    "id" : "finance-storage.order-transaction-summaries",
+    "version" : "1.1"
+  }, {
+    "id" : "finance-storage.invoice-transaction-summaries",
+    "version" : "2.0"
+  } ],
+  "provides" : [ {
+    "id" : "finance.budgets",
+    "version" : "1.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance/budgets",
+      "permissionsRequired" : [ "finance.budgets.collection.get" ],
+      "modulePermissions" : [ "finance-storage.budgets.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/finance/budgets",
+      "permissionsRequired" : [ "finance.budgets.item.post" ],
+      "modulePermissions" : [ "finance-storage.budgets.item.post", "finance-storage.group-fund-fiscal-years.collection.get", "finance-storage.group-fund-fiscal-years.item.put", "finance-storage.transactions.item.post", "finance-storage.fiscal-years.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance/budgets/{id}",
+      "permissionsRequired" : [ "finance.budgets.item.get" ],
+      "modulePermissions" : [ "finance-storage.budgets.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/finance/budgets/{id}",
+      "permissionsRequired" : [ "finance.budgets.item.put" ],
+      "modulePermissions" : [ "finance-storage.budgets.item.put", "finance-storage.budgets.item.get" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/finance/budgets/{id}",
+      "permissionsRequired" : [ "finance.budgets.item.delete" ],
+      "modulePermissions" : [ "finance-storage.budgets.item.delete" ]
+    } ]
+  }, {
+    "id" : "finance.fund-types",
+    "version" : "1.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance/fund-types",
+      "permissionsRequired" : [ "finance.fund-types.collection.get" ],
+      "modulePermissions" : [ "finance-storage.fund-types.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/finance/fund-types",
+      "permissionsRequired" : [ "finance.fund-types.item.post" ],
+      "modulePermissions" : [ "finance-storage.fund-types.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance/fund-types/{id}",
+      "permissionsRequired" : [ "finance.fund-types.item.get" ],
+      "modulePermissions" : [ "finance-storage.fund-types.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/finance/fund-types/{id}",
+      "permissionsRequired" : [ "finance.fund-types.item.put" ],
+      "modulePermissions" : [ "finance-storage.fund-types.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/finance/fund-types/{id}",
+      "permissionsRequired" : [ "finance.fund-types.item.delete" ],
+      "modulePermissions" : [ "finance-storage.fund-types.item.delete" ]
+    } ]
+  }, {
+    "id" : "finance.funds",
+    "version" : "1.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance/funds",
+      "permissionsRequired" : [ "finance.funds.collection.get" ],
+      "modulePermissions" : [ "finance-storage.funds.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/finance/funds",
+      "permissionsRequired" : [ "finance.funds.item.post" ],
+      "modulePermissions" : [ "finance-storage.funds.item.post", "finance-storage.ledgers.item.get", "finance-storage.fiscal-years.item.get", "finance-storage.fiscal-years.collection.get", "finance-storage.group-fund-fiscal-years.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance/funds/{id}",
+      "permissionsRequired" : [ "finance.funds.item.get" ],
+      "modulePermissions" : [ "finance-storage.funds.item.get", "finance-storage.ledgers.item.get", "finance-storage.fiscal-years.item.get", "finance-storage.fiscal-years.collection.get", "finance-storage.group-fund-fiscal-years.collection.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/finance/funds/{id}",
+      "permissionsRequired" : [ "finance.funds.item.put" ],
+      "modulePermissions" : [ "finance-storage.funds.item.put", "finance-storage.ledgers.item.get", "finance-storage.fiscal-years.item.get", "finance-storage.fiscal-years.collection.get", "finance-storage.groups.collection.get", "finance-storage.budgets.collection.get", "finance-storage.group-fund-fiscal-years.collection.get", "finance-storage.group-fund-fiscal-years.item.post", "finance-storage.group-fund-fiscal-years.item.delete" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/finance/funds/{id}",
+      "permissionsRequired" : [ "finance.funds.item.delete" ],
+      "modulePermissions" : [ "finance-storage.funds.item.delete", "finance-storage.group-fund-fiscal-years.collection.get", "finance-storage.group-fund-fiscal-years.item.delete" ]
+    } ]
+  }, {
+    "id" : "finance.fiscal-years",
+    "version" : "1.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance/fiscal-years",
+      "permissionsRequired" : [ "finance.fiscal-years.collection.get" ],
+      "modulePermissions" : [ "finance-storage.fiscal-years.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/finance/fiscal-years",
+      "permissionsRequired" : [ "finance.fiscal-years.item.post" ],
+      "modulePermissions" : [ "finance-storage.fiscal-years.item.post", "configuration.entries.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance/fiscal-years/{id}",
+      "permissionsRequired" : [ "finance.fiscal-years.item.get" ],
+      "modulePermissions" : [ "finance-storage.fiscal-years.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/finance/fiscal-years/{id}",
+      "permissionsRequired" : [ "finance.fiscal-years.item.put" ],
+      "modulePermissions" : [ "finance-storage.fiscal-years.item.put", "configuration.entries.collection.get" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/finance/fiscal-years/{id}",
+      "permissionsRequired" : [ "finance.fiscal-years.item.delete" ],
+      "modulePermissions" : [ "finance-storage.fiscal-years.item.delete" ]
+    } ]
+  }, {
+    "id" : "finance.group-fund-fiscal-years",
+    "version" : "1.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance/group-fund-fiscal-years",
+      "permissionsRequired" : [ "finance.group-fund-fiscal-years.collection.get" ],
+      "modulePermissions" : [ "finance-storage.group-fund-fiscal-years.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/finance/group-fund-fiscal-years",
+      "permissionsRequired" : [ "finance.group-fund-fiscal-years.item.post" ],
+      "modulePermissions" : [ "finance-storage.group-fund-fiscal-years.item.post" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/finance/group-fund-fiscal-years/{id}",
+      "permissionsRequired" : [ "finance.group-fund-fiscal-years.item.delete" ],
+      "modulePermissions" : [ "finance-storage.group-fund-fiscal-years.item.delete" ]
+    } ]
+  }, {
+    "id" : "finance.ledgers",
+    "version" : "1.4",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance/ledgers",
+      "permissionsRequired" : [ "finance.ledgers.collection.get" ],
+      "modulePermissions" : [ "finance-storage.ledgers.collection.get", "finance-storage.ledgersFY.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/finance/ledgers",
+      "permissionsRequired" : [ "finance.ledgers.item.post" ],
+      "modulePermissions" : [ "finance-storage.ledgers.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance/ledgers/{id}",
+      "permissionsRequired" : [ "finance.ledgers.item.get" ],
+      "modulePermissions" : [ "finance-storage.ledgers.item.get", "finance-storage.ledgersFY.collection.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/finance/ledgers/{id}",
+      "permissionsRequired" : [ "finance.ledgers.item.put" ],
+      "modulePermissions" : [ "finance-storage.ledgers.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/finance/ledgers/{id}",
+      "permissionsRequired" : [ "finance.ledgers.item.delete" ],
+      "modulePermissions" : [ "finance-storage.ledgers.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance/ledgers/{id}/current-fiscal-year",
+      "permissionsRequired" : [ "finance.ledgers.current-fiscal-year.item.get" ],
+      "modulePermissions" : [ "finance-storage.ledgers.item.get", "finance-storage.fiscal-years.item.get", "finance-storage.fiscal-years.collection.get" ]
+    } ]
+  }, {
+    "id" : "finance.groups",
+    "version" : "1.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance/groups",
+      "permissionsRequired" : [ "finance.groups.collection.get" ],
+      "modulePermissions" : [ "finance-storage.groups.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/finance/groups",
+      "permissionsRequired" : [ "finance.groups.item.post" ],
+      "modulePermissions" : [ "finance-storage.groups.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance/groups/{id}",
+      "permissionsRequired" : [ "finance.groups.item.get" ],
+      "modulePermissions" : [ "finance-storage.groups.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/finance/groups/{id}",
+      "permissionsRequired" : [ "finance.groups.item.put" ],
+      "modulePermissions" : [ "finance-storage.groups.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/finance/groups/{id}",
+      "permissionsRequired" : [ "finance.groups.item.delete" ],
+      "modulePermissions" : [ "finance-storage.groups.item.delete" ]
+    } ]
+  }, {
+    "id" : "finance.transactions",
+    "version" : "3.0",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/finance/allocations",
+      "permissionsRequired" : [ "finance.allocations.item.post" ],
+      "modulePermissions" : [ "finance-storage.transactions.item.post", "finance-storage.funds.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/finance/encumbrances",
+      "permissionsRequired" : [ "finance.encumbrances.item.post" ],
+      "modulePermissions" : [ "finance-storage.transactions.item.post" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/finance/transfers",
+      "permissionsRequired" : [ "finance.transfers.item.post" ],
+      "modulePermissions" : [ "finance-storage.transactions.item.post", "finance-storage.funds.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/finance/payments",
+      "permissionsRequired" : [ "finance.payments.item.post" ],
+      "modulePermissions" : [ "finance-storage.transactions.item.post" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/finance/credits",
+      "permissionsRequired" : [ "finance.credits.item.post" ],
+      "modulePermissions" : [ "finance-storage.transactions.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance/transactions",
+      "permissionsRequired" : [ "finance.transactions.collection.get" ],
+      "modulePermissions" : [ "finance-storage.transactions.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance/transactions/{id}",
+      "permissionsRequired" : [ "finance.transactions.item.get" ],
+      "modulePermissions" : [ "finance-storage.transactions.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/finance/release-encumbrance/{id}",
+      "permissionsRequired" : [ "finance.release-encumbrance.item.post" ],
+      "modulePermissions" : [ "finance-storage.transactions.item.get", "finance-storage.transactions.item.put" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/finance/awaiting-payment",
+      "permissionsRequired" : [ "finance.awaiting-payment.item.post" ],
+      "modulePermissions" : [ "finance-storage.transactions.item.put", "finance-storage.transactions.item.get" ]
+    } ]
+  }, {
+    "id" : "finance.order-transaction-summaries",
+    "version" : "1.2",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/finance/order-transaction-summaries",
+      "permissionsRequired" : [ "finance.order-transaction-summaries.item.post" ],
+      "modulePermissions" : [ "finance-storage.order-transaction-summaries.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/finance/order-transaction-summaries/{id}",
+      "permissionsRequired" : [ "finance.order-transaction-summaries.item.put" ],
+      "modulePermissions" : [ "finance-storage.order-transaction-summaries.item.put" ]
+    } ]
+  }, {
+    "id" : "finance.group-fiscal-year-summaries",
+    "version" : "1.2",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance/group-fiscal-year-summaries",
+      "permissionsRequired" : [ "finance.group-fiscal-year-summaries.collection.get" ],
+      "modulePermissions" : [ "finance-storage.budgets.collection.get", "finance-storage.group-fund-fiscal-years.collection.get" ]
+    } ]
+  }, {
+    "id" : "finance.invoice-transaction-summaries",
+    "version" : "2.0",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/finance/invoice-transaction-summaries",
+      "permissionsRequired" : [ "finance.invoice-transaction-summaries.item.post" ],
+      "modulePermissions" : [ "finance-storage.invoice-transaction-summaries.item.post" ]
+    } ]
+  }, {
+    "id" : "finance.exchange-rate",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance/exchange-rate",
+      "permissionsRequired" : [ "finance.exchange-rate.item.get" ]
+    } ]
+  }, {
+    "id" : "_jsonSchemas",
+    "version" : "1.0",
+    "interfaceType" : "multiple",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/_/jsonSchemas",
+      "permissionsRequired" : [ ]
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "finance.budgets.collection.get",
+    "displayName" : "Budgets - get the collection of budgets",
+    "description" : "Get collection of budgets"
+  }, {
+    "permissionName" : "finance.budgets.item.post",
+    "displayName" : "Budgets - create a new budget",
+    "description" : "Create a new fund type"
+  }, {
+    "permissionName" : "finance.budgets.item.get",
+    "displayName" : "Budgets - get an existing budget",
+    "description" : "Fetch a fund type"
+  }, {
+    "permissionName" : "finance.budgets.item.put",
+    "displayName" : "Budgets - modify an existing budget",
+    "description" : "Update a fund type"
+  }, {
+    "permissionName" : "finance.budgets.item.delete",
+    "displayName" : "Budgets - delete an existing budget",
+    "description" : "Delete a fund type"
+  }, {
+    "permissionName" : "finance.budgets.all",
+    "displayName" : "All budget permissions",
+    "description" : "All permissions for the budget APIs",
+    "subPermissions" : [ "finance.budgets.collection.get", "finance.budgets.item.post", "finance.budgets.item.get", "finance.budgets.item.put", "finance.budgets.item.delete" ]
+  }, {
+    "permissionName" : "finance.fund-types.collection.get",
+    "displayName" : "Fund types - get the collection of fund types",
+    "description" : "Get collection of fund types"
+  }, {
+    "permissionName" : "finance.fund-types.item.post",
+    "displayName" : "Fund types - create a new fund type",
+    "description" : "Create a new fund type"
+  }, {
+    "permissionName" : "finance.fund-types.item.get",
+    "displayName" : "Fund types - get an existing fund type",
+    "description" : "Fetch a fund type"
+  }, {
+    "permissionName" : "finance.fund-types.item.put",
+    "displayName" : "Fund types - modify an existing fund type",
+    "description" : "Update a fund type"
+  }, {
+    "permissionName" : "finance.fund-types.item.delete",
+    "displayName" : "Fund types - delete an existing fund type",
+    "description" : "Delete a fund type"
+  }, {
+    "permissionName" : "finance.fund-types.all",
+    "displayName" : "All fund type permissions",
+    "description" : "All permissions for the fund type APIs",
+    "subPermissions" : [ "finance.fund-types.collection.get", "finance.fund-types.item.post", "finance.fund-types.item.get", "finance.fund-types.item.put", "finance.fund-types.item.delete" ]
+  }, {
+    "permissionName" : "finance.funds.collection.get",
+    "displayName" : "Finances - get finance funds collection",
+    "description" : "Get finance funds collection"
+  }, {
+    "permissionName" : "finance.funds.item.get",
+    "displayName" : "Finances - get individual finance funds from storage",
+    "description" : "Get individual finance funds"
+  }, {
+    "permissionName" : "finance.funds.item.post",
+    "displayName" : "Finances - create finance funds",
+    "description" : "Create finance funds"
+  }, {
+    "permissionName" : "finance.funds.item.put",
+    "displayName" : "Finances - modify finance funds",
+    "description" : "Modify finance funds"
+  }, {
+    "permissionName" : "finance.funds.item.delete",
+    "displayName" : "Finances - delete finance funds",
+    "description" : "Delete finance funds"
+  }, {
+    "permissionName" : "finance.funds.all",
+    "displayName" : "Finance Funds - all permissions",
+    "description" : "Entire set of permissions needed to use the Finance funds interface",
+    "subPermissions" : [ "finance.funds.collection.get", "finance.funds.item.get", "finance.funds.item.post", "finance.funds.item.put", "finance.funds.item.delete" ],
+    "visible" : false
+  }, {
+    "permissionName" : "finance.fiscal-years.collection.get",
+    "displayName" : "Finances - get finance fiscal-years collection",
+    "description" : "Get finance fiscal years collection"
+  }, {
+    "permissionName" : "finance.fiscal-years.item.get",
+    "displayName" : "Finances - get individual finance fiscal year from storage",
+    "description" : "Get individual finance fiscal year"
+  }, {
+    "permissionName" : "finance.fiscal-years.item.post",
+    "displayName" : "Finances - create finance fiscal-years",
+    "description" : "Create finance fiscal year"
+  }, {
+    "permissionName" : "finance.fiscal-years.item.put",
+    "displayName" : "Finances - modify finance fiscal year",
+    "description" : "Modify finance fiscal year"
+  }, {
+    "permissionName" : "finance.fiscal-years.item.delete",
+    "displayName" : "Finances - delete finance fiscal year",
+    "description" : "Delete finance fiscal year"
+  }, {
+    "permissionName" : "finance.fiscal-years.all",
+    "displayName" : "Finance fiscal years - all permissions",
+    "description" : "Entire set of permissions needed to use the Finance fiscal years interface",
+    "subPermissions" : [ "finance.fiscal-years.collection.get", "finance.fiscal-years.item.get", "finance.fiscal-years.item.post", "finance.fiscal-years.item.put", "finance.fiscal-years.item.delete" ],
+    "visible" : false
+  }, {
+    "permissionName" : "finance.ledgers.collection.get",
+    "displayName" : "Ledgers - get the collection of ledgers",
+    "description" : "Get collection of ledgers"
+  }, {
+    "permissionName" : "finance.ledgers.item.post",
+    "displayName" : "Ledgers - create a new ledger",
+    "description" : "Create a new ledger"
+  }, {
+    "permissionName" : "finance.ledgers.item.get",
+    "displayName" : "Ledgers - get an existing ledger",
+    "description" : "Fetch a ledger"
+  }, {
+    "permissionName" : "finance.ledgers.item.put",
+    "displayName" : "Ledgers - modify an existing ledger",
+    "description" : "Update a ledger"
+  }, {
+    "permissionName" : "finance.ledgers.item.delete",
+    "displayName" : "Ledgers - delete an existing ledger",
+    "description" : "Delete a ledger"
+  }, {
+    "permissionName" : "finance.ledgers.current-fiscal-year.item.get",
+    "displayName" : "Ledgers - get a current fiscal year for a specific ledger",
+    "description" : "Get a current fiscal year"
+  }, {
+    "permissionName" : "finance.ledgers.all",
+    "displayName" : "All ledger permissions",
+    "description" : "All permissions for the ledger APIs",
+    "subPermissions" : [ "finance.ledgers.collection.get", "finance.ledgers.item.post", "finance.ledgers.item.get", "finance.ledgers.item.put", "finance.ledgers.item.delete", "finance.ledgers.current-fiscal-year.item.get" ]
+  }, {
+    "permissionName" : "finance.groups.collection.get",
+    "displayName" : "Groups - get the collection of groups",
+    "description" : "Get collection of groups"
+  }, {
+    "permissionName" : "finance.groups.item.post",
+    "displayName" : "Groups - create a new group",
+    "description" : "Create a new group"
+  }, {
+    "permissionName" : "finance.groups.item.get",
+    "displayName" : "Groups - get an existing group",
+    "description" : "Fetch a group"
+  }, {
+    "permissionName" : "finance.groups.item.put",
+    "displayName" : "Groups - modify an existing group",
+    "description" : "Update a group"
+  }, {
+    "permissionName" : "finance.groups.item.delete",
+    "displayName" : "Groups - delete an existing group",
+    "description" : "Delete a group"
+  }, {
+    "permissionName" : "finance.groups.all",
+    "displayName" : "All group permissions",
+    "description" : "All permissions for the group APIs",
+    "subPermissions" : [ "finance.groups.collection.get", "finance.groups.item.post", "finance.groups.item.get", "finance.groups.item.put", "finance.groups.item.delete" ]
+  }, {
+    "permissionName" : "finance.group-fund-fiscal-years.collection.get",
+    "displayName" : "Finances - get finance group fund fiscal years collection",
+    "description" : "Get finance group fund fiscal years collection"
+  }, {
+    "permissionName" : "finance.group-fund-fiscal-years.item.post",
+    "displayName" : "Finances - create finance group fund fiscal year",
+    "description" : "Create finance group fund fiscal years"
+  }, {
+    "permissionName" : "finance.group-fund-fiscal-years.item.delete",
+    "displayName" : "Finances - delete finance group fund fiscal years",
+    "description" : "Delete finance group fund fiscal year"
+  }, {
+    "permissionName" : "finance.group-fund-fiscal-years.all",
+    "displayName" : "Finance group fund fiscal years - all permissions",
+    "description" : "Entire set of permissions needed to use the Finance - group fund fiscal years interface",
+    "subPermissions" : [ "finance.group-fund-fiscal-years.collection.get", "finance.group-fund-fiscal-years.item.post", "finance.group-fund-fiscal-years.item.delete" ],
+    "visible" : false
+  }, {
+    "permissionName" : "finance.allocations.item.post",
+    "displayName" : "Allocations - create a new transaction of type allocation",
+    "description" : "Create a new allocation"
+  }, {
+    "permissionName" : "finance.encumbrances.item.post",
+    "displayName" : "Encumbrances - create a new transaction of type encumbrance",
+    "description" : "Create a new encumbrance"
+  }, {
+    "permissionName" : "finance.transfers.item.post",
+    "displayName" : "Transfers - create a new transaction of type transfer",
+    "description" : "Create a new transfer"
+  }, {
+    "permissionName" : "finance.payments.item.post",
+    "displayName" : "Payments - create a new transaction of type payment",
+    "description" : "Create a new payment"
+  }, {
+    "permissionName" : "finance.credits.item.post",
+    "displayName" : "Credits - create a new transaction of type credit",
+    "description" : "Create a new credit"
+  }, {
+    "permissionName" : "finance.transactions.collection.get",
+    "displayName" : "Finances - Get finance transaction collection",
+    "description" : "Get finance transaction collection"
+  }, {
+    "permissionName" : "finance.transactions.item.get",
+    "displayName" : "Finances - get an existing transaction",
+    "description" : "Get an existing transaction"
+  }, {
+    "permissionName" : "finance.transactions.all",
+    "displayName" : "All transactions permissions",
+    "description" : "All permissions for the transaction APIs",
+    "subPermissions" : [ "finance.allocations.item.post", "finance.encumbrances.item.post", "finance.transfers.item.post", "finance.payments.item.post", "finance.credits.item.post", "finance.transactions.collection.get", "finance.transactions.item.get", "finance.awaiting-payment.item.post", "finance.release-encumbrance.item.post" ]
+  }, {
+    "permissionName" : "finance.awaiting-payment.item.post",
+    "displayName" : "Move money from encumbered to awaiting payment",
+    "description" : "Move money from encumbered to awaiting payment"
+  }, {
+    "permissionName" : "finance.release-encumbrance.item.post",
+    "displayName" : "Release encumbrance",
+    "description" : "Release any remaining money encumbered back to the budget's available pool"
+  }, {
+    "permissionName" : "finance.group-fiscal-year-summaries.collection.get",
+    "displayName" : "Finances - get group fiscal year summaries",
+    "description" : "Get group fiscal year summaries collection"
+  }, {
+    "permissionName" : "finance.order-transaction-summaries.item.post",
+    "displayName" : "Finances - Post Order transaction Summaries",
+    "description" : "Post Order Transaction Summary"
+  }, {
+    "permissionName" : "finance.order-transaction-summaries.item.put",
+    "displayName" : "Finances - Put Order transaction Summaries",
+    "description" : "Put Order Transaction Summary"
+  }, {
+    "permissionName" : "finance.invoice-transaction-summaries.item.post",
+    "displayName" : "Finances - Post Invoice transaction Summaries",
+    "description" : "Post Invoice Transaction Summary"
+  }, {
+    "permissionName" : "finance.exchange-rate.item.get",
+    "displayName" : "Finances - Exchange Rate",
+    "description" : "Get Exchange Rate"
+  }, {
+    "permissionName" : "finance.all",
+    "displayName" : "Finance module - all permissions",
+    "description" : "Entire set of permissions needed to use the finance module",
+    "subPermissions" : [ "finance.budgets.all", "finance.fund-types.all", "finance.funds.all", "finance.group-fund-fiscal-years.all", "finance.ledgers.all", "finance.fiscal-years.all", "finance.groups.all", "finance.transactions.all", "finance.group-fiscal-year-summaries.collection.get", "finance.order-transaction-summaries.item.post", "finance.order-transaction-summaries.item.put", "finance.invoice-transaction-summaries.item.post", "finance.exchange-rate.item.get" ],
+    "visible" : false
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-finance:3.0.1",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 469762048,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-finance-storage-5.0.2",
+  "name" : "Finance CRUD module",
+  "provides" : [ {
+    "id" : "finance-storage.budgets",
+    "version" : "2.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance-storage/budgets",
+      "permissionsRequired" : [ "finance-storage.budgets.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/finance-storage/budgets",
+      "permissionsRequired" : [ "finance-storage.budgets.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance-storage/budgets/{id}",
+      "permissionsRequired" : [ "finance-storage.budgets.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/finance-storage/budgets/{id}",
+      "permissionsRequired" : [ "finance-storage.budgets.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/finance-storage/budgets/{id}",
+      "permissionsRequired" : [ "finance-storage.budgets.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance-storage/group-budgets",
+      "permissionsRequired" : [ "finance-storage.group-budgets.collection.get" ]
+    } ]
+  }, {
+    "id" : "finance-storage.fiscal-years",
+    "version" : "2.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance-storage/fiscal-years",
+      "permissionsRequired" : [ "finance-storage.fiscal-years.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/finance-storage/fiscal-years",
+      "permissionsRequired" : [ "finance-storage.fiscal-years.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance-storage/fiscal-years/{id}",
+      "permissionsRequired" : [ "finance-storage.fiscal-years.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/finance-storage/fiscal-years/{id}",
+      "permissionsRequired" : [ "finance-storage.fiscal-years.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/finance-storage/fiscal-years/{id}",
+      "permissionsRequired" : [ "finance-storage.fiscal-years.item.delete" ]
+    } ]
+  }, {
+    "id" : "finance-storage.fund-types",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance-storage/fund-types",
+      "permissionsRequired" : [ "finance-storage.fund-types.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/finance-storage/fund-types",
+      "permissionsRequired" : [ "finance-storage.fund-types.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance-storage/fund-types/{id}",
+      "permissionsRequired" : [ "finance-storage.fund-types.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/finance-storage/fund-types/{id}",
+      "permissionsRequired" : [ "finance-storage.fund-types.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/finance-storage/fund-types/{id}",
+      "permissionsRequired" : [ "finance-storage.fund-types.item.delete" ]
+    } ]
+  }, {
+    "id" : "finance-storage.funds",
+    "version" : "3.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance-storage/funds",
+      "permissionsRequired" : [ "finance-storage.funds.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/finance-storage/funds",
+      "permissionsRequired" : [ "finance-storage.funds.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance-storage/funds/{id}",
+      "permissionsRequired" : [ "finance-storage.funds.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/finance-storage/funds/{id}",
+      "permissionsRequired" : [ "finance-storage.funds.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/finance-storage/funds/{id}",
+      "permissionsRequired" : [ "finance-storage.funds.item.delete" ]
+    } ]
+  }, {
+    "id" : "finance-storage.groups",
+    "version" : "1.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance-storage/groups",
+      "permissionsRequired" : [ "finance-storage.groups.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/finance-storage/groups",
+      "permissionsRequired" : [ "finance-storage.groups.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance-storage/groups/{id}",
+      "permissionsRequired" : [ "finance-storage.groups.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/finance-storage/groups/{id}",
+      "permissionsRequired" : [ "finance-storage.groups.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/finance-storage/groups/{id}",
+      "permissionsRequired" : [ "finance-storage.groups.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance-storage/group-fund-fiscal-years",
+      "permissionsRequired" : [ "finance-storage.group-fund-fiscal-years.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/finance-storage/group-fund-fiscal-years",
+      "permissionsRequired" : [ "finance-storage.group-fund-fiscal-years.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance-storage/group-fund-fiscal-years/{id}",
+      "permissionsRequired" : [ "finance-storage.group-fund-fiscal-years.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/finance-storage/group-fund-fiscal-years/{id}",
+      "permissionsRequired" : [ "finance-storage.group-fund-fiscal-years.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/finance-storage/group-fund-fiscal-years/{id}",
+      "permissionsRequired" : [ "finance-storage.group-fund-fiscal-years.item.delete" ]
+    } ]
+  }, {
+    "id" : "finance-storage.ledgers",
+    "version" : "2.3",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance-storage/ledgers",
+      "permissionsRequired" : [ "finance-storage.ledgers.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/finance-storage/ledgers",
+      "permissionsRequired" : [ "finance-storage.ledgers.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance-storage/ledgers/{id}",
+      "permissionsRequired" : [ "finance-storage.ledgers.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/finance-storage/ledgers/{id}",
+      "permissionsRequired" : [ "finance-storage.ledgers.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/finance-storage/ledgers/{id}",
+      "permissionsRequired" : [ "finance-storage.ledgers.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance-storage/ledger-fiscal-years",
+      "permissionsRequired" : [ "finance-storage.ledgersFY.collection.get" ]
+    } ]
+  }, {
+    "id" : "finance-storage.transactions",
+    "version" : "3.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance-storage/transactions",
+      "permissionsRequired" : [ "finance-storage.transactions.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/finance-storage/transactions",
+      "permissionsRequired" : [ "finance-storage.transactions.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance-storage/transactions/{id}",
+      "permissionsRequired" : [ "finance-storage.transactions.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/finance-storage/transactions/{id}",
+      "permissionsRequired" : [ "finance-storage.transactions.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/finance-storage/transactions/{id}",
+      "permissionsRequired" : [ "finance-storage.transactions.item.delete" ]
+    } ]
+  }, {
+    "id" : "finance-storage.order-transaction-summaries",
+    "version" : "1.1",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/finance-storage/order-transaction-summaries",
+      "permissionsRequired" : [ "finance-storage.order-transaction-summaries.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance-storage/order-transaction-summaries/{id}",
+      "permissionsRequired" : [ "finance-storage.order-transaction-summaries.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/finance-storage/order-transaction-summaries/{id}",
+      "permissionsRequired" : [ "finance-storage.order-transaction-summaries.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/finance-storage/order-transaction-summaries/{id}",
+      "permissionsRequired" : [ "finance-storage.order-transaction-summaries.item.delete" ]
+    } ]
+  }, {
+    "id" : "finance-storage.invoice-transaction-summaries",
+    "version" : "2.0",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/finance-storage/invoice-transaction-summaries",
+      "permissionsRequired" : [ "finance-storage.invoice-transaction-summaries.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/finance-storage/invoice-transaction-summaries/{id}",
+      "permissionsRequired" : [ "finance-storage.invoice-transaction-summaries.item.get" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/finance-storage/invoice-transaction-summaries/{id}",
+      "permissionsRequired" : [ "finance-storage.invoice-transaction-summaries.item.delete" ]
+    } ]
+  }, {
+    "id" : "_tenant",
+    "version" : "1.2",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST", "DELETE" ],
+      "pathPattern" : "/_/tenant"
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "finance-storage.budgets.collection.get",
+    "displayName" : "budget-collection get",
+    "description" : "Get a collection of budgets"
+  }, {
+    "permissionName" : "finance-storage.budgets.item.post",
+    "displayName" : "budget-item post",
+    "description" : "Create a new budget"
+  }, {
+    "permissionName" : "finance-storage.budgets.item.get",
+    "displayName" : "budget-item get",
+    "description" : "Fetch a budget"
+  }, {
+    "permissionName" : "finance-storage.budgets.item.put",
+    "displayName" : "budget-item put",
+    "description" : "Update a budget"
+  }, {
+    "permissionName" : "finance-storage.budgets.item.delete",
+    "displayName" : "budget-item delete",
+    "description" : "Delete a budget"
+  }, {
+    "permissionName" : "finance-storage.group-budgets.collection.get",
+    "displayName" : "Get budget-collection from group-budget view",
+    "description" : "Get a collection of budgets"
+  }, {
+    "permissionName" : "finance-storage.budgets.all",
+    "displayName" : "All budget perms",
+    "description" : "All permissions for the budget",
+    "subPermissions" : [ "finance-storage.budgets.collection.get", "finance-storage.budgets.item.post", "finance-storage.budgets.item.get", "finance-storage.budgets.item.put", "finance-storage.budgets.item.delete", "finance-storage.group-budgets.collection.get" ]
+  }, {
+    "permissionName" : "finance-storage.fiscal-years.collection.get",
+    "displayName" : "fiscal-year-collection get",
+    "description" : "Get collection of fiscal year"
+  }, {
+    "permissionName" : "finance-storage.fiscal-years.item.post",
+    "displayName" : "fiscal-year-item post",
+    "description" : "Create a new fiscal year"
+  }, {
+    "permissionName" : "finance-storage.fiscal-years.item.get",
+    "displayName" : "fiscal-year-item get",
+    "description" : "Fetch a fiscal year"
+  }, {
+    "permissionName" : "finance-storage.fiscal-years.item.put",
+    "displayName" : "fiscal-year-item put",
+    "description" : "Update a fiscal year"
+  }, {
+    "permissionName" : "finance-storage.fiscal-years.item.delete",
+    "displayName" : "fiscal-year-item delete",
+    "description" : "Delete a fiscal year"
+  }, {
+    "permissionName" : "finance-storage.fiscal-years.all",
+    "displayName" : "All fiscal_year perms",
+    "description" : "All permissions for the fiscal year",
+    "subPermissions" : [ "finance-storage.fiscal-years.collection.get", "finance-storage.fiscal-years.item.post", "finance-storage.fiscal-years.item.get", "finance-storage.fiscal-years.item.put", "finance-storage.fiscal-years.item.delete" ]
+  }, {
+    "permissionName" : "finance-storage.fund-types.collection.get",
+    "displayName" : "Fund-type - get the collection of Fund-types",
+    "description" : "Get collection of fund types"
+  }, {
+    "permissionName" : "finance-storage.fund-types.item.post",
+    "displayName" : "Fund-type - create a new Fund-type",
+    "description" : "Create a new fund type"
+  }, {
+    "permissionName" : "finance-storage.fund-types.item.get",
+    "displayName" : "Fund-type - get an existing Fund-type",
+    "description" : "Fetch a fund type"
+  }, {
+    "permissionName" : "finance-storage.fund-types.item.put",
+    "displayName" : "Fund-type - modify an existing Fund-type",
+    "description" : "Update a fund type"
+  }, {
+    "permissionName" : "finance-storage.fund-types.item.delete",
+    "displayName" : "Fund-type - delete an existing Fund-type",
+    "description" : "Delete a fund type"
+  }, {
+    "permissionName" : "finance-storage.fund-types.all",
+    "displayName" : "All fund-type perms",
+    "description" : "All permissions for the fund type",
+    "subPermissions" : [ "finance-storage.fund-types.collection.get", "finance-storage.fund-types.item.post", "finance-storage.fund-types.item.get", "finance-storage.fund-types.item.put", "finance-storage.fund-types.item.delete" ]
+  }, {
+    "permissionName" : "finance-storage.funds.collection.get",
+    "displayName" : "fund-collection get",
+    "description" : "Get collection of funds"
+  }, {
+    "permissionName" : "finance-storage.funds.item.post",
+    "displayName" : "fund-item post",
+    "description" : "Create a new fund"
+  }, {
+    "permissionName" : "finance-storage.funds.item.get",
+    "displayName" : "fund-item get",
+    "description" : "Fetch a fund"
+  }, {
+    "permissionName" : "finance-storage.funds.item.put",
+    "displayName" : "fund-item put",
+    "description" : "Update a fund"
+  }, {
+    "permissionName" : "finance-storage.funds.item.delete",
+    "displayName" : "fund-item delete",
+    "description" : "Delete a fund"
+  }, {
+    "permissionName" : "finance-storage.funds.all",
+    "displayName" : "All fund perms",
+    "description" : "All permissions for the fund",
+    "subPermissions" : [ "finance-storage.funds.collection.get", "finance-storage.funds.item.post", "finance-storage.funds.item.get", "finance-storage.funds.item.put", "finance-storage.funds.item.delete" ]
+  }, {
+    "permissionName" : "finance-storage.groups.collection.get",
+    "displayName" : "Get a collection of group records",
+    "description" : "Get a collection of group records"
+  }, {
+    "permissionName" : "finance-storage.groups.item.post",
+    "displayName" : "Create a new group record",
+    "description" : "Create a new group record"
+  }, {
+    "permissionName" : "finance-storage.groups.item.get",
+    "displayName" : "Get a specific group record",
+    "description" : "Get a group record"
+  }, {
+    "permissionName" : "finance-storage.groups.item.put",
+    "displayName" : "Update a specific group record",
+    "description" : "Update a specific group record"
+  }, {
+    "permissionName" : "finance-storage.groups.item.delete",
+    "displayName" : "Delete a specific group record",
+    "description" : "Delete a specific group record"
+  }, {
+    "permissionName" : "finance-storage.group-fund-fiscal-years.collection.get",
+    "displayName" : "Get a collection of group/fund/fiscal year records relations",
+    "description" : "Get a collection of group/fund/fiscal year records relations"
+  }, {
+    "permissionName" : "finance-storage.group-fund-fiscal-years.item.post",
+    "displayName" : "Create a new group/fund/fiscal year records relation",
+    "description" : "Create a new group/fund/fiscal year records relation"
+  }, {
+    "permissionName" : "finance-storage.group-fund-fiscal-years.item.get",
+    "displayName" : "Get a specific group/fund/fiscal year records relation",
+    "description" : "Get a group/fund/fiscal year records relation"
+  }, {
+    "permissionName" : "finance-storage.group-fund-fiscal-years.item.put",
+    "displayName" : "Update a specific group/fund/fiscal year records relation",
+    "description" : "Update a specific group/fund/fiscal year records relation"
+  }, {
+    "permissionName" : "finance-storage.group-fund-fiscal-years.item.delete",
+    "displayName" : "Delete a specific group/fund/fiscal year records relation",
+    "description" : "Delete a specific group/fund/fiscal year records relation"
+  }, {
+    "permissionName" : "finance-storage.groups.all",
+    "displayName" : "All group related permissions",
+    "description" : "All group related permissions",
+    "subPermissions" : [ "finance-storage.groups.collection.get", "finance-storage.groups.item.post", "finance-storage.groups.item.get", "finance-storage.groups.item.put", "finance-storage.groups.item.delete", "finance-storage.group-fund-fiscal-years.collection.get", "finance-storage.group-fund-fiscal-years.item.post", "finance-storage.group-fund-fiscal-years.item.get", "finance-storage.group-fund-fiscal-years.item.put", "finance-storage.group-fund-fiscal-years.item.delete" ]
+  }, {
+    "permissionName" : "finance-storage.ledgers.collection.get",
+    "displayName" : "ledger-collection get",
+    "description" : "Get collection of ledgers"
+  }, {
+    "permissionName" : "finance-storage.ledgers.item.post",
+    "displayName" : "ledger-item post",
+    "description" : "Create a new ledger"
+  }, {
+    "permissionName" : "finance-storage.ledgers.item.get",
+    "displayName" : "ledger-item get",
+    "description" : "Fetch a ledger"
+  }, {
+    "permissionName" : "finance-storage.ledgers.item.put",
+    "displayName" : "ledger-item put",
+    "description" : "Update a ledger"
+  }, {
+    "permissionName" : "finance-storage.ledgers.item.delete",
+    "displayName" : "ledger-item delete",
+    "description" : "Delete a ledger"
+  }, {
+    "permissionName" : "finance-storage.ledgersFY.collection.get",
+    "displayName" : "ledgersFY-collection get",
+    "description" : "Get collection of ledgersFY"
+  }, {
+    "permissionName" : "finance-storage.ledgers.all",
+    "displayName" : "All fund perms",
+    "description" : "All permissions for the ledger",
+    "subPermissions" : [ "finance-storage.ledgers.collection.get", "finance-storage.ledgers.item.post", "finance-storage.ledgers.item.get", "finance-storage.ledgers.item.put", "finance-storage.ledgers.item.delete", "finance-storage.ledgersFY.collection.get" ]
+  }, {
+    "permissionName" : "finance-storage.transactions.collection.get",
+    "displayName" : "finance-storage.transactions.-collection get",
+    "description" : "Get collection of transactions"
+  }, {
+    "permissionName" : "finance-storage.transactions.item.post",
+    "displayName" : "finance-storage.transactions.-item post",
+    "description" : "Create a new transaction"
+  }, {
+    "permissionName" : "finance-storage.transactions.item.get",
+    "displayName" : "finance-storage.transactions.-item get",
+    "description" : "Fetch a transaction"
+  }, {
+    "permissionName" : "finance-storage.transactions.item.put",
+    "displayName" : "finance-storage.transactions.-item put",
+    "description" : "Update a transaction"
+  }, {
+    "permissionName" : "finance-storage.transactions.item.delete",
+    "displayName" : "finance-storage.transactions.-item delete",
+    "description" : "Delete a transaction"
+  }, {
+    "permissionName" : "finance-storage.transactions.all",
+    "displayName" : "All transaction perms",
+    "description" : "All permissions for the transaction",
+    "subPermissions" : [ "finance-storage.transactions.collection.get", "finance-storage.transactions.item.post", "finance-storage.transactions.item.get", "finance-storage.transactions.item.put" ]
+  }, {
+    "permissionName" : "finance-storage.order-transaction-summaries.item.get",
+    "displayName" : "Retrieve a new order transaction summary record",
+    "description" : "Retrieve a new order transaction summary record"
+  }, {
+    "permissionName" : "finance-storage.order-transaction-summaries.item.post",
+    "displayName" : "Create a new order transaction summary record",
+    "description" : "Create a new order transaction summary record"
+  }, {
+    "permissionName" : "finance-storage.order-transaction-summaries.item.put",
+    "displayName" : "Update order transaction summary record",
+    "description" : "Update order transaction summary record"
+  }, {
+    "permissionName" : "finance-storage.order-transaction-summaries.item.delete",
+    "displayName" : "Delete a new order transaction summary record",
+    "description" : "Delete a new order transaction summary record"
+  }, {
+    "permissionName" : "finance-storage.order-transaction-summaries.all",
+    "displayName" : "All order transaction summary perms",
+    "description" : "All permissions for the order transaction summary",
+    "subPermissions" : [ "finance-storage.order-transaction-summaries.item.get", "finance-storage.order-transaction-summaries.item.post", "finance-storage.order-transaction-summaries.item.put", "finance-storage.order-transaction-summaries.item.delete" ]
+  }, {
+    "permissionName" : "finance-storage.invoice-transaction-summaries.item.get",
+    "displayName" : "Retrieve an invoice transaction summary record",
+    "description" : "Retrieve an invoice transaction summary record"
+  }, {
+    "permissionName" : "finance-storage.invoice-transaction-summaries.item.post",
+    "displayName" : "Create a new invoice transaction summary record",
+    "description" : "Create a new invoice transaction summary record"
+  }, {
+    "permissionName" : "finance-storage.invoice-transaction-summaries.item.delete",
+    "displayName" : "Delete an invoice transaction summary record",
+    "description" : "Delete an  invoice transaction summary record"
+  }, {
+    "permissionName" : "finance-storage.invoice-transaction-summaries.all",
+    "displayName" : "All invoice transaction summary perms",
+    "description" : "All permissions for the invoice transaction summary",
+    "subPermissions" : [ "finance-storage.invoice-transaction-summaries.item.get", "finance-storage.invoice-transaction-summaries.item.post", "finance-storage.invoice-transaction-summaries.item.delete" ]
+  }, {
+    "permissionName" : "finance.module.all",
+    "displayName" : "All finance-module perms",
+    "description" : "All permissions for the finance module",
+    "subPermissions" : [ "finance-storage.budgets.all", "finance-storage.fiscal-years.all", "finance-storage.funds.all", "finance-storage.groups.all", "finance-storage.ledgers.all", "finance-storage.transactions.all", "finance-storage.fund-types.all", "finance-storage.order-transaction-summaries.all", "finance-storage.invoice-transaction-summaries.all" ]
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-finance-storage:5.0.2",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    }, {
+      "name" : "DB_HOST",
+      "value" : "postgres"
+    }, {
+      "name" : "DB_PORT",
+      "value" : "5432"
+    }, {
+      "name" : "DB_USERNAME",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_PASSWORD",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_DATABASE",
+      "value" : "okapi_modules"
+    }, {
+      "name" : "DB_QUERYTIMEOUT",
+      "value" : "60000"
+    }, {
+      "name" : "DB_CHARSET",
+      "value" : "UTF-8"
+    }, {
+      "name" : "DB_MAXPOOLSIZE",
+      "value" : "5"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-gobi-1.10.0",
+  "name" : "GOBI® Module",
+  "requires" : [ {
+    "id" : "orders",
+    "version" : "10.4"
+  }, {
+    "id" : "configuration",
+    "version" : "2.0"
+  }, {
+    "id" : "contributor-name-types",
+    "version" : "1.2"
+  }, {
+    "id" : "material-types",
+    "version" : "2.2"
+  }, {
+    "id" : "locations",
+    "version" : "3.0"
+  }, {
+    "id" : "organizations-storage.organizations",
+    "version" : "3.1"
+  }, {
+    "id" : "finance.funds",
+    "version" : "1.1"
+  }, {
+    "id" : "identifier-types",
+    "version" : "1.2"
+  } ],
+  "provides" : [ {
+    "id" : "gobi",
+    "version" : "1.9",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/gobi/validate",
+      "permissionsRequired" : [ "gobi.item.post" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/gobi/validate",
+      "permissionsRequired" : [ "gobi.item.post" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/gobi/orders",
+      "permissionsRequired" : [ "gobi.item.post" ],
+      "modulePermissions" : [ "orders.item.post", "orders.collection.get", "orders.item.get", "orders.item.put", "inventory-storage.contributor-name-types.collection.get", "inventory-storage.material-types.collection.get", "inventory-storage.locations.collection.get", "inventory-storage.identifier-types.collection.get", "organizations-storage.organizations.collection.get", "configuration.entries.collection.get", "finance.funds.collection.get", "orders.item.approve" ]
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "gobi.item.post",
+    "displayName" : "gobi - post order",
+    "description" : "Creates an order"
+  }, {
+    "permissionName" : "gobi.all",
+    "displayName" : "gobi - all permissions",
+    "description" : "Entire set of permissions needed to use gobi",
+    "subPermissions" : [ "gobi.item.post" ]
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-gobi:1.10.0",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-inventory-16.0.3",
+  "name" : "Inventory Module",
+  "requires" : [ {
+    "id" : "item-storage",
+    "version" : "8.4"
+  }, {
+    "id" : "instance-storage",
+    "version" : "7.2"
+  }, {
+    "id" : "instance-storage-batch",
+    "version" : "0.2"
+  }, {
+    "id" : "holdings-storage",
+    "version" : "2.0 3.0 4.0"
+  }, {
+    "id" : "material-types",
+    "version" : "2.0"
+  }, {
+    "id" : "loan-types",
+    "version" : "2.0"
+  }, {
+    "id" : "locations",
+    "version" : "2.0 3.0"
+  }, {
+    "id" : "instance-types",
+    "version" : "1.0 2.0"
+  }, {
+    "id" : "identifier-types",
+    "version" : "1.0"
+  }, {
+    "id" : "contributor-name-types",
+    "version" : "1.0"
+  }, {
+    "id" : "users",
+    "version" : "15.0"
+  }, {
+    "id" : "pubsub-event-types",
+    "version" : "0.1"
+  }, {
+    "id" : "pubsub-publishers",
+    "version" : "0.1"
+  }, {
+    "id" : "pubsub-subscribers",
+    "version" : "0.1"
+  }, {
+    "id" : "pubsub-publish",
+    "version" : "0.1"
+  }, {
+    "id" : "instance-preceding-succeeding-titles",
+    "version" : "0.1"
+  }, {
+    "id" : "request-storage",
+    "version" : "3.3"
+  }, {
+    "id" : "source-storage-records",
+    "version" : "2.0"
+  } ],
+  "provides" : [ {
+    "id" : "inventory",
+    "version" : "10.5",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/inventory/items",
+      "permissionsRequired" : [ "inventory.items.collection.get" ],
+      "modulePermissions" : [ "inventory-storage.items.collection.get", "inventory-storage.material-types.item.get", "inventory-storage.material-types.collection.get", "inventory-storage.loan-types.item.get", "inventory-storage.loan-types.collection.get", "inventory-storage.locations.item.get", "inventory-storage.locations.collection.get", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.instances.collection.get", "inventory-storage.instances.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/inventory/items/{id}",
+      "permissionsRequired" : [ "inventory.items.item.get" ],
+      "modulePermissions" : [ "inventory-storage.items.item.get", "inventory-storage.material-types.item.get", "inventory-storage.material-types.collection.get", "inventory-storage.loan-types.item.get", "inventory-storage.loan-types.collection.get", "inventory-storage.locations.item.get", "inventory-storage.locations.collection.get", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.instances.collection.get", "inventory-storage.instances.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/inventory/items/{id}/mark-withdrawn",
+      "permissionsRequired" : [ "inventory.items.item.mark-withdrawn.post" ],
+      "modulePermissions" : [ "circulation-storage.requests.collection.get", "circulation-storage.requests.item.put", "inventory-storage.items.item.put", "inventory-storage.material-types.item.get", "inventory-storage.material-types.collection.get", "inventory-storage.loan-types.item.get", "inventory-storage.loan-types.collection.get", "inventory-storage.locations.item.get", "inventory-storage.locations.collection.get", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.instances.collection.get", "inventory-storage.instances.item.get", "users.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/inventory/items",
+      "permissionsRequired" : [ "inventory.items.item.post" ],
+      "modulePermissions" : [ "inventory-storage.items.item.post", "inventory-storage.material-types.item.get", "inventory-storage.material-types.collection.get", "inventory-storage.loan-types.item.get", "inventory-storage.loan-types.collection.get", "inventory-storage.locations.item.get", "inventory-storage.locations.collection.get", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.instances.collection.get", "inventory-storage.instances.item.get", "users.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/inventory/items/{id}",
+      "permissionsRequired" : [ "inventory.items.item.put" ],
+      "modulePermissions" : [ "inventory-storage.items.item.put", "users.item.get" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/inventory/items/{id}",
+      "permissionsRequired" : [ "inventory.items.item.delete" ],
+      "modulePermissions" : [ "inventory-storage.items.item.delete" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/inventory/items",
+      "permissionsRequired" : [ "inventory.items.collection.delete" ],
+      "modulePermissions" : [ "inventory-storage.items.collection.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/inventory/instances",
+      "permissionsRequired" : [ "inventory.instances.collection.get" ],
+      "modulePermissions" : [ "inventory-storage.instances.collection.get", "inventory-storage.instances.item.get", "inventory-storage.preceding-succeeding-titles.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/inventory/instances/{id}",
+      "permissionsRequired" : [ "inventory.instances.item.get" ],
+      "modulePermissions" : [ "inventory-storage.instances.item.get", "inventory-storage.preceding-succeeding-titles.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/inventory/instances",
+      "permissionsRequired" : [ "inventory.instances.item.post" ],
+      "modulePermissions" : [ "inventory-storage.instances.item.post", "inventory-storage.instances.item.get", "inventory-storage.preceding-succeeding-titles.collection.get", "inventory-storage.preceding-succeeding-titles.item.post", "inventory-storage.preceding-succeeding-titles.item.put", "inventory-storage.preceding-succeeding-titles.item.delete" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/inventory/instances/{id}",
+      "permissionsRequired" : [ "inventory.instances.item.put" ],
+      "modulePermissions" : [ "inventory-storage.instances.item.put", "inventory-storage.instances.item.get", "inventory-storage.instances.item.post", "inventory-storage.instances.item.delete", "source-storage.records.update", "inventory-storage.preceding-succeeding-titles.collection.get", "inventory-storage.preceding-succeeding-titles.item.post", "inventory-storage.preceding-succeeding-titles.item.put", "inventory-storage.preceding-succeeding-titles.item.delete" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/inventory/instances/{id}",
+      "permissionsRequired" : [ "inventory.instances.item.delete" ],
+      "modulePermissions" : [ "inventory-storage.instances.item.delete" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/inventory/instances",
+      "permissionsRequired" : [ "inventory.instances.collection.delete" ],
+      "modulePermissions" : [ "inventory-storage.instances.collection.delete" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/inventory/ingest/mods",
+      "permissionsRequired" : [ "inventory.ingest.mods.post" ],
+      "modulePermissions" : [ "inventory-storage.items.item.post", "inventory-storage.instances.item.post", "inventory-storage.instances.collection.get", "inventory-storage.holdings.item.post", "inventory-storage.holdings.collection.get", "inventory-storage.material-types.collection.get", "inventory-storage.loan-types.collection.get", "inventory-storage.locations.collection.get", "inventory-storage.instance-types.collection.get", "inventory-storage.identifier-types.collection.get", "inventory-storage.contributor-name-types.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/inventory/ingest/mods/status/{id}",
+      "permissionsRequired" : [ "inventory.ingest.mods.status.get" ]
+    } ]
+  }, {
+    "id" : "inventory-batch",
+    "version" : "0.5",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/inventory/instances/batch",
+      "permissionsRequired" : [ "inventory.instances.batch.post" ],
+      "modulePermissions" : [ "inventory-storage.instances.item.post", "inventory-storage.instances.item.get", "inventory-storage.instances.item.put", "inventory-storage.instances.item.delete", "inventory-storage.instances.batch.post", "inventory-storage.preceding-succeeding-titles.collection.get", "inventory-storage.preceding-succeeding-titles.item.post", "inventory-storage.preceding-succeeding-titles.item.put", "inventory-storage.preceding-succeeding-titles.item.delete" ]
+    } ]
+  }, {
+    "id" : "inventory-config",
+    "version" : "0.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/inventory/config/instances/blocked-fields",
+      "permissionsRequired" : [ "inventory.config.instances.blocked-fields.get" ],
+      "modulePermissions" : [ ]
+    } ]
+  }, {
+    "id" : "isbn-utils",
+    "version" : "2.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/isbn/convertTo13",
+      "permissionsRequired" : [ "isbn-utils.convert-to-13.get" ],
+      "modulePermissions" : [ ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/isbn/convertTo10",
+      "permissionsRequired" : [ "isbn-utils.convert-to-10.get" ],
+      "modulePermissions" : [ ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/isbn/validator",
+      "permissionsRequired" : [ "isbn-utils.validator.get" ],
+      "modulePermissions" : [ ]
+    } ]
+  }, {
+    "id" : "inventory-event-handlers",
+    "version" : "0.1",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/inventory/handlers/data-import",
+      "permissionsRequired" : [ "inventory.events.post" ],
+      "modulePermissions" : [ "pubsub.publish.post", "inventory-storage.items.collection.get", "inventory-storage.items.item.post", "inventory-storage.material-types.item.get", "inventory-storage.material-types.collection.get", "inventory-storage.loan-types.item.get", "inventory-storage.loan-types.collection.get", "inventory-storage.locations.item.get", "inventory-storage.locations.collection.get", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.holdings.item.post", "inventory-storage.instances.collection.get", "inventory-storage.instances.item.get", "inventory-storage.instances.item.post", "inventory-storage.instances.item.put", "inventory-storage.holdings.item.put", "inventory-storage.items.item.put", "inventory-storage.preceding-succeeding-titles.item.post" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/inventory/handlers/instances",
+      "permissionsRequired" : [ "inventory.events.post" ],
+      "modulePermissions" : [ "inventory-storage.instances.item.get", "inventory-storage.instances.item.put", "pubsub.publish.post" ]
+    } ]
+  }, {
+    "id" : "_tenant",
+    "version" : "1.2",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/_/tenant",
+      "modulePermissions" : [ "pubsub.event-types.post", "pubsub.publishers.post", "pubsub.subscribers.post" ]
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "inventory.items.collection.get",
+    "displayName" : "Inventory - get item collection",
+    "description" : "Get item collection"
+  }, {
+    "permissionName" : "inventory.items.collection.delete",
+    "displayName" : "Inventory - delete entire item collection",
+    "description" : "Delete entire item collection"
+  }, {
+    "permissionName" : "inventory.items.item.get",
+    "displayName" : "Inventory - get individual item",
+    "description" : "Get individual item"
+  }, {
+    "permissionName" : "inventory.items.item.mark-withdrawn.post",
+    "displayName" : "Inventory - mark an item as withdrawn",
+    "description" : "Mark an item as withdrawn"
+  }, {
+    "permissionName" : "inventory.items.item.post",
+    "displayName" : "Inventory - create individual item",
+    "description" : "Create individual item"
+  }, {
+    "permissionName" : "inventory.items.item.put",
+    "displayName" : "Inventory - modify item",
+    "description" : "Modify item"
+  }, {
+    "permissionName" : "inventory.items.item.delete",
+    "displayName" : "Inventory - delete individual item",
+    "description" : "Delete individual item"
+  }, {
+    "permissionName" : "inventory.instances.collection.get",
+    "displayName" : "Inventory - get instance collection",
+    "description" : "Get instance collection"
+  }, {
+    "permissionName" : "inventory.instances.collection.delete",
+    "displayName" : "Inventory - delete entire instance collection",
+    "description" : "Delete entire instance collection"
+  }, {
+    "permissionName" : "inventory.instances.item.get",
+    "displayName" : "Inventory - get individual instance",
+    "description" : "Get individual instance"
+  }, {
+    "permissionName" : "inventory.instances.item.post",
+    "displayName" : "Inventory - create individual instance",
+    "description" : "Create individual instance"
+  }, {
+    "permissionName" : "inventory.instances.batch.post",
+    "displayName" : "Inventory - create batch of individual instance",
+    "description" : "Create batch of individual instance"
+  }, {
+    "permissionName" : "inventory.instances.item.put",
+    "displayName" : "Inventory - modify instance",
+    "description" : "Modify instance"
+  }, {
+    "permissionName" : "inventory.instances.item.delete",
+    "displayName" : "Inventory - delete individual instance",
+    "description" : "Delete individual instance"
+  }, {
+    "permissionName" : "inventory.ingest.mods.post",
+    "displayName" : "Inventory - ingest a MODS format file",
+    "description" : "Request ingestion of a MODS format file"
+  }, {
+    "permissionName" : "inventory.ingest.mods.status.get",
+    "displayName" : "Inventory - MODS ingest status",
+    "description" : "Check the status of a MODS format file ingestion"
+  }, {
+    "permissionName" : "inventory.config.instances.blocked-fields.get",
+    "displayName" : "Inventory - get configuration for blocked fields of instances",
+    "description" : "Get configuration for blocked fields of instances"
+  }, {
+    "permissionName" : "inventory.events.post",
+    "displayName" : "Inventory - post event",
+    "description" : "Post event to handle in inventory"
+  }, {
+    "permissionName" : "inventory.all",
+    "displayName" : "Inventory - all permissions",
+    "description" : "Entire set of permissions needed to use the inventory",
+    "subPermissions" : [ "inventory.items.collection.get", "inventory.items.item.get", "inventory.items.item.post", "inventory.items.item.put", "inventory.items.item.delete", "inventory.items.collection.delete", "inventory.instances.collection.get", "inventory.instances.item.get", "inventory.instances.item.post", "inventory.instances.batch.post", "inventory.instances.item.put", "inventory.instances.item.delete", "inventory.instances.collection.delete", "inventory.ingest.mods.post", "inventory.ingest.mods.status.get", "inventory.config.instances.blocked-fields.get", "inventory.items.item.mark-withdrawn.post" ]
+  }, {
+    "permissionName" : "isbn-utils.convert-to-13.get",
+    "displayName" : "ISBN utils - convert to ISBN-13 format",
+    "description" : "Convert isbn code to ISBN-13 format"
+  }, {
+    "permissionName" : "isbn-utils.convert-to-10.get",
+    "displayName" : "ISBN utils - convert to ISBN-10 format",
+    "description" : "Convert isbn code to ISBN-10 format"
+  }, {
+    "permissionName" : "isbn-utils.validator.get",
+    "displayName" : "ISBN utils - validate ISBN code",
+    "description" : "Check that isbn code is valid"
+  }, {
+    "permissionName" : "isbn-utils.all",
+    "displayName" : "Isbn-utils - all permissions",
+    "description" : "Entire set of permissions needed to use the isbn-utils",
+    "subPermissions" : [ "isbn-utils.convert-to-13.get", "isbn-utils.convert-to-10.get", "isbn-utils.validator.get" ]
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-inventory:16.0.3",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0 -Dorg.folio.metadata.inventory.storage.type=okapi"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 715827883,
+        "PortBindings" : {
+          "9403/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-inventory-storage-19.3.6",
+  "name" : "Inventory Storage Module",
+  "provides" : [ {
+    "id" : "item-storage",
+    "version" : "8.5",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/item-storage/items",
+      "permissionsRequired" : [ "inventory-storage.items.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/item-storage/items/{id}",
+      "permissionsRequired" : [ "inventory-storage.items.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/item-storage/items",
+      "permissionsRequired" : [ "inventory-storage.items.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/item-storage/items/{id}",
+      "permissionsRequired" : [ "inventory-storage.items.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/item-storage/items/{id}",
+      "permissionsRequired" : [ "inventory-storage.items.item.delete" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/item-storage/items",
+      "permissionsRequired" : [ "inventory-storage.items.collection.delete" ]
+    } ]
+  }, {
+    "id" : "item-storage-batch-sync",
+    "version" : "0.5",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/item-storage/batch/synchronous",
+      "permissionsRequired" : [ "inventory-storage.items.batch.post" ]
+    } ]
+  }, {
+    "id" : "holdings-storage",
+    "version" : "4.2",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/holdings-storage/holdings",
+      "permissionsRequired" : [ "inventory-storage.holdings.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/holdings-storage/holdings/{id}",
+      "permissionsRequired" : [ "inventory-storage.holdings.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/holdings-storage/holdings",
+      "permissionsRequired" : [ "inventory-storage.holdings.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/holdings-storage/holdings/{id}",
+      "permissionsRequired" : [ "inventory-storage.holdings.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/holdings-storage/holdings/{id}",
+      "permissionsRequired" : [ "inventory-storage.holdings.item.delete" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/holdings-storage/holdings",
+      "permissionsRequired" : [ "inventory-storage.holdings.collection.delete" ]
+    } ]
+  }, {
+    "id" : "holdings-storage-batch-sync",
+    "version" : "0.2",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/holdings-storage/batch/synchronous",
+      "permissionsRequired" : [ "inventory-storage.holdings.batch.post" ]
+    } ]
+  }, {
+    "id" : "instance-storage",
+    "version" : "7.4",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/instance-storage/instances",
+      "permissionsRequired" : [ "inventory-storage.instances.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/instance-storage/instances/{id}",
+      "permissionsRequired" : [ "inventory-storage.instances.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/instance-storage/instances",
+      "permissionsRequired" : [ "inventory-storage.instances.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/instance-storage/instances/{id}",
+      "permissionsRequired" : [ "inventory-storage.instances.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/instance-storage/instances/{id}",
+      "permissionsRequired" : [ "inventory-storage.instances.item.delete" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/instance-storage/instances/{id}/source-record",
+      "permissionsRequired" : [ "inventory-storage.instances.source-record.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/instance-storage/instances/{id}/source-record/marc-json",
+      "permissionsRequired" : [ "inventory-storage.instances.source-record.marc-json.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/instance-storage/instances/{id}/source-record/marc-json",
+      "permissionsRequired" : [ "inventory-storage.instances.source-record.marc-json.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/instance-storage/instances/{id}/source-record/marc-json",
+      "permissionsRequired" : [ "inventory-storage.instances.source-record.marc-json.delete" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/instance-storage/instances",
+      "permissionsRequired" : [ "inventory-storage.instances.collection.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/instance-storage/instance-relationships",
+      "permissionsRequired" : [ "inventory-storage.instances.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/instance-storage/instance-relationships",
+      "permissionsRequired" : [ "inventory-storage.instances.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/instance-storage/instance-relationships/{id}",
+      "permissionsRequired" : [ "inventory-storage.instances.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/instance-storage/instance-relationships/{id}",
+      "permissionsRequired" : [ "inventory-storage.instances.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/instance-storage/instance-relationships/{id}",
+      "permissionsRequired" : [ "inventory-storage.instances.item.delete" ]
+    } ]
+  }, {
+    "id" : "instance-preceding-succeeding-titles",
+    "version" : "0.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/preceding-succeeding-titles",
+      "permissionsRequired" : [ "inventory-storage.preceding-succeeding-titles.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/preceding-succeeding-titles/{id}",
+      "permissionsRequired" : [ "inventory-storage.preceding-succeeding-titles.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/preceding-succeeding-titles",
+      "permissionsRequired" : [ "inventory-storage.preceding-succeeding-titles.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/preceding-succeeding-titles/{id}",
+      "permissionsRequired" : [ "inventory-storage.preceding-succeeding-titles.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/preceding-succeeding-titles/{id}",
+      "permissionsRequired" : [ "inventory-storage.preceding-succeeding-titles.item.delete" ]
+    } ]
+  }, {
+    "id" : "instance-storage-batch",
+    "version" : "0.3",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/instance-storage/batch/instances",
+      "permissionsRequired" : [ "inventory-storage.instances.batch.post" ]
+    } ]
+  }, {
+    "id" : "instance-storage-batch-sync",
+    "version" : "0.3",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/instance-storage/batch/synchronous",
+      "permissionsRequired" : [ "inventory-storage.instances.batch.post" ]
+    } ]
+  }, {
+    "id" : "loan-types",
+    "version" : "2.2",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/loan-types",
+      "permissionsRequired" : [ "inventory-storage.loan-types.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/loan-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.loan-types.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/loan-types",
+      "permissionsRequired" : [ "inventory-storage.loan-types.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/loan-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.loan-types.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/loan-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.loan-types.item.delete" ]
+    } ]
+  }, {
+    "id" : "material-types",
+    "version" : "2.2",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/material-types",
+      "permissionsRequired" : [ "inventory-storage.material-types.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/material-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.material-types.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/material-types",
+      "permissionsRequired" : [ "inventory-storage.material-types.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/material-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.material-types.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/material-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.material-types.item.delete" ]
+    } ]
+  }, {
+    "id" : "shelf-locations",
+    "version" : "1.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/shelf-locations",
+      "permissionsRequired" : [ "inventory-storage.shelf-locations.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/shelf-locations/{id}",
+      "permissionsRequired" : [ "inventory-storage.shelf-locations.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/shelf-locations",
+      "permissionsRequired" : [ "inventory-storage.shelf-locations.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/shelf-locations/{id}",
+      "permissionsRequired" : [ "inventory-storage.shelf-locations.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/shelf-locations/{id}",
+      "permissionsRequired" : [ "inventory-storage.shelf-locations.item.delete" ]
+    } ]
+  }, {
+    "id" : "location-units",
+    "version" : "2.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/location-units/institutions",
+      "permissionsRequired" : [ "inventory-storage.location-units.institutions.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/location-units/institutions/{id}",
+      "permissionsRequired" : [ "inventory-storage.location-units.institutions.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/location-units/institutions",
+      "permissionsRequired" : [ "inventory-storage.location-units.institutions.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/location-units/institutions/{id}",
+      "permissionsRequired" : [ "inventory-storage.location-units.institutions.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/location-units/institutions/{id}",
+      "permissionsRequired" : [ "inventory-storage.location-units.institutions.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/location-units/campuses",
+      "permissionsRequired" : [ "inventory-storage.location-units.campuses.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/location-units/campuses/{id}",
+      "permissionsRequired" : [ "inventory-storage.location-units.campuses.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/location-units/campuses",
+      "permissionsRequired" : [ "inventory-storage.location-units.campuses.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/location-units/campuses/{id}",
+      "permissionsRequired" : [ "inventory-storage.location-units.campuses.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/location-units/campuses/{id}",
+      "permissionsRequired" : [ "inventory-storage.location-units.campuses.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/location-units/libraries",
+      "permissionsRequired" : [ "inventory-storage.location-units.libraries.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/location-units/libraries/{id}",
+      "permissionsRequired" : [ "inventory-storage.location-units.libraries.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/location-units/libraries",
+      "permissionsRequired" : [ "inventory-storage.location-units.libraries.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/location-units/libraries/{id}",
+      "permissionsRequired" : [ "inventory-storage.location-units.libraries.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/location-units/libraries/{id}",
+      "permissionsRequired" : [ "inventory-storage.location-units.libraries.item.delete" ]
+    } ]
+  }, {
+    "id" : "locations",
+    "version" : "3.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/locations",
+      "permissionsRequired" : [ "inventory-storage.locations.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/locations/{id}",
+      "permissionsRequired" : [ "inventory-storage.locations.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/locations",
+      "permissionsRequired" : [ "inventory-storage.locations.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/locations/{id}",
+      "permissionsRequired" : [ "inventory-storage.locations.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/locations/{id}",
+      "permissionsRequired" : [ "inventory-storage.locations.item.delete" ]
+    } ]
+  }, {
+    "id" : "instance-relationship-types",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/instance-relationship-types",
+      "permissionsRequired" : [ "inventory-storage.instance-relationship-types.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/instance-relationship-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.instance-relationship-types.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/instance-relationship-types",
+      "permissionsRequired" : [ "inventory-storage.instance-relationship-types.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/instance-relationship-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.instance-relationship-types.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/instance-relationship-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.instance-relationship-types.item.delete" ]
+    } ]
+  }, {
+    "id" : "identifier-types",
+    "version" : "1.2",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/identifier-types",
+      "permissionsRequired" : [ "inventory-storage.identifier-types.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/identifier-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.identifier-types.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/identifier-types",
+      "permissionsRequired" : [ "inventory-storage.identifier-types.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/identifier-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.identifier-types.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/identifier-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.identifier-types.item.delete" ]
+    } ]
+  }, {
+    "id" : "contributor-types",
+    "version" : "2.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/contributor-types",
+      "permissionsRequired" : [ "inventory-storage.contributor-types.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/contributor-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.contributor-types.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/contributor-types",
+      "permissionsRequired" : [ "inventory-storage.contributor-types.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/contributor-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.contributor-types.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/contributor-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.contributor-types.item.delete" ]
+    } ]
+  }, {
+    "id" : "contributor-name-types",
+    "version" : "1.2",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/contributor-name-types",
+      "permissionsRequired" : [ "inventory-storage.contributor-name-types.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/contributor-name-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.contributor-name-types.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/contributor-name-types",
+      "permissionsRequired" : [ "inventory-storage.contributor-name-types.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/contributor-name-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.contributor-name-types.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/contributor-name-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.contributor-name-types.item.delete" ]
+    } ]
+  }, {
+    "id" : "instance-bulk",
+    "version" : "0.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/instance-bulk/ids",
+      "permissionsRequired" : [ "inventory-storage.instance-bulk.ids.get" ]
+    } ]
+  }, {
+    "id" : "instance-formats",
+    "version" : "2.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/instance-formats",
+      "permissionsRequired" : [ "inventory-storage.instance-formats.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/instance-formats/{id}",
+      "permissionsRequired" : [ "inventory-storage.instance-formats.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/instance-formats",
+      "permissionsRequired" : [ "inventory-storage.instance-formats.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/instance-formats/{id}",
+      "permissionsRequired" : [ "inventory-storage.instance-formats.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/instance-formats/{id}",
+      "permissionsRequired" : [ "inventory-storage.instance-formats.item.delete" ]
+    } ]
+  }, {
+    "id" : "instance-types",
+    "version" : "2.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/instance-types",
+      "permissionsRequired" : [ "inventory-storage.instance-types.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/instance-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.instance-types.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/instance-types",
+      "permissionsRequired" : [ "inventory-storage.instance-types.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/instance-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.instance-types.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/instance-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.instance-types.item.delete" ]
+    } ]
+  }, {
+    "id" : "nature-of-content-terms",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/nature-of-content-terms",
+      "permissionsRequired" : [ "inventory-storage.nature-of-content-terms.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/nature-of-content-terms/{id}",
+      "permissionsRequired" : [ "inventory-storage.nature-of-content-terms.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/nature-of-content-terms",
+      "permissionsRequired" : [ "inventory-storage.nature-of-content-terms.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/nature-of-content-terms/{id}",
+      "permissionsRequired" : [ "inventory-storage.nature-of-content-terms.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/nature-of-content-terms/{id}",
+      "permissionsRequired" : [ "inventory-storage.nature-of-content-terms.item.delete" ]
+    } ]
+  }, {
+    "id" : "classification-types",
+    "version" : "1.2",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/classification-types",
+      "permissionsRequired" : [ "inventory-storage.classification-types.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/classification-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.classification-types.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/classification-types",
+      "permissionsRequired" : [ "inventory-storage.classification-types.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/classification-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.classification-types.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/classification-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.classification-types.item.delete" ]
+    } ]
+  }, {
+    "id" : "alternative-title-types",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/alternative-title-types",
+      "permissionsRequired" : [ "inventory-storage.alternative-title-types.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/alternative-title-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.alternative-title-types.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/alternative-title-types",
+      "permissionsRequired" : [ "inventory-storage.alternative-title-types.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/alternative-title-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.alternative-title-types.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/alternative-title-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.alternative-title-types.item.delete" ]
+    } ]
+  }, {
+    "id" : "modes-of-issuance",
+    "version" : "1.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/modes-of-issuance",
+      "permissionsRequired" : [ "inventory-storage.modes-of-issuance.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/modes-of-issuance/{id}",
+      "permissionsRequired" : [ "inventory-storage.modes-of-issuance.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/modes-of-issuance",
+      "permissionsRequired" : [ "inventory-storage.modes-of-issuance.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/modes-of-issuance/{id}",
+      "permissionsRequired" : [ "inventory-storage.modes-of-issuance.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/modes-of-issuance/{id}",
+      "permissionsRequired" : [ "inventory-storage.modes-of-issuance.item.delete" ]
+    } ]
+  }, {
+    "id" : "instance-statuses",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/instance-statuses",
+      "permissionsRequired" : [ "inventory-storage.instance-statuses.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/instance-statuses/{id}",
+      "permissionsRequired" : [ "inventory-storage.instance-statuses.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/instance-statuses",
+      "permissionsRequired" : [ "inventory-storage.instance-statuses.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/instance-statuses/{id}",
+      "permissionsRequired" : [ "inventory-storage.instance-statuses.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/instance-statuses/{id}",
+      "permissionsRequired" : [ "inventory-storage.instance-statuses.item.delete" ]
+    } ]
+  }, {
+    "id" : "electronic-access-relationships",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/electronic-access-relationships",
+      "permissionsRequired" : [ "inventory-storage.electronic-access-relationships.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/electronic-access-relationships/{id}",
+      "permissionsRequired" : [ "inventory-storage.electronic-access-relationships.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/electronic-access-relationships",
+      "permissionsRequired" : [ "inventory-storage.electronic-access-relationships.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/electronic-access-relationships/{id}",
+      "permissionsRequired" : [ "inventory-storage.electronic-access-relationships.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/electronic-access-relationships/{id}",
+      "permissionsRequired" : [ "inventory-storage.electronic-access-relationships.item.delete" ]
+    } ]
+  }, {
+    "id" : "statistical-code-types",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/statistical-code-types",
+      "permissionsRequired" : [ "inventory-storage.statistical-code-types.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/statistical-code-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.statistical-code-types.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/statistical-code-types",
+      "permissionsRequired" : [ "inventory-storage.statistical-code-types.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/statistical-code-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.statistical-code-types.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/statistical-code-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.statistical-code-types.item.delete" ]
+    } ]
+  }, {
+    "id" : "statistical-codes",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/statistical-codes",
+      "permissionsRequired" : [ "inventory-storage.statistical-codes.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/statistical-codes/{id}",
+      "permissionsRequired" : [ "inventory-storage.statistical-codes.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/statistical-codes",
+      "permissionsRequired" : [ "inventory-storage.statistical-codes.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/statistical-codes/{id}",
+      "permissionsRequired" : [ "inventory-storage.statistical-codes.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/statistical-codes/{id}",
+      "permissionsRequired" : [ "inventory-storage.statistical-codes.item.delete" ]
+    } ]
+  }, {
+    "id" : "ill-policies",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/ill-policies",
+      "permissionsRequired" : [ "inventory-storage.ill-policies.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/ill-policies/{id}",
+      "permissionsRequired" : [ "inventory-storage.ill-policies.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/ill-policies",
+      "permissionsRequired" : [ "inventory-storage.ill-policies.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/ill-policies/{id}",
+      "permissionsRequired" : [ "inventory-storage.ill-policies.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/ill-policies/{id}",
+      "permissionsRequired" : [ "inventory-storage.ill-policies.item.delete" ]
+    } ]
+  }, {
+    "id" : "holdings-types",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/holdings-types",
+      "permissionsRequired" : [ "inventory-storage.holdings-types.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/holdings-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.holdings-types.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/holdings-types",
+      "permissionsRequired" : [ "inventory-storage.holdings-types.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/holdings-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.holdings-types.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/holdings-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.holdings-types.item.delete" ]
+    } ]
+  }, {
+    "id" : "call-number-types",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/call-number-types",
+      "permissionsRequired" : [ "inventory-storage.call-number-types.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/call-number-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.call-number-types.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/call-number-types",
+      "permissionsRequired" : [ "inventory-storage.call-number-types.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/call-number-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.call-number-types.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/call-number-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.call-number-types.item.delete" ]
+    } ]
+  }, {
+    "id" : "instance-note-types",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/instance-note-types",
+      "permissionsRequired" : [ "inventory-storage.instance-note-types.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/instance-note-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.instance-note-types.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/instance-note-types",
+      "permissionsRequired" : [ "inventory-storage.instance-note-types.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/instance-note-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.instance-note-types.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/instance-note-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.instance-note-types.item.delete" ]
+    } ]
+  }, {
+    "id" : "holdings-note-types",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/holdings-note-types",
+      "permissionsRequired" : [ "inventory-storage.holdings-note-types.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/holdings-note-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.holdings-note-types.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/holdings-note-types",
+      "permissionsRequired" : [ "inventory-storage.holdings-note-types.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/holdings-note-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.holdings-note-types.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/holdings-note-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.holdings-note-types.item.delete" ]
+    } ]
+  }, {
+    "id" : "item-note-types",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/item-note-types",
+      "permissionsRequired" : [ "inventory-storage.item-note-types.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/item-note-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.item-note-types.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/item-note-types",
+      "permissionsRequired" : [ "inventory-storage.item-note-types.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/item-note-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.item-note-types.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/item-note-types/{id}",
+      "permissionsRequired" : [ "inventory-storage.item-note-types.item.delete" ]
+    } ]
+  }, {
+    "id" : "item-damaged-statuses",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/item-damaged-statuses",
+      "permissionsRequired" : [ "inventory-storage.item-damaged-statuses.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/item-damaged-statuses/{id}",
+      "permissionsRequired" : [ "inventory-storage.item-damaged-statuses.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/item-damaged-statuses",
+      "permissionsRequired" : [ "inventory-storage.item-damaged-statuses.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/item-damaged-statuses/{id}",
+      "permissionsRequired" : [ "inventory-storage.item-damaged-statuses.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/item-damaged-statuses/{id}",
+      "permissionsRequired" : [ "inventory-storage.item-damaged-statuses.item.delete" ]
+    } ]
+  }, {
+    "id" : "service-points",
+    "version" : "3.2",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/service-points",
+      "permissionsRequired" : [ "inventory-storage.service-points.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/service-points/{id}",
+      "permissionsRequired" : [ "inventory-storage.service-points.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/service-points",
+      "permissionsRequired" : [ "inventory-storage.service-points.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/service-points/{id}",
+      "permissionsRequired" : [ "inventory-storage.service-points.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/service-points/{id}",
+      "permissionsRequired" : [ "inventory-storage.service-points.item.delete" ]
+    } ]
+  }, {
+    "id" : "service-points-users",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/service-points-users",
+      "permissionsRequired" : [ "inventory-storage.service-points-users.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/service-points-users/{id}",
+      "permissionsRequired" : [ "inventory-storage.service-points-users.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/service-points-users",
+      "permissionsRequired" : [ "inventory-storage.service-points-users.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/service-points-users/{id}",
+      "permissionsRequired" : [ "inventory-storage.service-points-users.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/service-points-users/{id}",
+      "permissionsRequired" : [ "inventory-storage.service-points-users.item.delete" ]
+    } ]
+  }, {
+    "id" : "hrid-settings-storage",
+    "version" : "1.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/hrid-settings-storage/hrid-settings",
+      "permissionsRequired" : [ "inventory-storage.hrid-settings.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/hrid-settings-storage/hrid-settings",
+      "permissionsRequired" : [ "inventory-storage.hrid-settings.item.put" ]
+    } ]
+  }, {
+    "id" : "_tenant",
+    "version" : "1.2",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/_/tenant"
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/_/tenant"
+    } ]
+  }, {
+    "id" : "_jsonSchemas",
+    "version" : "1.0",
+    "interfaceType" : "multiple",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/_/jsonSchemas",
+      "permissionsRequired" : [ ]
+    } ]
+  }, {
+    "id" : "oaipmhview",
+    "version" : "1.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/oai-pmh-view/instances",
+      "permissionsRequired" : [ "inventory-storage.oai-pmh-view.instances.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/oai-pmh-view/updatedInstanceIds",
+      "permissionsRequired" : [ "inventory-storage.oai-pmh-view.updatedinstanceids.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/oai-pmh-view/enrichedInstances",
+      "permissionsRequired" : [ "inventory-storage.oai-pmh-view.enrichedinstances.collection.post" ]
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "inventory-storage.items.collection.get",
+    "displayName" : "inventory storage - get item collection",
+    "description" : "get item collection from storage"
+  }, {
+    "permissionName" : "inventory-storage.items.collection.delete",
+    "displayName" : "inventory storage - delete entire item collection",
+    "description" : "delete entire item collection from storage"
+  }, {
+    "permissionName" : "inventory-storage.items.item.get",
+    "displayName" : "inventory storage - get individual item",
+    "description" : "get individual item from storage"
+  }, {
+    "permissionName" : "inventory-storage.items.item.post",
+    "displayName" : "inventory storage - create individual item",
+    "description" : "create individual item in storage"
+  }, {
+    "permissionName" : "inventory-storage.items.item.put",
+    "displayName" : "inventory storage - modify item",
+    "description" : "modify item in storage"
+  }, {
+    "permissionName" : "inventory-storage.items.item.delete",
+    "displayName" : "inventory storage - delete individual item",
+    "description" : "delete individual item from storage"
+  }, {
+    "permissionName" : "inventory-storage.items.batch.post",
+    "displayName" : "inventory storage - create a number of items",
+    "description" : "create a number of items in storage"
+  }, {
+    "permissionName" : "inventory-storage.holdings.collection.get",
+    "displayName" : "inventory storage - get holdings collection",
+    "description" : "get holdings collection from storage"
+  }, {
+    "permissionName" : "inventory-storage.holdings.collection.delete",
+    "displayName" : "inventory storage - delete entire holdings collection",
+    "description" : "delete entire holdings collection from storage"
+  }, {
+    "permissionName" : "inventory-storage.holdings.item.get",
+    "displayName" : "inventory storage - get individual holdings record",
+    "description" : "get individual holdings record from storage"
+  }, {
+    "permissionName" : "inventory-storage.holdings.item.post",
+    "displayName" : "inventory storage - create individual holdings record",
+    "description" : "create individual holdings record in storage"
+  }, {
+    "permissionName" : "inventory-storage.holdings.item.put",
+    "displayName" : "inventory storage - modify holdings record",
+    "description" : "modify holdings record in storage"
+  }, {
+    "permissionName" : "inventory-storage.holdings.item.delete",
+    "displayName" : "inventory storage - delete individual holdings record",
+    "description" : "delete individual holdings record from storage"
+  }, {
+    "permissionName" : "inventory-storage.holdings.batch.post",
+    "displayName" : "inventory storage - create a number of holdings",
+    "description" : "create a number of holdings in storage"
+  }, {
+    "permissionName" : "inventory-storage.instances.collection.get",
+    "displayName" : "inventory storage - get instance collection",
+    "description" : "get instance collection from storage"
+  }, {
+    "permissionName" : "inventory-storage.instances.collection.delete",
+    "displayName" : "inventory storage - delete entire instance collection",
+    "description" : "delete entire instance collection from storage"
+  }, {
+    "permissionName" : "inventory-storage.instances.item.get",
+    "displayName" : "inventory storage - get individual instance",
+    "description" : "get individual instance from storage"
+  }, {
+    "permissionName" : "inventory-storage.instances.item.post",
+    "displayName" : "inventory storage - create individual instance",
+    "description" : "create individual instance in storage"
+  }, {
+    "permissionName" : "inventory-storage.instances.item.put",
+    "displayName" : "inventory storage - modify instance",
+    "description" : "modify instance in storage"
+  }, {
+    "permissionName" : "inventory-storage.instances.item.delete",
+    "displayName" : "inventory storage - delete individual instance",
+    "description" : "delete individual instance from storage"
+  }, {
+    "permissionName" : "inventory-storage.instances.batch.post",
+    "displayName" : "inventory storage - create a number of instances",
+    "description" : "create a number of instances in storage"
+  }, {
+    "permissionName" : "inventory-storage.instances.source-record.delete",
+    "displayName" : "inventory storage - delete source record of an individual instance",
+    "description" : "delete source record of individual instance from storage"
+  }, {
+    "permissionName" : "inventory-storage.instances.source-record.marc-json.get",
+    "displayName" : "inventory storage - get MARC JSON source record of an individual instance",
+    "description" : "get MARC JSON source record of individual instance from storage"
+  }, {
+    "permissionName" : "inventory-storage.instances.source-record.marc-json.put",
+    "displayName" : "inventory storage - set MARC JSON source record of an individual instance",
+    "description" : "set MARC JSON source record of individual instance in storage"
+  }, {
+    "permissionName" : "inventory-storage.instances.source-record.marc-json.delete",
+    "displayName" : "inventory storage - delete MARC JSON source record of an individual instance",
+    "description" : "delete MARC JSON source record of individual instance in storage"
+  }, {
+    "permissionName" : "inventory-storage.loan-types.collection.get",
+    "displayName" : "inventory storage - get loan-type collection",
+    "description" : "get loan-type collection from storage"
+  }, {
+    "permissionName" : "inventory-storage.loan-types.item.get",
+    "displayName" : "inventory storage - get individual loan-type",
+    "description" : "get individual loan-type from storage"
+  }, {
+    "permissionName" : "inventory-storage.loan-types.item.post",
+    "displayName" : "inventory storage - create individual loan-type",
+    "description" : "create individual loan-type in storage"
+  }, {
+    "permissionName" : "inventory-storage.loan-types.item.put",
+    "displayName" : "inventory storage - modify loan-type",
+    "description" : "modify loan-type in storage"
+  }, {
+    "permissionName" : "inventory-storage.loan-types.item.delete",
+    "displayName" : "inventory storage - delete individual loan-type",
+    "description" : "delete individual loan-type from storage"
+  }, {
+    "permissionName" : "inventory-storage.material-types.collection.get",
+    "displayName" : "inventory storage - get material-type collection",
+    "description" : "get material-type collection from storage"
+  }, {
+    "permissionName" : "inventory-storage.material-types.item.get",
+    "displayName" : "inventory storage - get individual material-type",
+    "description" : "get individual material-type from storage"
+  }, {
+    "permissionName" : "inventory-storage.material-types.item.post",
+    "displayName" : "inventory storage - create individual material-type",
+    "description" : "create individual material-type in storage"
+  }, {
+    "permissionName" : "inventory-storage.material-types.item.put",
+    "displayName" : "inventory storage - modify material-type",
+    "description" : "modify material-type in storage"
+  }, {
+    "permissionName" : "inventory-storage.material-types.item.delete",
+    "displayName" : "inventory storage - delete individual material-type",
+    "description" : "delete individual material-type from storage"
+  }, {
+    "permissionName" : "inventory-storage.shelf-locations.collection.get",
+    "displayName" : "inventory storage - get shelf location collection",
+    "description" : "get shelf location collection from storage"
+  }, {
+    "permissionName" : "inventory-storage.shelf-locations.item.get",
+    "displayName" : "inventory storage - get individual shelf location",
+    "description" : "get individual shelf location from storage"
+  }, {
+    "permissionName" : "inventory-storage.shelf-locations.item.post",
+    "displayName" : "inventory storage - create individual shelf location",
+    "description" : "create individual shelf location in storage"
+  }, {
+    "permissionName" : "inventory-storage.shelf-locations.item.put",
+    "displayName" : "inventory storage - modify shelf location",
+    "description" : "modify shelf location in storage"
+  }, {
+    "permissionName" : "inventory-storage.shelf-locations.item.delete",
+    "displayName" : "inventory storage - delete individual shelf location",
+    "description" : "delete individual shelf location from storage"
+  }, {
+    "permissionName" : "inventory-storage.location-units.institutions.collection.get",
+    "displayName" : "inventory storage - location units - get institution collection",
+    "description" : "Get institution collection"
+  }, {
+    "permissionName" : "inventory-storage.location-units.institutions.item.get",
+    "displayName" : "inventory storage - location units - get individual institution",
+    "description" : "get individual institution"
+  }, {
+    "permissionName" : "inventory-storage.location-units.institutions.item.post",
+    "displayName" : "inventory storage - location units - create individual institution",
+    "description" : "create individual instution"
+  }, {
+    "permissionName" : "inventory-storage.location-units.institutions.item.put",
+    "displayName" : "inventory storage - location units - modify institution",
+    "description" : "modify institution"
+  }, {
+    "permissionName" : "inventory-storage.location-units.institutions.item.delete",
+    "displayName" : "inventory storage - location units - delete individual institution",
+    "description" : "delete individual institution"
+  }, {
+    "permissionName" : "inventory-storage.location-units.campuses.collection.get",
+    "displayName" : "inventory storage - location units - get campus collection",
+    "description" : "Get campus collection"
+  }, {
+    "permissionName" : "inventory-storage.location-units.campuses.item.get",
+    "displayName" : "inventory storage - location units - get individual campus",
+    "description" : "get individual campus"
+  }, {
+    "permissionName" : "inventory-storage.location-units.campuses.item.post",
+    "displayName" : "inventory storage - location units - create individual campus",
+    "description" : "create individual instution"
+  }, {
+    "permissionName" : "inventory-storage.location-units.campuses.item.put",
+    "displayName" : "inventory storage - location units - modify campus",
+    "description" : "modify campus"
+  }, {
+    "permissionName" : "inventory-storage.location-units.campuses.item.delete",
+    "displayName" : "inventory storage - location units - delete individual campus",
+    "description" : "delete individual campus"
+  }, {
+    "permissionName" : "inventory-storage.location-units.libraries.collection.get",
+    "displayName" : "inventory storage - location units - get library collection",
+    "description" : "Get library collection"
+  }, {
+    "permissionName" : "inventory-storage.location-units.libraries.item.get",
+    "displayName" : "inventory storage - location units - get individual library",
+    "description" : "get individual library"
+  }, {
+    "permissionName" : "inventory-storage.location-units.libraries.item.post",
+    "displayName" : "inventory storage - location units - create individual library",
+    "description" : "create individual instution"
+  }, {
+    "permissionName" : "inventory-storage.location-units.libraries.item.put",
+    "displayName" : "inventory storage - location units - modify library",
+    "description" : "modify library"
+  }, {
+    "permissionName" : "inventory-storage.location-units.libraries.item.delete",
+    "displayName" : "inventory storage - location units - delete individual library",
+    "description" : "delete individual library"
+  }, {
+    "permissionName" : "inventory-storage.locations.collection.get",
+    "displayName" : "inventory storage - locations - get location collection",
+    "description" : "get location collection"
+  }, {
+    "permissionName" : "inventory-storage.locations.item.get",
+    "displayName" : "inventory storage - locations - get individual location",
+    "description" : "get individual location"
+  }, {
+    "permissionName" : "inventory-storage.locations.item.post",
+    "displayName" : "inventory storage - locations - create individual location",
+    "description" : "create individual location"
+  }, {
+    "permissionName" : "inventory-storage.locations.item.put",
+    "displayName" : "inventory storage - locations - modify location",
+    "description" : "modify location"
+  }, {
+    "permissionName" : "inventory-storage.locations.item.delete",
+    "displayName" : "inventory storage - locations - delete individual location",
+    "description" : "delete individual location"
+  }, {
+    "permissionName" : "inventory-storage.instance-relationship-types.collection.get",
+    "displayName" : "inventory storage - get instance-relationship-type collection",
+    "description" : "get instance-relationship-type collection from storage"
+  }, {
+    "permissionName" : "inventory-storage.instance-relationship-types.item.get",
+    "displayName" : "inventory storage - get individual instance-relationship-type",
+    "description" : "get individual instance-relationship-type from storage"
+  }, {
+    "permissionName" : "inventory-storage.instance-relationship-types.item.post",
+    "displayName" : "inventory storage - create individual instance-relationship-type",
+    "description" : "create individual instance-relationship-type in storage"
+  }, {
+    "permissionName" : "inventory-storage.instance-relationship-types.item.put",
+    "displayName" : "inventory storage - modify instance-relationship-type",
+    "description" : "modify instance-relationship-type in storage"
+  }, {
+    "permissionName" : "inventory-storage.instance-relationship-types.item.delete",
+    "displayName" : "inventory storage - delete individual instance-relationship-type",
+    "description" : "delete individual instance-relationship-type from storage"
+  }, {
+    "permissionName" : "inventory-storage.preceding-succeeding-titles.collection.get",
+    "displayName" : "inventory storage - get preceding-succeeding-title collection",
+    "description" : "get preceding-succeeding-title collection from storage"
+  }, {
+    "permissionName" : "inventory-storage.preceding-succeeding-titles.item.get",
+    "displayName" : "inventory storage - get individual preceding-succeeding-title",
+    "description" : "get individual preceding-succeeding-title from storage"
+  }, {
+    "permissionName" : "inventory-storage.preceding-succeeding-titles.item.post",
+    "displayName" : "inventory storage - create individual preceding-succeeding-title",
+    "description" : "create individual preceding-succeeding-title in storage"
+  }, {
+    "permissionName" : "inventory-storage.preceding-succeeding-titles.item.put",
+    "displayName" : "inventory storage - modify preceding-succeeding-title",
+    "description" : "modify preceding-succeeding-title in storage"
+  }, {
+    "permissionName" : "inventory-storage.preceding-succeeding-titles.item.delete",
+    "displayName" : "inventory storage - delete individual preceding-succeeding-title",
+    "description" : "delete individual preceding-succeeding-title from storage"
+  }, {
+    "permissionName" : "inventory-storage.identifier-types.collection.get",
+    "displayName" : "inventory storage - get identifier-type collection",
+    "description" : "get identifier-type collection from storage"
+  }, {
+    "permissionName" : "inventory-storage.identifier-types.item.get",
+    "displayName" : "inventory storage - get individual identifier-type",
+    "description" : "get individual identifier-type from storage"
+  }, {
+    "permissionName" : "inventory-storage.identifier-types.item.post",
+    "displayName" : "inventory storage - create individual identifier-type",
+    "description" : "create individual identifier-type in storage"
+  }, {
+    "permissionName" : "inventory-storage.identifier-types.item.put",
+    "displayName" : "inventory storage - modify identifier-type",
+    "description" : "modify identifier-type in storage"
+  }, {
+    "permissionName" : "inventory-storage.identifier-types.item.delete",
+    "displayName" : "inventory storage - delete individual identifier-type",
+    "description" : "delete individual identifier-type from storage"
+  }, {
+    "permissionName" : "inventory-storage.contributor-types.collection.get",
+    "displayName" : "inventory storage - get contributor-type collection",
+    "description" : "get contributor-type collection from storage"
+  }, {
+    "permissionName" : "inventory-storage.contributor-types.item.get",
+    "displayName" : "inventory storage - get individual contributor-type",
+    "description" : "get individual contributor-type from storage"
+  }, {
+    "permissionName" : "inventory-storage.contributor-types.item.post",
+    "displayName" : "inventory storage - create individual contributor-type",
+    "description" : "create individual contributor-type in storage"
+  }, {
+    "permissionName" : "inventory-storage.contributor-types.item.put",
+    "displayName" : "inventory storage - modify contributor-type",
+    "description" : "modify contributor-type in storage"
+  }, {
+    "permissionName" : "inventory-storage.contributor-types.item.delete",
+    "displayName" : "inventory storage - delete individual contributor-type",
+    "description" : "delete individual contributor-type from storage"
+  }, {
+    "permissionName" : "inventory-storage.service-points.collection.get",
+    "displayName" : "inventory storage - get service-point collection",
+    "description" : "get service-point collection from storage"
+  }, {
+    "permissionName" : "inventory-storage.service-points.item.get",
+    "displayName" : "inventory storage - get individual service-point",
+    "description" : "get individual service-point from storage"
+  }, {
+    "permissionName" : "inventory-storage.service-points.item.post",
+    "displayName" : "inventory storage - create individual service-point",
+    "description" : "create individual service-point in storage"
+  }, {
+    "permissionName" : "inventory-storage.service-points.item.put",
+    "displayName" : "inventory storage - modify service-point",
+    "description" : "modify service-point in storage"
+  }, {
+    "permissionName" : "inventory-storage.service-points.item.delete",
+    "displayName" : "inventory storage - delete individual service-point",
+    "description" : "delete individual service-point from storage"
+  }, {
+    "permissionName" : "inventory-storage.service-points-users.collection.get",
+    "displayName" : "inventory storage - get service-point-users collection",
+    "description" : "get service-point-users collection from storage"
+  }, {
+    "permissionName" : "inventory-storage.service-points-users.item.get",
+    "displayName" : "inventory storage - get individual service-points-user",
+    "description" : "get individual service-points-user from storage"
+  }, {
+    "permissionName" : "inventory-storage.service-points-users.item.post",
+    "displayName" : "inventory storage - create individual service-points-user",
+    "description" : "create individual service-points-user in storage"
+  }, {
+    "permissionName" : "inventory-storage.service-points-users.item.put",
+    "displayName" : "inventory storage - modify service-points-user",
+    "description" : "modify service-points-user in storage"
+  }, {
+    "permissionName" : "inventory-storage.service-points-users.item.delete",
+    "displayName" : "inventory storage - delete individual service-points-user",
+    "description" : "delete individual service-points-user from storage"
+  }, {
+    "permissionName" : "inventory-storage.contributor-name-types.collection.get",
+    "displayName" : "inventory storage - get contributor-name-type collection",
+    "description" : "get contributor-name-type collection from storage"
+  }, {
+    "permissionName" : "inventory-storage.contributor-name-types.item.get",
+    "displayName" : "inventory storage - get individual contributor-name-type",
+    "description" : "get individual contributor-name-type from storage"
+  }, {
+    "permissionName" : "inventory-storage.contributor-name-types.item.post",
+    "displayName" : "inventory storage - create individual contributor-name-type",
+    "description" : "create individual contributor-name-type in storage"
+  }, {
+    "permissionName" : "inventory-storage.contributor-name-types.item.put",
+    "displayName" : "inventory storage - modify contributor-name-type",
+    "description" : "modify contributor-name-type in storage"
+  }, {
+    "permissionName" : "inventory-storage.contributor-name-types.item.delete",
+    "displayName" : "inventory storage - delete individual contributor-name-type",
+    "description" : "delete individual contributor-name-type from storage"
+  }, {
+    "permissionName" : "inventory-storage.instance-bulk.ids.get",
+    "displayName" : "inventory storage - get bulk ids",
+    "description" : "get a bulk set of instance ids from storage"
+  }, {
+    "permissionName" : "inventory-storage.instance-formats.collection.get",
+    "displayName" : "inventory storage - get formats collection",
+    "description" : "get contributor-name-type collection from storage"
+  }, {
+    "permissionName" : "inventory-storage.instance-formats.item.get",
+    "displayName" : "inventory storage - get individual format",
+    "description" : "get individual instance format from storage"
+  }, {
+    "permissionName" : "inventory-storage.instance-formats.item.post",
+    "displayName" : "inventory storage - create individual format",
+    "description" : "create individual instance format in storage"
+  }, {
+    "permissionName" : "inventory-storage.instance-formats.item.put",
+    "displayName" : "inventory storage - modify format",
+    "description" : "modify instance format in storage"
+  }, {
+    "permissionName" : "inventory-storage.instance-formats.item.delete",
+    "displayName" : "inventory storage - delete individual format",
+    "description" : "delete individual instance format from storage"
+  }, {
+    "permissionName" : "inventory-storage.instance-types.collection.get",
+    "displayName" : "inventory storage - get instance types collection",
+    "description" : "get instance-type collection from storage"
+  }, {
+    "permissionName" : "inventory-storage.instance-types.item.get",
+    "displayName" : "inventory storage - get individual instance type",
+    "description" : "get individual instance type from storage"
+  }, {
+    "permissionName" : "inventory-storage.instance-types.item.post",
+    "displayName" : "inventory storage - create individual instance type",
+    "description" : "create individual instance type in storage"
+  }, {
+    "permissionName" : "inventory-storage.instance-types.item.put",
+    "displayName" : "inventory storage - modify instance type",
+    "description" : "modify instance type in storage"
+  }, {
+    "permissionName" : "inventory-storage.instance-types.item.delete",
+    "displayName" : "inventory storage - delete individual instance type",
+    "description" : "delete instance type in storage"
+  }, {
+    "permissionName" : "inventory-storage.nature-of-content-terms.collection.get",
+    "displayName" : "inventory storage - get content terms collection",
+    "description" : "get nature-of-content terms collection from storage"
+  }, {
+    "permissionName" : "inventory-storage.nature-of-content-terms.item.get",
+    "displayName" : "inventory storage - get individual content term",
+    "description" : "get individual nature-of-content term from storage"
+  }, {
+    "permissionName" : "inventory-storage.nature-of-content-terms.item.post",
+    "displayName" : "inventory storage - create individual content term",
+    "description" : "create individual nature-of-content term in storage"
+  }, {
+    "permissionName" : "inventory-storage.nature-of-content-terms.item.put",
+    "displayName" : "inventory storage - modify content term",
+    "description" : "modify nature-of-content term in storage"
+  }, {
+    "permissionName" : "inventory-storage.nature-of-content-terms.item.delete",
+    "displayName" : "inventory storage - delete individual content term",
+    "description" : "delete nature-of-content term in storage"
+  }, {
+    "permissionName" : "inventory-storage.classification-types.collection.get",
+    "displayName" : "inventory storage - get classification types collection",
+    "description" : "get classification types collection from storage"
+  }, {
+    "permissionName" : "inventory-storage.classification-types.item.get",
+    "displayName" : "inventory storage - get individual classification type",
+    "description" : "get individual classification type from storage"
+  }, {
+    "permissionName" : "inventory-storage.classification-types.item.post",
+    "displayName" : "inventory storage - create individual classification type",
+    "description" : "create individual classification type in storage"
+  }, {
+    "permissionName" : "inventory-storage.classification-types.item.put",
+    "displayName" : "inventory storage - modify classification type",
+    "description" : "modify classification type in storage"
+  }, {
+    "permissionName" : "inventory-storage.classification-types.item.delete",
+    "displayName" : "inventory storage - delete individual classification type",
+    "description" : "delete individual classification qualifier from storage"
+  }, {
+    "permissionName" : "inventory-storage.alternative-title-types.collection.get",
+    "displayName" : "inventory storage - get alternative-title-type collection",
+    "description" : "get alternative-title-type collection from storage"
+  }, {
+    "permissionName" : "inventory-storage.alternative-title-types.item.get",
+    "displayName" : "inventory storage - get individual alternative-title-type",
+    "description" : "get individual alternative-title-type from storage"
+  }, {
+    "permissionName" : "inventory-storage.alternative-title-types.item.post",
+    "displayName" : "inventory storage - create individual alternative-title-type",
+    "description" : "create individual alternative-title-type in storage"
+  }, {
+    "permissionName" : "inventory-storage.alternative-title-types.item.put",
+    "displayName" : "inventory storage - modify alternative-title-type",
+    "description" : "modify alternative-title-type in storage"
+  }, {
+    "permissionName" : "inventory-storage.alternative-title-types.item.delete",
+    "displayName" : "inventory storage - delete individual alternative-title-type",
+    "description" : "delete individual alternative-title-type from storage"
+  }, {
+    "permissionName" : "inventory-storage.modes-of-issuance.collection.get",
+    "displayName" : "inventory storage - get modes of issuance collection",
+    "description" : "get modes of issuance collection from storage"
+  }, {
+    "permissionName" : "inventory-storage.modes-of-issuance.item.get",
+    "displayName" : "inventory storage - get individual mode of issuance",
+    "description" : "get individual mode of issuance from storage"
+  }, {
+    "permissionName" : "inventory-storage.modes-of-issuance.item.post",
+    "displayName" : "inventory storage - create individual mode of issuance",
+    "description" : "create individual mode of issuance in storage"
+  }, {
+    "permissionName" : "inventory-storage.modes-of-issuance.item.put",
+    "displayName" : "inventory storage - modify mode of issuance",
+    "description" : "modify mode of issuance in storage"
+  }, {
+    "permissionName" : "inventory-storage.modes-of-issuance.item.delete",
+    "displayName" : "inventory storage - delete individual mode of issuance",
+    "description" : "delete individual mode of issuance from storage"
+  }, {
+    "permissionName" : "inventory-storage.instance-statuses.collection.get",
+    "displayName" : "inventory storage - get instance status collection",
+    "description" : "get instance status collection from storage"
+  }, {
+    "permissionName" : "inventory-storage.instance-statuses.item.get",
+    "displayName" : "inventory storage - get individual instance status",
+    "description" : "get individual instance status from storage"
+  }, {
+    "permissionName" : "inventory-storage.instance-statuses.item.post",
+    "displayName" : "inventory storage - create individual instance status",
+    "description" : "create individual instance status in storage"
+  }, {
+    "permissionName" : "inventory-storage.instance-statuses.item.put",
+    "displayName" : "inventory storage - modify instance status",
+    "description" : "modify instance status in storage"
+  }, {
+    "permissionName" : "inventory-storage.instance-statuses.item.delete",
+    "displayName" : "inventory storage - delete individual instance status",
+    "description" : "delete individual instance status from storage"
+  }, {
+    "permissionName" : "inventory-storage.electronic-access-relationships.collection.get",
+    "displayName" : "inventory storage - get URL relationship types collection",
+    "description" : "get statistical codes collection from storage"
+  }, {
+    "permissionName" : "inventory-storage.electronic-access-relationships.item.get",
+    "displayName" : "inventory storage - get individual URL relationship type",
+    "description" : "get individual statistical code from storage"
+  }, {
+    "permissionName" : "inventory-storage.electronic-access-relationships.item.post",
+    "displayName" : "inventory storage - create individual URL relationship type",
+    "description" : "create individual statistical code in storage"
+  }, {
+    "permissionName" : "inventory-storage.electronic-access-relationships.item.put",
+    "displayName" : "inventory storage - modify URL relationship type",
+    "description" : "modify statistical code in storage"
+  }, {
+    "permissionName" : "inventory-storage.electronic-access-relationships.item.delete",
+    "displayName" : "inventory storage - delete individual URL relationship",
+    "description" : "delete individual URL relationship type from storage"
+  }, {
+    "permissionName" : "inventory-storage.statistical-code-types.collection.get",
+    "displayName" : "inventory storage - get statistical code types collection",
+    "description" : "get statistical code types collection from storage"
+  }, {
+    "permissionName" : "inventory-storage.statistical-code-types.item.get",
+    "displayName" : "inventory storage - get individual statistical code type",
+    "description" : "get individual statistical code type from storage"
+  }, {
+    "permissionName" : "inventory-storage.statistical-code-types.item.post",
+    "displayName" : "inventory storage - create individual statistical code type",
+    "description" : "create individual statistical code type in storage"
+  }, {
+    "permissionName" : "inventory-storage.statistical-code-types.item.put",
+    "displayName" : "inventory storage - modify statistical code type",
+    "description" : "modify statistical code type in storage"
+  }, {
+    "permissionName" : "inventory-storage.statistical-code-types.item.delete",
+    "displayName" : "inventory storage - delete individual statistical code type",
+    "description" : "delete individual statistical code type from storage"
+  }, {
+    "permissionName" : "inventory-storage.statistical-codes.collection.get",
+    "displayName" : "inventory storage - get statistical codes collection",
+    "description" : "get statistical codes collection from storage"
+  }, {
+    "permissionName" : "inventory-storage.statistical-codes.item.get",
+    "displayName" : "inventory storage - get individual statistical code",
+    "description" : "get individual statistical code from storage"
+  }, {
+    "permissionName" : "inventory-storage.statistical-codes.item.post",
+    "displayName" : "inventory storage - create individual statistical code",
+    "description" : "create individual statistical code in storage"
+  }, {
+    "permissionName" : "inventory-storage.statistical-codes.item.put",
+    "displayName" : "inventory storage - modify statistical code",
+    "description" : "modify statistical code in storage"
+  }, {
+    "permissionName" : "inventory-storage.statistical-codes.item.delete",
+    "displayName" : "inventory storage - delete individual statistical code",
+    "description" : "delete individual statistical code from storage"
+  }, {
+    "permissionName" : "inventory-storage.ill-policies.collection.get",
+    "displayName" : "inventory storage - get ill-policy collection",
+    "description" : "get ill-policy collection from storage"
+  }, {
+    "permissionName" : "inventory-storage.ill-policies.item.get",
+    "displayName" : "inventory storage - get individual ill-policy",
+    "description" : "get individual ill-policy from storage"
+  }, {
+    "permissionName" : "inventory-storage.ill-policies.item.post",
+    "displayName" : "inventory storage - create individual ill-policy",
+    "description" : "create individual ill-policy in storage"
+  }, {
+    "permissionName" : "inventory-storage.ill-policies.item.put",
+    "displayName" : "inventory storage - modify ill-policy",
+    "description" : "modify ill-policy in storage"
+  }, {
+    "permissionName" : "inventory-storage.ill-policies.item.delete",
+    "displayName" : "inventory storage - delete individual ill-policy",
+    "description" : "delete individual ill-policy from storage"
+  }, {
+    "permissionName" : "inventory-storage.holdings-types.collection.get",
+    "displayName" : "inventory storage - get holdings-type collection",
+    "description" : "get holdings-type collection from storage"
+  }, {
+    "permissionName" : "inventory-storage.holdings-types.item.get",
+    "displayName" : "inventory storage - get individual holdings-type",
+    "description" : "get individual holdings-type from storage"
+  }, {
+    "permissionName" : "inventory-storage.holdings-types.item.post",
+    "displayName" : "inventory storage - create individual holdings-type",
+    "description" : "create individual holdings-type in storage"
+  }, {
+    "permissionName" : "inventory-storage.holdings-types.item.put",
+    "displayName" : "inventory storage - modify holdings-type",
+    "description" : "modify holdings-type in storage"
+  }, {
+    "permissionName" : "inventory-storage.holdings-types.item.delete",
+    "displayName" : "inventory storage - delete individual holdings-type",
+    "description" : "delete individual holdings-type from storage"
+  }, {
+    "permissionName" : "inventory-storage.instance-note-types.collection.get",
+    "displayName" : "inventory storage - get instance-note-type collection",
+    "description" : "get instance-note-type collection from storage"
+  }, {
+    "permissionName" : "inventory-storage.instance-note-types.item.get",
+    "displayName" : "inventory storage - get individual instance-note-type",
+    "description" : "get individual instance-note-type from storage"
+  }, {
+    "permissionName" : "inventory-storage.instance-note-types.item.post",
+    "displayName" : "inventory storage - create individual instance-note-type",
+    "description" : "create individual instance-note-type in storage"
+  }, {
+    "permissionName" : "inventory-storage.instance-note-types.item.put",
+    "displayName" : "inventory storage - modify instance-note-type",
+    "description" : "modify instance-note-type in storage"
+  }, {
+    "permissionName" : "inventory-storage.instance-note-types.item.delete",
+    "displayName" : "inventory storage - delete individual instance-note-type",
+    "description" : "delete individual instance-note-type from storage"
+  }, {
+    "permissionName" : "inventory-storage.holdings-note-types.collection.get",
+    "displayName" : "inventory storage - get holdings-note-type collection",
+    "description" : "get holdings-note-type collection from storage"
+  }, {
+    "permissionName" : "inventory-storage.holdings-note-types.item.get",
+    "displayName" : "inventory storage - get individual holdings-note-type",
+    "description" : "get individual holdings-note-type from storage"
+  }, {
+    "permissionName" : "inventory-storage.holdings-note-types.item.post",
+    "displayName" : "inventory storage - create individual holdings-note-type",
+    "description" : "create individual holdings-note-type in storage"
+  }, {
+    "permissionName" : "inventory-storage.holdings-note-types.item.put",
+    "displayName" : "inventory storage - modify holdings-note-type",
+    "description" : "modify holdings-note-type in storage"
+  }, {
+    "permissionName" : "inventory-storage.holdings-note-types.item.delete",
+    "displayName" : "inventory storage - delete individual holdings-note-type",
+    "description" : "delete individual holdings-note-type from storage"
+  }, {
+    "permissionName" : "inventory-storage.item-note-types.collection.get",
+    "displayName" : "inventory storage - get item-note-type collection",
+    "description" : "get item-note-type collection from storage"
+  }, {
+    "permissionName" : "inventory-storage.item-note-types.item.get",
+    "displayName" : "inventory storage - get individual item-note-type",
+    "description" : "get individual item-note-type from storage"
+  }, {
+    "permissionName" : "inventory-storage.item-note-types.item.post",
+    "displayName" : "inventory storage - create individual item-note-type",
+    "description" : "create individual item-note-type in storage"
+  }, {
+    "permissionName" : "inventory-storage.item-note-types.item.put",
+    "displayName" : "inventory storage - modify item-note-type",
+    "description" : "modify item-note-type in storage"
+  }, {
+    "permissionName" : "inventory-storage.item-note-types.item.delete",
+    "displayName" : "inventory storage - delete individual item-note-type",
+    "description" : "delete individual item-note-type from storage"
+  }, {
+    "permissionName" : "inventory-storage.item-damaged-statuses.collection.get",
+    "displayName" : "inventory storage - get item-damaged-statuses collection",
+    "description" : "get item-damaged-statuses collection from storage"
+  }, {
+    "permissionName" : "inventory-storage.item-damaged-statuses.item.get",
+    "displayName" : "inventory storage - get individual item-damaged-status",
+    "description" : "get individual item-damaged-status from storage"
+  }, {
+    "permissionName" : "inventory-storage.item-damaged-statuses.item.post",
+    "displayName" : "inventory storage - create individual item-damaged-status",
+    "description" : "create individual item-damaged-status in storage"
+  }, {
+    "permissionName" : "inventory-storage.item-damaged-statuses.item.put",
+    "displayName" : "inventory storage - modify item-damaged-status",
+    "description" : "modify item-damaged-status in storage"
+  }, {
+    "permissionName" : "inventory-storage.item-damaged-statuses.item.delete",
+    "displayName" : "inventory storage - delete individual item-damaged-status",
+    "description" : "delete individual item-damaged-status from storage"
+  }, {
+    "permissionName" : "inventory-storage.call-number-types.collection.get",
+    "displayName" : "inventory storage - get call-number-type collection",
+    "description" : "get call-number-type collection from storage"
+  }, {
+    "permissionName" : "inventory-storage.call-number-types.item.get",
+    "displayName" : "inventory storage - get individual call-number-type",
+    "description" : "get individual call-number-type from storage"
+  }, {
+    "permissionName" : "inventory-storage.call-number-types.item.post",
+    "displayName" : "inventory storage - create individual call-number-type",
+    "description" : "create individual call-number-type in storage"
+  }, {
+    "permissionName" : "inventory-storage.call-number-types.item.put",
+    "displayName" : "inventory storage - modify call-number-type",
+    "description" : "modify call-number-type in storage"
+  }, {
+    "permissionName" : "inventory-storage.call-number-types.item.delete",
+    "displayName" : "inventory storage - delete individual call-number-type",
+    "description" : "delete individual call-number-type from storage"
+  }, {
+    "permissionName" : "inventory-storage.hrid-settings.item.get",
+    "displayName" : "inventory storage - get HRID settings",
+    "description" : "get the HRID settings from storage"
+  }, {
+    "permissionName" : "inventory-storage.hrid-settings.item.put",
+    "displayName" : "inventory storage - modify HRID settings",
+    "description" : "modify the HRID settings in storage"
+  }, {
+    "permissionName" : "inventory-storage.oai-pmh-view.instances.collection.get",
+    "displayName" : "inventory storage - get instances for oai pmh",
+    "description" : "get instances for oai pmh"
+  }, {
+    "permissionName" : "inventory-storage.oai-pmh-view.updatedinstanceids.collection.get",
+    "displayName" : "inventory storage - get updated instances ids for oai pmh",
+    "description" : "get updated instances ids for oai pmh"
+  }, {
+    "permissionName" : "inventory-storage.oai-pmh-view.enrichedinstances.collection.post",
+    "displayName" : "inventory storage - get enriched instances for oai pmh",
+    "description" : "get enriched instances for oai pmh"
+  }, {
+    "permissionName" : "inventory-storage.all",
+    "displayName" : "inventory storage module - all permissions",
+    "description" : "Entire set of permissions needed to use the inventory storage module",
+    "subPermissions" : [ "inventory-storage.items.collection.get", "inventory-storage.items.item.get", "inventory-storage.items.item.post", "inventory-storage.items.item.put", "inventory-storage.items.item.delete", "inventory-storage.items.collection.delete", "inventory-storage.items.batch.post", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.holdings.item.post", "inventory-storage.holdings.item.put", "inventory-storage.holdings.item.delete", "inventory-storage.holdings.collection.delete", "inventory-storage.holdings.batch.post", "inventory-storage.instances.collection.get", "inventory-storage.instances.item.get", "inventory-storage.instances.item.post", "inventory-storage.instances.item.put", "inventory-storage.instances.item.delete", "inventory-storage.instances.source-record.delete", "inventory-storage.instances.source-record.marc-json.get", "inventory-storage.instances.source-record.marc-json.put", "inventory-storage.instances.source-record.marc-json.delete", "inventory-storage.instances.collection.delete", "inventory-storage.instances.batch.post", "inventory-storage.loan-types.collection.get", "inventory-storage.loan-types.item.get", "inventory-storage.loan-types.item.post", "inventory-storage.loan-types.item.put", "inventory-storage.loan-types.item.delete", "inventory-storage.material-types.collection.get", "inventory-storage.material-types.item.get", "inventory-storage.material-types.item.post", "inventory-storage.material-types.item.put", "inventory-storage.material-types.item.delete", "inventory-storage.shelf-locations.collection.get", "inventory-storage.shelf-locations.item.get", "inventory-storage.shelf-locations.item.post", "inventory-storage.shelf-locations.item.put", "inventory-storage.shelf-locations.item.delete", "inventory-storage.location-units.institutions.collection.get", "inventory-storage.location-units.institutions.item.get", "inventory-storage.location-units.institutions.item.post", "inventory-storage.location-units.institutions.item.put", "inventory-storage.location-units.institutions.item.delete", "inventory-storage.location-units.campuses.collection.get", "inventory-storage.location-units.campuses.item.get", "inventory-storage.location-units.campuses.item.post", "inventory-storage.location-units.campuses.item.put", "inventory-storage.location-units.campuses.item.delete", "inventory-storage.location-units.libraries.collection.get", "inventory-storage.location-units.libraries.item.get", "inventory-storage.location-units.libraries.item.post", "inventory-storage.location-units.libraries.item.put", "inventory-storage.location-units.libraries.item.delete", "inventory-storage.locations.collection.get", "inventory-storage.locations.item.get", "inventory-storage.locations.item.post", "inventory-storage.locations.item.put", "inventory-storage.locations.item.delete", "inventory-storage.instance-relationship-types.collection.get", "inventory-storage.instance-relationship-types.item.get", "inventory-storage.instance-relationship-types.item.post", "inventory-storage.instance-relationship-types.item.put", "inventory-storage.instance-relationship-types.item.delete", "inventory-storage.identifier-types.collection.get", "inventory-storage.identifier-types.item.get", "inventory-storage.identifier-types.item.post", "inventory-storage.identifier-types.item.put", "inventory-storage.identifier-types.item.delete", "inventory-storage.contributor-types.collection.get", "inventory-storage.contributor-types.item.get", "inventory-storage.contributor-types.item.post", "inventory-storage.contributor-types.item.put", "inventory-storage.contributor-types.item.delete", "inventory-storage.contributor-name-types.collection.get", "inventory-storage.contributor-name-types.item.get", "inventory-storage.contributor-name-types.item.post", "inventory-storage.contributor-name-types.item.put", "inventory-storage.contributor-name-types.item.delete", "inventory-storage.instance-bulk.ids.get", "inventory-storage.instance-formats.collection.get", "inventory-storage.instance-formats.item.get", "inventory-storage.instance-formats.item.post", "inventory-storage.instance-formats.item.put", "inventory-storage.instance-formats.item.delete", "inventory-storage.instance-types.collection.get", "inventory-storage.instance-types.item.get", "inventory-storage.instance-types.item.post", "inventory-storage.instance-types.item.put", "inventory-storage.instance-types.item.delete", "inventory-storage.nature-of-content-terms.collection.get", "inventory-storage.nature-of-content-terms.item.get", "inventory-storage.nature-of-content-terms.item.post", "inventory-storage.nature-of-content-terms.item.put", "inventory-storage.nature-of-content-terms.item.delete", "inventory-storage.classification-types.collection.get", "inventory-storage.classification-types.item.get", "inventory-storage.classification-types.item.post", "inventory-storage.classification-types.item.put", "inventory-storage.classification-types.item.delete", "inventory-storage.alternative-title-types.collection.get", "inventory-storage.alternative-title-types.item.get", "inventory-storage.alternative-title-types.item.post", "inventory-storage.alternative-title-types.item.put", "inventory-storage.alternative-title-types.item.delete", "inventory-storage.modes-of-issuance.collection.get", "inventory-storage.modes-of-issuance.item.get", "inventory-storage.modes-of-issuance.item.post", "inventory-storage.modes-of-issuance.item.put", "inventory-storage.modes-of-issuance.item.delete", "inventory-storage.instance-statuses.collection.get", "inventory-storage.instance-statuses.item.get", "inventory-storage.instance-statuses.item.post", "inventory-storage.instance-statuses.item.put", "inventory-storage.instance-statuses.item.delete", "inventory-storage.electronic-access-relationships.collection.get", "inventory-storage.electronic-access-relationships.item.get", "inventory-storage.electronic-access-relationships.item.post", "inventory-storage.electronic-access-relationships.item.put", "inventory-storage.electronic-access-relationships.item.delete", "inventory-storage.statistical-code-types.collection.get", "inventory-storage.statistical-code-types.item.get", "inventory-storage.statistical-code-types.item.post", "inventory-storage.statistical-code-types.item.put", "inventory-storage.statistical-code-types.item.delete", "inventory-storage.statistical-codes.collection.get", "inventory-storage.statistical-codes.item.get", "inventory-storage.statistical-codes.item.post", "inventory-storage.statistical-codes.item.put", "inventory-storage.statistical-codes.item.delete", "inventory-storage.ill-policies.collection.get", "inventory-storage.ill-policies.item.get", "inventory-storage.ill-policies.item.post", "inventory-storage.ill-policies.item.put", "inventory-storage.ill-policies.item.delete", "inventory-storage.holdings-types.collection.get", "inventory-storage.holdings-types.item.get", "inventory-storage.holdings-types.item.post", "inventory-storage.holdings-types.item.put", "inventory-storage.holdings-types.item.delete", "inventory-storage.call-number-types.collection.get", "inventory-storage.call-number-types.item.get", "inventory-storage.call-number-types.item.post", "inventory-storage.call-number-types.item.put", "inventory-storage.call-number-types.item.delete", "inventory-storage.instance-note-types.collection.get", "inventory-storage.instance-note-types.item.get", "inventory-storage.instance-note-types.item.post", "inventory-storage.instance-note-types.item.put", "inventory-storage.instance-note-types.item.delete", "inventory-storage.holdings-note-types.collection.get", "inventory-storage.holdings-note-types.item.get", "inventory-storage.holdings-note-types.item.post", "inventory-storage.holdings-note-types.item.put", "inventory-storage.holdings-note-types.item.delete", "inventory-storage.item-note-types.collection.get", "inventory-storage.item-note-types.item.get", "inventory-storage.item-note-types.item.post", "inventory-storage.item-note-types.item.put", "inventory-storage.item-note-types.item.delete", "inventory-storage.item-damaged-statuses.collection.get", "inventory-storage.item-damaged-statuses.item.get", "inventory-storage.item-damaged-statuses.item.post", "inventory-storage.item-damaged-statuses.item.put", "inventory-storage.item-damaged-statuses.item.delete", "inventory-storage.service-points.collection.get", "inventory-storage.service-points.item.get", "inventory-storage.service-points.item.post", "inventory-storage.service-points.item.put", "inventory-storage.service-points.item.delete", "inventory-storage.service-points-users.collection.get", "inventory-storage.service-points-users.item.get", "inventory-storage.service-points-users.item.post", "inventory-storage.service-points-users.item.put", "inventory-storage.service-points-users.item.delete", "inventory-storage.hrid-settings.item.get", "inventory-storage.hrid-settings.item.put", "inventory-storage.preceding-succeeding-titles.collection.get", "inventory-storage.preceding-succeeding-titles.item.get", "inventory-storage.preceding-succeeding-titles.item.post", "inventory-storage.preceding-succeeding-titles.item.put", "inventory-storage.preceding-succeeding-titles.item.delete", "inventory-storage.oai-pmh-view.instances.collection.get", "inventory-storage.oai-pmh-view.updatedinstanceids.collection.get", "inventory-storage.oai-pmh-view.enrichedinstances.collection.post" ]
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-inventory-storage:19.3.6",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    }, {
+      "name" : "DB_HOST",
+      "value" : "postgres"
+    }, {
+      "name" : "DB_PORT",
+      "value" : "5432"
+    }, {
+      "name" : "DB_USERNAME",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_PASSWORD",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_DATABASE",
+      "value" : "okapi_modules"
+    }, {
+      "name" : "DB_QUERYTIMEOUT",
+      "value" : "60000"
+    }, {
+      "name" : "DB_CHARSET",
+      "value" : "UTF-8"
+    }, {
+      "name" : "DB_MAXPOOLSIZE",
+      "value" : "5"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 715827883,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-invoice-4.0.3",
+  "name" : "Invoice business logic module",
+  "requires" : [ {
+    "id" : "configuration",
+    "version" : "2.0"
+  }, {
+    "id" : "finance.funds",
+    "version" : "1.1"
+  }, {
+    "id" : "invoice-storage.invoices",
+    "version" : "4.0"
+  }, {
+    "id" : "invoice-storage.invoice-lines",
+    "version" : "3.0"
+  }, {
+    "id" : "invoice-storage.invoice-line-number",
+    "version" : "1.0"
+  }, {
+    "id" : "order-lines",
+    "version" : "1.3"
+  }, {
+    "id" : "voucher-storage.vouchers",
+    "version" : "1.2"
+  }, {
+    "id" : "voucher-storage.voucher-lines",
+    "version" : "2.0"
+  }, {
+    "id" : "voucher-storage.voucher-number",
+    "version" : "1.0"
+  }, {
+    "id" : "acquisitions-units",
+    "version" : "1.1"
+  }, {
+    "id" : "batch-voucher-storage.export-configurations",
+    "version" : "1.0"
+  }, {
+    "id" : "batch-voucher-storage.batch-vouchers",
+    "version" : "2.0"
+  }, {
+    "id" : "finance.transactions",
+    "version" : "3.0"
+  }, {
+    "id" : "finance-storage.transactions",
+    "version" : "3.0"
+  }, {
+    "id" : "batch-group-storage.batch-groups",
+    "version" : "1.0"
+  }, {
+    "id" : "batch-voucher-storage.batch-voucher-exports",
+    "version" : "1.1"
+  }, {
+    "id" : "finance.ledgers",
+    "version" : "1.4"
+  }, {
+    "id" : "organizations-storage.organizations",
+    "version" : "3.1"
+  } ],
+  "provides" : [ {
+    "id" : "invoice",
+    "version" : "5.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/invoice/invoices",
+      "permissionsRequired" : [ "invoice.invoices.collection.get" ],
+      "modulePermissions" : [ "invoice-storage.invoices.collection.get", "acquisitions-units.units.collection.get", "acquisitions-units.memberships.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/invoice/invoices",
+      "permissionsRequired" : [ "invoice.invoices.item.post" ],
+      "permissionsDesired" : [ "invoices.acquisitions-units-assignments.assign" ],
+      "modulePermissions" : [ "invoice-storage.invoices.item.post", "invoice-storage.invoice-number.get", "acquisitions-units.units.collection.get", "acquisitions-units.memberships.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/invoice/invoices/{id}",
+      "permissionsRequired" : [ "invoice.invoices.item.get" ],
+      "modulePermissions" : [ "invoice-storage.invoices.item.get", "invoice-storage.invoices.item.put", "invoice-storage.invoice-lines.collection.get", "acquisitions-units.units.collection.get", "acquisitions-units.memberships.collection.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/invoice/invoices/{id}",
+      "permissionsRequired" : [ "invoice.invoices.item.put" ],
+      "permissionsDesired" : [ "invoices.acquisitions-units-assignments.manage" ],
+      "modulePermissions" : [ "configuration.entries.collection.get", "invoice-storage.invoices.item.put", "invoice-storage.invoices.item.get", "invoice-storage.invoice-lines.item.put", "invoice-storage.invoice-lines.collection.get", "orders.po-lines.item.put", "orders.po-lines.item.get", "voucher-storage.vouchers.collection.get", "voucher-storage.vouchers.item.post", "voucher-storage.vouchers.item.put", "voucher-storage.voucher-lines.collection.get", "voucher-storage.voucher-lines.item.post", "voucher-storage.voucher-lines.item.delete", "voucher-storage.voucher-number.get", "acquisitions-units.units.collection.get", "acquisitions-units.memberships.collection.get", "finance.awaiting-payment.item.post", "finance.invoice-transaction-summaries.item.post", "finance.payments.item.post", "finance.credits.item.post", "finance.transactions.collection.get", "finance.funds.collection.get", "finance.ledgers.current-fiscal-year.item.get", "finance-storage.transactions.item.post" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/invoice/invoices/{id}",
+      "permissionsRequired" : [ "invoice.invoices.item.delete" ],
+      "modulePermissions" : [ "invoice-storage.invoices.item.get", "invoice-storage.invoices.item.delete", "acquisitions-units.units.collection.get", "acquisitions-units.memberships.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/invoice/invoice-lines",
+      "permissionsRequired" : [ "invoice.invoice-lines.collection.get" ],
+      "modulePermissions" : [ "invoice-storage.invoice-lines.collection.get", "acquisitions-units.units.collection.get", "acquisitions-units.memberships.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/invoice/invoice-lines",
+      "permissionsRequired" : [ "invoice.invoice-lines.item.post" ],
+      "modulePermissions" : [ "invoice-storage.invoice-line-number.get", "invoice-storage.invoices.item.get", "invoice-storage.invoices.item.put", "invoice-storage.invoice-lines.item.post", "invoice-storage.invoice-lines.item.put", "invoice-storage.invoice-lines.collection.get", "acquisitions-units.units.collection.get", "acquisitions-units.memberships.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/invoice/invoice-lines/{id}",
+      "permissionsRequired" : [ "invoice.invoice-lines.item.get" ],
+      "modulePermissions" : [ "invoice-storage.invoice-lines.item.get", "invoice-storage.invoice-lines.item.put", "invoice-storage.invoice-lines.collection.get", "invoice-storage.invoices.item.get", "invoice-storage.invoices.item.put", "acquisitions-units.units.collection.get", "acquisitions-units.memberships.collection.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/invoice/invoice-lines/{id}",
+      "permissionsRequired" : [ "invoice.invoice-lines.item.put" ],
+      "modulePermissions" : [ "invoice-storage.invoice-lines.item.put", "invoice-storage.invoice-lines.item.get", "invoice-storage.invoice-lines.collection.get", "invoice-storage.invoices.item.get", "invoice-storage.invoices.item.put", "acquisitions-units.units.collection.get", "acquisitions-units.memberships.collection.get" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/invoice/invoice-lines/{id}",
+      "permissionsRequired" : [ "invoice.invoice-lines.item.delete" ],
+      "modulePermissions" : [ "invoice-storage.invoice-lines.item.get", "invoice-storage.invoice-lines.item.delete", "invoice-storage.invoice-lines.item.put", "invoice-storage.invoice-lines.collection.get", "invoice-storage.invoices.item.get", "invoice-storage.invoices.item.put", "invoice-storage.invoices.collection.get", "acquisitions-units.units.collection.get", "acquisitions-units.memberships.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/invoice/invoice-number",
+      "permissionsRequired" : [ "invoice.invoice-number.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/invoice/invoices/{id}/documents",
+      "permissionsRequired" : [ "invoice.invoices.documents.collection.get" ],
+      "modulePermissions" : [ "invoice-storage.invoices.documents.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/invoice/invoices/{id}/documents",
+      "permissionsRequired" : [ "invoice.invoices.documents.item.post" ],
+      "modulePermissions" : [ "invoice-storage.invoices.documents.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/invoice/invoices/{id}/documents/{documentId}",
+      "permissionsRequired" : [ "invoice.invoices.documents.item.get" ],
+      "modulePermissions" : [ "invoice-storage.invoices.documents.item.get" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/invoice/invoices/{id}/documents/{documentId}",
+      "permissionsRequired" : [ "invoice.invoices.documents.item.delete" ],
+      "modulePermissions" : [ "invoice-storage.invoices.documents.item.delete" ]
+    } ]
+  }, {
+    "id" : "voucher",
+    "version" : "2.2",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/voucher/vouchers",
+      "permissionsRequired" : [ "voucher.vouchers.collection.get" ],
+      "modulePermissions" : [ "voucher-storage.vouchers.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/voucher/vouchers/{id}",
+      "permissionsRequired" : [ "voucher.vouchers.item.get" ],
+      "modulePermissions" : [ "voucher-storage.vouchers.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/voucher/vouchers/{id}",
+      "permissionsRequired" : [ "voucher.vouchers.item.put" ],
+      "modulePermissions" : [ "voucher-storage.vouchers.item.get", "voucher-storage.vouchers.item.put" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/voucher/voucher-lines",
+      "permissionsRequired" : [ "voucher.voucher-lines.collection.get" ],
+      "modulePermissions" : [ "voucher-storage.voucher-lines.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/voucher/voucher-lines/{id}",
+      "permissionsRequired" : [ "voucher.voucher-lines.item.get" ],
+      "modulePermissions" : [ "voucher-storage.voucher-lines.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/voucher/voucher-lines/{id}",
+      "permissionsRequired" : [ "voucher.voucher-lines.item.put" ],
+      "modulePermissions" : [ "voucher-storage.voucher-lines.item.put" ]
+    } ]
+  }, {
+    "id" : "voucher-number",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/voucher/voucher-number/start/{value}",
+      "permissionsRequired" : [ "voucher-number.start.post" ],
+      "modulePermissions" : [ "voucher-storage.voucher-number.start.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/voucher/voucher-number/start",
+      "permissionsRequired" : [ "voucher-number.start.get" ],
+      "modulePermissions" : [ "voucher-storage.voucher-number.start.get" ]
+    } ]
+  }, {
+    "id" : "batch-voucher.export-configurations",
+    "version" : "1.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/batch-voucher/export-configurations",
+      "permissionsRequired" : [ "batch-voucher.export-configurations.collection.get" ],
+      "modulePermissions" : [ "batch-voucher-storage.export-configurations.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/batch-voucher/export-configurations",
+      "permissionsRequired" : [ "batch-voucher.export-configurations.item.post" ],
+      "modulePermissions" : [ "batch-voucher-storage.export-configurations.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/batch-voucher/export-configurations/{id}",
+      "permissionsRequired" : [ "batch-voucher.export-configurations.item.get" ],
+      "modulePermissions" : [ "batch-voucher-storage.export-configurations.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/batch-voucher/export-configurations/{id}",
+      "permissionsRequired" : [ "batch-voucher.export-configurations.item.put" ],
+      "modulePermissions" : [ "batch-voucher-storage.export-configurations.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/batch-voucher/export-configurations/{id}",
+      "permissionsRequired" : [ "batch-voucher.export-configurations.item.delete" ],
+      "modulePermissions" : [ "batch-voucher-storage.export-configurations.item.delete" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/batch-voucher/export-configurations/{id}/credentials",
+      "permissionsRequired" : [ "batch-voucher.export-configurations.credentials.item.post" ],
+      "modulePermissions" : [ "batch-voucher-storage.export-configurations.credentials.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/batch-voucher/export-configurations/{id}/credentials",
+      "permissionsRequired" : [ "batch-voucher.export-configurations.credentials.item.get" ],
+      "modulePermissions" : [ "batch-voucher-storage.export-configurations.credentials.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/batch-voucher/export-configurations/{id}/credentials",
+      "permissionsRequired" : [ "batch-voucher.export-configurations.credentials.item.put" ],
+      "modulePermissions" : [ "batch-voucher-storage.export-configurations.credentials.item.put" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/batch-voucher/export-configurations/{id}/credentials/test",
+      "permissionsRequired" : [ "batch-voucher.export-configurations.credentials.test" ],
+      "modulePermissions" : [ "batch-voucher-storage.export-configurations.item.get", "batch-voucher-storage.export-configurations.credentials.item.get" ]
+    } ]
+  }, {
+    "id" : "batch-group",
+    "version" : "1.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/batch-groups",
+      "permissionsRequired" : [ "batch-groups.collection.get" ],
+      "modulePermissions" : [ "batch-group-storage.batch-groups.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/batch-groups",
+      "permissionsRequired" : [ "batch-groups.item.post" ],
+      "modulePermissions" : [ "batch-group-storage.batch-groups.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/batch-groups/{id}",
+      "permissionsRequired" : [ "batch-groups.item.get" ],
+      "modulePermissions" : [ "batch-group-storage.batch-groups.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/batch-groups/{id}",
+      "permissionsRequired" : [ "batch-groups.item.put" ],
+      "modulePermissions" : [ "batch-group-storage.batch-groups.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/batch-groups/{id}",
+      "permissionsRequired" : [ "batch-groups.item.delete" ],
+      "modulePermissions" : [ "batch-group-storage.batch-groups.item.delete" ]
+    } ]
+  }, {
+    "id" : "batch-voucher.batch-vouchers",
+    "version" : "2.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/batch-voucher/batch-vouchers/{id}",
+      "permissionsRequired" : [ "batch-voucher.batch-vouchers.item.get" ],
+      "modulePermissions" : [ "batch-voucher-storage.batch-vouchers.item.get" ]
+    } ]
+  }, {
+    "id" : "batch-voucher.batch-voucher-exports",
+    "version" : "1.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/batch-voucher/batch-voucher-exports/{id}",
+      "permissionsRequired" : [ "batch-voucher.batch-voucher-exports.item.get" ],
+      "modulePermissions" : [ "batch-voucher-storage.batch-voucher-exports.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/batch-voucher/batch-voucher-exports",
+      "permissionsRequired" : [ "batch-voucher.batch-voucher-exports.collection.get" ],
+      "modulePermissions" : [ "batch-voucher-storage.batch-voucher-exports.collection.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/batch-voucher/batch-voucher-exports/{id}",
+      "permissionsRequired" : [ "batch-voucher.batch-voucher-exports.item.put" ],
+      "modulePermissions" : [ "batch-voucher-storage.batch-voucher-exports.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/batch-voucher/batch-voucher-exports/{id}",
+      "permissionsRequired" : [ "batch-voucher.batch-voucher-exports.item.delete" ],
+      "modulePermissions" : [ "batch-voucher-storage.batch-voucher-exports.item.delete" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/batch-voucher/batch-voucher-exports",
+      "permissionsRequired" : [ "batch-voucher.batch-voucher-exports.item.post" ],
+      "modulePermissions" : [ "batch-voucher-storage.batch-voucher-exports.item.post", "batch-voucher-storage.batch-voucher-exports.item.put", "batch-voucher-storage.batch-vouchers.item.post", "batch-voucher-storage.batch-vouchers.item.get", "batch-voucher-storage.export-configurations.collection.get", "batch-voucher-storage.export-configurations.credentials.item.get", "invoice-storage.invoices.item.get", "invoice-storage.invoices.collection.get", "voucher-storage.vouchers.collection.get", "voucher-storage.voucher-lines.collection.get", "batch-group-storage.batch-groups.item.get", "organizations-storage.organizations.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/batch-voucher/batch-voucher-exports/scheduled",
+      "permissionsRequired" : [ "batch-voucher.batch-voucher-exports.scheduled.item.post" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/batch-voucher/batch-voucher-exports/{id}/upload",
+      "permissionsRequired" : [ "batch-voucher.batch-voucher-exports.upload.item.post" ],
+      "modulePermissions" : [ "batch-voucher-storage.batch-voucher-exports.item.put", "batch-voucher-storage.batch-voucher-exports.item.get", "batch-voucher-storage.export-configurations.collection.get", "batch-voucher-storage.export-configurations.credentials.item.get", "batch-voucher-storage.batch-vouchers.item.get" ]
+    } ]
+  }, {
+    "id" : "_jsonSchemas",
+    "version" : "1.0",
+    "interfaceType" : "multiple",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/_/jsonSchemas",
+      "permissionsRequired" : [ ]
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "invoice.invoices.collection.get",
+    "displayName" : "Invoice - get collection of Invoice",
+    "description" : "Get collection of Invoice"
+  }, {
+    "permissionName" : "invoice.invoices.item.get",
+    "displayName" : "Invoice - get an existing Invoice",
+    "description" : "Get an existing Invoice"
+  }, {
+    "permissionName" : "invoice.invoices.item.post",
+    "displayName" : "Invoice - create a new Invoice",
+    "description" : "Create a new invoice"
+  }, {
+    "permissionName" : "invoice.invoices.item.put",
+    "displayName" : "Invoice - modify invoice",
+    "description" : "Modify an existing Invoice"
+  }, {
+    "permissionName" : "invoice.invoices.item.delete",
+    "displayName" : "Invoice - delete an existing Invoice",
+    "description" : "Delete an existing Invoice"
+  }, {
+    "permissionName" : "invoice.invoice-lines.collection.get",
+    "displayName" : "Invoice Line - get collection of Invoice lines",
+    "description" : "Get collection of Invoice lines"
+  }, {
+    "permissionName" : "invoice.invoice-lines.item.get",
+    "displayName" : "Invoice - get an existing Invoice line",
+    "description" : "Get an existing Invoice line"
+  }, {
+    "permissionName" : "invoice.invoice-lines.item.post",
+    "displayName" : "Invoice - create a new Invoice line",
+    "description" : "Create a new Invoice line"
+  }, {
+    "permissionName" : "invoice.invoice-lines.item.put",
+    "displayName" : "Invoice - modify an existing Invoice line",
+    "description" : "Modify an existing Invoice line"
+  }, {
+    "permissionName" : "invoice.invoice-lines.item.delete",
+    "displayName" : "Invoice - delete an existing Invoice line",
+    "description" : "Delete an existing Invoice line"
+  }, {
+    "permissionName" : "invoice.invoice-number.item.get",
+    "displayName" : "Invoice - generate a Invoice Number",
+    "description" : "Generate a Invoice Number"
+  }, {
+    "permissionName" : "voucher.vouchers.collection.get",
+    "displayName" : "Voucher - get collection of Voucher",
+    "description" : "Get collection of Voucher"
+  }, {
+    "permissionName" : "voucher.vouchers.item.get",
+    "displayName" : "Voucher - get an existing Voucher",
+    "description" : "Get an existing Voucher"
+  }, {
+    "permissionName" : "voucher.vouchers.item.put",
+    "displayName" : "Voucher - modify an existing Voucher",
+    "description" : "Modify an existing Voucher"
+  }, {
+    "permissionName" : "voucher.voucher-lines.collection.get",
+    "displayName" : "Voucher - get collection of lines",
+    "description" : "Get collection of Voucher lines"
+  }, {
+    "permissionName" : "voucher.voucher-lines.item.get",
+    "displayName" : "Voucher - get an existing Voucher line",
+    "description" : "Get an existing Voucher line"
+  }, {
+    "permissionName" : "voucher.voucher-lines.item.put",
+    "displayName" : "Voucher - modify an existing Voucher line",
+    "description" : "Modify an existing Voucher line"
+  }, {
+    "permissionName" : "voucher-number.start.post",
+    "displayName" : "Post voucher number sequence start value",
+    "description" : "Voucher number sequence - re(set) the start value of the sequence"
+  }, {
+    "permissionName" : "voucher-number.start.get",
+    "displayName" : "Get voucher number sequence start value",
+    "description" : "Voucher number sequence - get the start value of the sequence"
+  }, {
+    "permissionName" : "voucher.all",
+    "displayName" : "Invoice module - all Voucher permissions",
+    "description" : "Entire set of permissions needed to use Vouchers",
+    "subPermissions" : [ "voucher.vouchers.collection.get", "voucher.vouchers.item.get", "voucher.vouchers.item.put", "voucher.voucher-lines.collection.get", "voucher.voucher-lines.item.get", "voucher.voucher-lines.item.put" ],
+    "visible" : false
+  }, {
+    "permissionName" : "invoice.invoices.documents.collection.get",
+    "displayName" : "Document - get collection of Documents",
+    "description" : "Get collection of Documents"
+  }, {
+    "permissionName" : "invoice.invoices.documents.item.post",
+    "displayName" : "Document - create Document",
+    "description" : "Create new Document"
+  }, {
+    "permissionName" : "invoice.invoices.documents.item.get",
+    "displayName" : "Document - get an existing Document",
+    "description" : "Get an existing Document"
+  }, {
+    "permissionName" : "invoice.invoices.documents.item.delete",
+    "displayName" : "Document - modify an existing Document",
+    "description" : "Modify an existing Document"
+  }, {
+    "permissionName" : "invoice.invoices.documents.all",
+    "displayName" : "All documents perms",
+    "description" : "All permissions for the documents",
+    "subPermissions" : [ "invoice.invoices.documents.collection.get", "invoice.invoices.documents.item.post", "invoice.invoices.documents.item.get", "invoice.invoices.documents.item.delete" ]
+  }, {
+    "permissionName" : "batch-voucher.export-configurations.collection.get",
+    "displayName" : "Batch voucher - get batch voucher export configuration collection",
+    "description" : "Get batch voucher export configuration collection"
+  }, {
+    "permissionName" : "batch-voucher.export-configurations.item.get",
+    "displayName" : "Batch voucher - get individual batch voucher export configuration",
+    "description" : "Get individual batch voucher"
+  }, {
+    "permissionName" : "batch-voucher.export-configurations.item.post",
+    "displayName" : "Batch voucher - create batch voucher export configuration",
+    "description" : "Create batch voucher export configuration"
+  }, {
+    "permissionName" : "batch-voucher.export-configurations.item.put",
+    "displayName" : "Batch voucher - modify batch voucher export configuration",
+    "description" : "Modify batch voucher export configuration"
+  }, {
+    "permissionName" : "batch-voucher.export-configurations.item.delete",
+    "displayName" : "Batch voucher - delete batch voucher export configuration",
+    "description" : "Delete batch voucher export configuration"
+  }, {
+    "permissionName" : "batch-voucher.export-configurations.credentials.item.get",
+    "displayName" : "Batch voucher - get individual batch voucher export configuration credentials",
+    "description" : "Get individual batch voucher credentials"
+  }, {
+    "permissionName" : "batch-voucher.export-configurations.credentials.item.post",
+    "displayName" : "Batch voucher - create batch voucher export configuration credentials",
+    "description" : "Create batch voucher export configuration credentials"
+  }, {
+    "permissionName" : "batch-voucher.export-configurations.credentials.item.put",
+    "displayName" : "Batch voucher - modify batch voucher export configuration credentials",
+    "description" : "Modify batch voucher export configuration credentials"
+  }, {
+    "permissionName" : "batch-voucher.export-configurations.credentials.test",
+    "displayName" : "Batch voucher - test batch voucher export configuration credentials",
+    "description" : "Test batch voucher export configuration credentials"
+  }, {
+    "permissionName" : "batch-voucher.export-configurations.all",
+    "displayName" : "All batch voucher export configurations perms",
+    "description" : "All permissions for the batch voucher export configuration",
+    "subPermissions" : [ "batch-voucher.export-configurations.collection.get", "batch-voucher.export-configurations.item.get", "batch-voucher.export-configurations.item.post", "batch-voucher.export-configurations.item.put", "batch-voucher.export-configurations.item.delete", "batch-voucher.export-configurations.credentials.item.get", "batch-voucher.export-configurations.credentials.item.post", "batch-voucher.export-configurations.credentials.item.put", "batch-voucher.export-configurations.credentials.test" ]
+  }, {
+    "permissionName" : "invoices.acquisitions-units-assignments.assign",
+    "displayName" : "Acquisitions unit assignment - create unit assignment",
+    "description" : "Assign new invoice to acquisitions units"
+  }, {
+    "permissionName" : "invoices.acquisitions-units-assignments.manage",
+    "displayName" : "Acquisitions units assignment - manage unit assignments",
+    "description" : "Manage unit assignments during invoice update"
+  }, {
+    "permissionName" : "invoices.acquisitions-units-assignments.all",
+    "displayName" : "All invoice acquisitions-unit-assignments permissions",
+    "description" : "All permissions for the acquisitions-unit-assignments",
+    "subPermissions" : [ "invoices.acquisitions-units-assignments.assign", "invoices.acquisitions-units-assignments.manage" ]
+  }, {
+    "permissionName" : "batch-groups.collection.get",
+    "displayName" : "Batch-group - get collection of Batch-group",
+    "description" : "Get collection of Batch-group"
+  }, {
+    "permissionName" : "batch-groups.item.get",
+    "displayName" : "Batch-group - get an existing Batch-group",
+    "description" : "Get an existing Batch-group"
+  }, {
+    "permissionName" : "batch-groups.item.post",
+    "displayName" : "Batch-group - create a new Batch-group",
+    "description" : "Create a new Batch-group"
+  }, {
+    "permissionName" : "batch-groups.item.put",
+    "displayName" : "Batch-group - modify Batch-group",
+    "description" : "Modify an existing Batch-group"
+  }, {
+    "permissionName" : "batch-groups.item.delete",
+    "displayName" : "Batch-group - delete an existing Batch-group",
+    "description" : "Delete an existing Batch-group"
+  }, {
+    "permissionName" : "batch-groups.all",
+    "displayName" : "Batch-group module - all permissions",
+    "description" : "Entire set of permissions needed to use the batch-group module",
+    "subPermissions" : [ "batch-groups.collection.get", "batch-groups.item.get", "batch-groups.item.post", "batch-groups.item.put", "batch-groups.item.delete" ],
+    "visible" : false
+  }, {
+    "permissionName" : "batch-voucher.batch-vouchers.item.get",
+    "displayName" : "Batch-voucher - get an existing Batch-voucher",
+    "description" : "Get an existing Batch-voucher"
+  }, {
+    "permissionName" : "batch-voucher.all",
+    "displayName" : "Batch-voucher module - all permissions",
+    "description" : "Entire set of permissions needed to use the batch-voucher module",
+    "subPermissions" : [ "batch-voucher.batch-vouchers.item.get" ],
+    "visible" : false
+  }, {
+    "permissionName" : "batch-voucher.batch-voucher-exports.collection.get",
+    "displayName" : "Batch-voucher-exports - get collection of Batch-voucher-exports",
+    "description" : "Get collection of Batch-voucher-exports"
+  }, {
+    "permissionName" : "batch-voucher.batch-voucher-exports.item.get",
+    "displayName" : "Batch-voucher-exports - get an existing Batch-voucher-export",
+    "description" : "Get an existing Batch-voucher-export"
+  }, {
+    "permissionName" : "batch-voucher.batch-voucher-exports.item.post",
+    "displayName" : "Batch-voucher-exports - create a new Batch-voucher-export",
+    "description" : "Create a new Batch-voucher-export"
+  }, {
+    "permissionName" : "batch-voucher.batch-voucher-exports.scheduled.item.post",
+    "displayName" : "Batch-voucher-exports - Conditionally create a batch voucher export",
+    "description" : "Conditionally create a batch voucher export"
+  }, {
+    "permissionName" : "batch-voucher.batch-voucher-exports.upload.item.post",
+    "displayName" : "Batch-voucher-exports - (Re)upload the batch voucher associated with this voucher export to the configured URI, using the configured credentials",
+    "description" : "(Re)upload the batch voucher associated with this voucher export to the configured URI, using the configured credentials"
+  }, {
+    "permissionName" : "batch-voucher.batch-voucher-exports.item.put",
+    "displayName" : "Batch-voucher-exports - modify a existing Batch-voucher-export",
+    "description" : "Modify an existing Batch-voucher-export"
+  }, {
+    "permissionName" : "batch-voucher.batch-voucher-exports.item.delete",
+    "displayName" : "Batch-voucher-exports - delete an existing Batch-voucher-export",
+    "description" : "Delete an existing Batch-voucher-export"
+  }, {
+    "permissionName" : "batch-voucher.batch-voucher-exports.all",
+    "displayName" : "Batch-voucher-exports module - all permissions",
+    "description" : "Entire set of permissions needed to use the batch-voucher-exports module",
+    "subPermissions" : [ "batch-voucher.batch-voucher-exports.collection.get", "batch-voucher.batch-voucher-exports.item.get", "batch-voucher.batch-voucher-exports.item.post", "batch-voucher.batch-voucher-exports.item.put", "batch-voucher.batch-voucher-exports.item.delete", "batch-voucher.batch-voucher-exports.scheduled.item.post", "batch-voucher.batch-voucher-exports.upload.item.post" ],
+    "visible" : false
+  }, {
+    "permissionName" : "invoice.all",
+    "displayName" : "Invoice module - all permissions",
+    "description" : "Entire set of permissions needed to use the invoice module",
+    "subPermissions" : [ "invoice.invoices.collection.get", "invoice.invoices.item.get", "invoice.invoices.item.post", "invoice.invoices.item.put", "invoice.invoices.item.delete", "invoice.invoice-lines.collection.get", "invoice.invoice-lines.item.get", "invoice.invoice-lines.item.post", "invoice.invoice-lines.item.put", "invoice.invoice-lines.item.delete", "invoice.invoice-number.item.get", "invoice.invoice-number.item.post", "voucher-number.start.post", "voucher-number.start.get", "voucher.all", "invoice.invoices.documents.all", "invoices.acquisitions-units-assignments.all", "batch-voucher.export-configurations.all", "batch-groups.all", "batch-voucher.all", "batch-voucher.batch-voucher-exports.all" ],
+    "visible" : false
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-invoice:4.0.3",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 626349397,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-invoice-storage-4.0.1",
+  "name" : "Invoice CRUD module",
+  "provides" : [ {
+    "id" : "invoice-storage.invoices",
+    "version" : "4.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/invoice-storage/invoices",
+      "permissionsRequired" : [ "invoice-storage.invoices.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/invoice-storage/invoices",
+      "permissionsRequired" : [ "invoice-storage.invoices.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/invoice-storage/invoices/{id}",
+      "permissionsRequired" : [ "invoice-storage.invoices.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/invoice-storage/invoices/{id}",
+      "permissionsRequired" : [ "invoice-storage.invoices.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/invoice-storage/invoices/{id}",
+      "permissionsRequired" : [ "invoice-storage.invoices.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/invoice-storage/invoices/{id}/documents",
+      "permissionsRequired" : [ "invoice-storage.invoices.documents.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/invoice-storage/invoices/{id}/documents",
+      "permissionsRequired" : [ "invoice-storage.invoices.documents.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/invoice-storage/invoices/{id}/documents/{documentId}",
+      "permissionsRequired" : [ "invoice-storage.invoices.documents.item.get" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/invoice-storage/invoices/{id}/documents/{documentId}",
+      "permissionsRequired" : [ "invoice-storage.invoices.documents.item.delete" ]
+    } ]
+  }, {
+    "id" : "invoice-storage.invoice-lines",
+    "version" : "3.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/invoice-storage/invoice-lines",
+      "permissionsRequired" : [ "invoice-storage.invoice-lines.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/invoice-storage/invoice-lines",
+      "permissionsRequired" : [ "invoice-storage.invoice-lines.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/invoice-storage/invoice-lines/{id}",
+      "permissionsRequired" : [ "invoice-storage.invoice-lines.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/invoice-storage/invoice-lines/{id}",
+      "permissionsRequired" : [ "invoice-storage.invoice-lines.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/invoice-storage/invoice-lines/{id}",
+      "permissionsRequired" : [ "invoice-storage.invoice-lines.item.delete" ]
+    } ]
+  }, {
+    "id" : "invoice-storage.invoice-number",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/invoice-storage/invoice-number",
+      "permissionsRequired" : [ "invoice-storage.invoice-number.get" ]
+    } ]
+  }, {
+    "id" : "invoice-storage.invoice-line-number",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/invoice-storage/invoice-line-number",
+      "permissionsRequired" : [ "invoice-storage.invoice-line-number.get" ]
+    } ]
+  }, {
+    "id" : "voucher-storage.vouchers",
+    "version" : "1.2",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/voucher-storage/vouchers",
+      "permissionsRequired" : [ "voucher-storage.vouchers.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/voucher-storage/vouchers",
+      "permissionsRequired" : [ "voucher-storage.vouchers.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/voucher-storage/vouchers/{id}",
+      "permissionsRequired" : [ "voucher-storage.vouchers.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/voucher-storage/vouchers/{id}",
+      "permissionsRequired" : [ "voucher-storage.vouchers.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/voucher-storage/vouchers/{id}",
+      "permissionsRequired" : [ "voucher-storage.vouchers.item.delete" ]
+    } ]
+  }, {
+    "id" : "voucher-storage.voucher-lines",
+    "version" : "2.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/voucher-storage/voucher-lines",
+      "permissionsRequired" : [ "voucher-storage.voucher-lines.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/voucher-storage/voucher-lines",
+      "permissionsRequired" : [ "voucher-storage.voucher-lines.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/voucher-storage/voucher-lines/{id}",
+      "permissionsRequired" : [ "voucher-storage.voucher-lines.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/voucher-storage/voucher-lines/{id}",
+      "permissionsRequired" : [ "voucher-storage.voucher-lines.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/voucher-storage/voucher-lines/{id}",
+      "permissionsRequired" : [ "voucher-storage.voucher-lines.item.delete" ]
+    } ]
+  }, {
+    "id" : "voucher-storage.voucher-number",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/voucher-storage/voucher-number",
+      "permissionsRequired" : [ "voucher-storage.voucher-number.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/voucher-storage/voucher-number/start",
+      "permissionsRequired" : [ "voucher-storage.voucher-number.start.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/voucher-storage/voucher-number/start/{value}",
+      "permissionsRequired" : [ "voucher-storage.voucher-number.start.post" ]
+    } ]
+  }, {
+    "id" : "batch-voucher-storage.export-configurations",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/batch-voucher-storage/export-configurations",
+      "permissionsRequired" : [ "batch-voucher-storage.export-configurations.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/batch-voucher-storage/export-configurations",
+      "permissionsRequired" : [ "batch-voucher-storage.export-configurations.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/batch-voucher-storage/export-configurations/{id}",
+      "permissionsRequired" : [ "batch-voucher-storage.export-configurations.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/batch-voucher-storage/export-configurations/{id}",
+      "permissionsRequired" : [ "batch-voucher-storage.export-configurations.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/batch-voucher-storage/export-configurations/{id}",
+      "permissionsRequired" : [ "batch-voucher-storage.export-configurations.item.delete" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/batch-voucher-storage/export-configurations/{id}/credentials",
+      "permissionsRequired" : [ "batch-voucher-storage.export-configurations.credentials.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/batch-voucher-storage/export-configurations/{id}/credentials",
+      "permissionsRequired" : [ "batch-voucher-storage.export-configurations.credentials.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/batch-voucher-storage/export-configurations/{id}/credentials",
+      "permissionsRequired" : [ "batch-voucher-storage.export-configurations.credentials.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/batch-voucher-storage/export-configurations/{id}/credentials",
+      "permissionsRequired" : [ "batch-voucher-storage.export-configurations.credentials.item.delete" ]
+    } ]
+  }, {
+    "id" : "batch-voucher-storage.batch-vouchers",
+    "version" : "2.0",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/batch-voucher-storage/batch-vouchers",
+      "permissionsRequired" : [ "batch-voucher-storage.batch-vouchers.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/batch-voucher-storage/batch-vouchers/{id}",
+      "permissionsRequired" : [ "batch-voucher-storage.batch-vouchers.item.get" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/batch-voucher-storage/batch-vouchers/{id}",
+      "permissionsRequired" : [ "batch-voucher-storage.batch-vouchers.item.delete" ]
+    } ]
+  }, {
+    "id" : "batch-voucher-storage.batch-voucher-exports",
+    "version" : "1.1",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/batch-voucher-storage/batch-voucher-exports",
+      "permissionsRequired" : [ "batch-voucher-storage.batch-voucher-exports.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/batch-voucher-storage/batch-voucher-exports",
+      "permissionsRequired" : [ "batch-voucher-storage.batch-voucher-exports.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/batch-voucher-storage/batch-voucher-exports/{id}",
+      "permissionsRequired" : [ "batch-voucher-storage.batch-voucher-exports.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/batch-voucher-storage/batch-voucher-exports/{id}",
+      "permissionsRequired" : [ "batch-voucher-storage.batch-voucher-exports.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/batch-voucher-storage/batch-voucher-exports/{id}",
+      "permissionsRequired" : [ "batch-voucher-storage.batch-voucher-exports.item.delete" ]
+    } ]
+  }, {
+    "id" : "_tenant",
+    "version" : "1.2",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST", "DELETE" ],
+      "pathPattern" : "/_/tenant"
+    } ]
+  }, {
+    "id" : "batch-group-storage.batch-groups",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/batch-group-storage/batch-groups",
+      "permissionsRequired" : [ "batch-group-storage.batch-groups.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/batch-group-storage/batch-groups",
+      "permissionsRequired" : [ "batch-group-storage.batch-groups.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/batch-group-storage/batch-groups/{id}",
+      "permissionsRequired" : [ "batch-group-storage.batch-groups.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/batch-group-storage/batch-groups/{id}",
+      "permissionsRequired" : [ "batch-group-storage.batch-groups.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/batch-group-storage/batch-groups/{id}",
+      "permissionsRequired" : [ "batch-group-storage.batch-groups.item.delete" ]
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "invoice-storage.invoices.collection.get",
+    "displayName" : "Invoice storage - get invoice collection",
+    "description" : "Get invoice collection"
+  }, {
+    "permissionName" : "invoice-storage.invoices.item.get",
+    "displayName" : "Invoice storage - get individual invoice",
+    "description" : "Get individual invoice"
+  }, {
+    "permissionName" : "invoice-storage.invoices.item.post",
+    "displayName" : "Invoice storage - create invoice",
+    "description" : "Create invoice"
+  }, {
+    "permissionName" : "invoice-storage.invoices.item.put",
+    "displayName" : "Invoice storage - modify invoice",
+    "description" : "Modify invoice"
+  }, {
+    "permissionName" : "invoice-storage.invoices.item.delete",
+    "displayName" : "Invoice storage - delete invoice",
+    "description" : "Delete invoice"
+  }, {
+    "permissionName" : "invoice-storage.invoices.documents.collection.get",
+    "displayName" : "Invoice storage - get document collection",
+    "description" : "Get documents collection"
+  }, {
+    "permissionName" : "invoice-storage.invoices.documents.item.get",
+    "displayName" : "Invoice storage - get individual document",
+    "description" : "Get individual document"
+  }, {
+    "permissionName" : "invoice-storage.invoices.documents.item.post",
+    "displayName" : "Invoice storage - create document",
+    "description" : "Create document"
+  }, {
+    "permissionName" : "invoice-storage.invoices.documents.item.delete",
+    "displayName" : "Invoice storage - delete document",
+    "description" : "Delete document"
+  }, {
+    "permissionName" : "invoice-storage.invoice-lines.collection.get",
+    "displayName" : "Invoice storage - get invoice line collection",
+    "description" : "Get invoice line collection"
+  }, {
+    "permissionName" : "invoice-storage.invoice-lines.item.get",
+    "displayName" : "Invoice storage - get individual invoice line",
+    "description" : "Get individual invoice line"
+  }, {
+    "permissionName" : "invoice-storage.invoice-lines.item.post",
+    "displayName" : "Invoice storage - create invoice line",
+    "description" : "Create invoice line"
+  }, {
+    "permissionName" : "invoice-storage.invoice-lines.item.put",
+    "displayName" : "Invoice storage - modify invoice line",
+    "description" : "Modify invoice line"
+  }, {
+    "permissionName" : "invoice-storage.invoice-lines.item.delete",
+    "displayName" : "Invoice storage - delete invoice line",
+    "description" : "Delete invoice line"
+  }, {
+    "permissionName" : "invoice-storage.invoice-number.get",
+    "displayName" : "Invoice storage - generate invoice number",
+    "description" : "Get invoice number"
+  }, {
+    "permissionName" : "invoice-storage.invoice-line-number.get",
+    "displayName" : "Invoice storage - generate invoice line number",
+    "description" : "Get invoice line number"
+  }, {
+    "permissionName" : "voucher-storage.vouchers.collection.get",
+    "displayName" : "Voucher storage - get voucher collection",
+    "description" : "Get voucher collection"
+  }, {
+    "permissionName" : "voucher-storage.vouchers.item.get",
+    "displayName" : "voucher storage - get individual voucher",
+    "description" : "Get individual voucher"
+  }, {
+    "permissionName" : "voucher-storage.vouchers.item.post",
+    "displayName" : "voucher storage - create voucher",
+    "description" : "Create voucher"
+  }, {
+    "permissionName" : "voucher-storage.vouchers.item.put",
+    "displayName" : "Voucher storage - modify voucher",
+    "description" : "Modify voucher"
+  }, {
+    "permissionName" : "voucher-storage.vouchers.item.delete",
+    "displayName" : "Voucher storage - delete voucher",
+    "description" : "Delete voucher"
+  }, {
+    "permissionName" : "voucher-storage.voucher-number.get",
+    "displayName" : "Voucher storage - generate voucher number",
+    "description" : "Get voucher number"
+  }, {
+    "permissionName" : "voucher-storage.voucher-number.start.get",
+    "displayName" : "Voucher storage - get current start value of the voucher number",
+    "description" : "Get current start value of the voucher number"
+  }, {
+    "permissionName" : "voucher-storage.voucher-number.start.post",
+    "displayName" : "Voucher storage - (Re)set the start value of the voucher number sequence",
+    "description" : "Post voucher number start value"
+  }, {
+    "permissionName" : "voucher-storage.voucher-lines.collection.get",
+    "displayName" : "Voucher storage - get voucher line collection",
+    "description" : "Get voucher line collection"
+  }, {
+    "permissionName" : "voucher-storage.voucher-lines.item.get",
+    "displayName" : "Voucher storage - get individual voucher line",
+    "description" : "Get individual voucher line"
+  }, {
+    "permissionName" : "voucher-storage.voucher-lines.item.post",
+    "displayName" : "Voucher storage - create voucher line",
+    "description" : "Create voucher line"
+  }, {
+    "permissionName" : "voucher-storage.voucher-lines.item.put",
+    "displayName" : "Voucher storage - modify voucher line",
+    "description" : "Modify voucher line"
+  }, {
+    "permissionName" : "voucher-storage.voucher-lines.item.delete",
+    "displayName" : "Voucher storage - delete voucher line",
+    "description" : "Delete voucher line"
+  }, {
+    "permissionName" : "batch-voucher-storage.export-configurations.collection.get",
+    "displayName" : "Batch voucher storage - get batch voucher export configuration collection",
+    "description" : "Get batch voucher export configuration collection"
+  }, {
+    "permissionName" : "batch-voucher-storage.export-configurations.item.get",
+    "displayName" : "Batch voucher storage - get individual batch voucher export configuration",
+    "description" : "Get individual batch voucher configuration"
+  }, {
+    "permissionName" : "batch-voucher-storage.export-configurations.item.post",
+    "displayName" : "Batch voucher storage - create batch voucher export configuration",
+    "description" : "Create batch voucher export configuration"
+  }, {
+    "permissionName" : "batch-voucher-storage.export-configurations.item.put",
+    "displayName" : "Batch voucher storage - modify batch voucher export configuration",
+    "description" : "Modify batch voucher export configuration"
+  }, {
+    "permissionName" : "batch-voucher-storage.export-configurations.item.delete",
+    "displayName" : "Batch voucher storage - delete batch voucher export configuration",
+    "description" : "Delete batch voucher export configuration"
+  }, {
+    "permissionName" : "batch-voucher-storage.export-configurations.credentials.item.get",
+    "displayName" : "Batch voucher storage - get individual batch voucher export configuration credentials",
+    "description" : "Get individual batch voucher export configuration credentials"
+  }, {
+    "permissionName" : "batch-voucher-storage.export-configurations.credentials.item.post",
+    "displayName" : "Batch voucher storage - create batch voucher export configuration credentials",
+    "description" : "Create batch voucher export configuration credentials"
+  }, {
+    "permissionName" : "batch-voucher-storage.export-configurations.credentials.item.put",
+    "displayName" : "Batch voucher storage - modify batch voucher export configuration credentials",
+    "description" : "Modify batch voucher export configuration credentials"
+  }, {
+    "permissionName" : "batch-voucher-storage.export-configurations.credentials.item.delete",
+    "displayName" : "Batch voucher storage - delete batch voucher export configuration credentials",
+    "description" : "Delete batch voucher export configuration credentials"
+  }, {
+    "permissionName" : "batch-voucher-storage.batch-vouchers.item.get",
+    "displayName" : "Batch voucher storage - get a batch voucher",
+    "description" : "Get a batch voucher by id"
+  }, {
+    "permissionName" : "batch-voucher-storage.batch-vouchers.item.post",
+    "displayName" : "Batch voucher storage - create a batch voucher",
+    "description" : "Create a batch voucher"
+  }, {
+    "permissionName" : "batch-voucher-storage.batch-vouchers.item.delete",
+    "displayName" : "Batch voucher storage - delete a batch voucher",
+    "description" : "Delete a batch voucher by id"
+  }, {
+    "permissionName" : "batch-voucher-storage.batch-voucher-exports.collection.get",
+    "displayName" : "Batch voucher storage - get a batch voucher exports collection",
+    "description" : "Get a batch voucher exports collection by id"
+  }, {
+    "permissionName" : "batch-voucher-storage.batch-voucher-exports.item.get",
+    "displayName" : "Batch voucher storage - get a batch voucher exports",
+    "description" : "Get a batch voucher exports by id"
+  }, {
+    "permissionName" : "batch-voucher-storage.batch-voucher-exports.item.post",
+    "displayName" : "Batch voucher storage - create a batch voucher exports",
+    "description" : "Create a batch voucher exports"
+  }, {
+    "permissionName" : "batch-voucher-storage.batch-voucher-exports.item.put",
+    "displayName" : "Batch voucher storage - modify a batch voucher exports",
+    "description" : "Modify a batch voucher exports"
+  }, {
+    "permissionName" : "batch-voucher-storage.batch-voucher-exports.item.delete",
+    "displayName" : "Batch voucher storage - delete a batch voucher exports",
+    "description" : "Delete a batch voucher exports by id"
+  }, {
+    "permissionName" : "batch-group-storage.batch-groups.collection.get",
+    "displayName" : "Batch group storage - get batch group collection",
+    "description" : "Get batch group collection"
+  }, {
+    "permissionName" : "batch-group-storage.batch-groups.item.get",
+    "displayName" : "Batch group storage - get individual batch group",
+    "description" : "Get individual batch group"
+  }, {
+    "permissionName" : "batch-group-storage.batch-groups.item.post",
+    "displayName" : "Batch group storage - create batch group",
+    "description" : "Create batch group"
+  }, {
+    "permissionName" : "batch-group-storage.batch-groups.item.put",
+    "displayName" : "Batch group storage - modify batch group",
+    "description" : "Modify batch group"
+  }, {
+    "permissionName" : "batch-group-storage.batch-groups.item.delete",
+    "displayName" : "Batch group storage - delete batch group",
+    "description" : "Delete batch group"
+  }, {
+    "permissionName" : "voucher-storage.module.all",
+    "displayName" : "Voucher storage - all permissions",
+    "description" : "Entire set of permissions needed to use vouchers",
+    "subPermissions" : [ "voucher-storage.vouchers.collection.get", "voucher-storage.vouchers.item.get", "voucher-storage.vouchers.item.post", "voucher-storage.vouchers.item.put", "voucher-storage.vouchers.item.delete", "voucher-storage.voucher-number.get", "voucher-storage.voucher-number.start.get", "voucher-storage.voucher-number.start.post", "voucher-storage.voucher-lines.collection.get", "voucher-storage.voucher-lines.item.get", "voucher-storage.voucher-lines.item.post", "voucher-storage.voucher-lines.item.put", "voucher-storage.voucher-lines.item.delete" ],
+    "visible" : false
+  }, {
+    "permissionName" : "batch-voucher-storage.module.all",
+    "displayName" : "Batch voucher storage - all permissions",
+    "description" : "Entire set of permissions needed to use batch vouchers",
+    "subPermissions" : [ "batch-voucher-storage.batch-vouchers.item.get", "batch-voucher-storage.batch-vouchers.item.post", "batch-voucher-storage.batch-vouchers.item.delete", "batch-voucher-storage.batch-voucher-exports.collection.get", "batch-voucher-storage.batch-voucher-exports.item.get", "batch-voucher-storage.batch-voucher-exports.item.post", "batch-voucher-storage.batch-voucher-exports.item.put", "batch-voucher-storage.batch-voucher-exports.item.delete", "batch-voucher-storage.export-configurations.collection.get", "batch-voucher-storage.export-configurations.item.get", "batch-voucher-storage.export-configurations.item.post", "batch-voucher-storage.export-configurations.item.put", "batch-voucher-storage.export-configurations.item.delete", "batch-voucher-storage.export-configurations.credentials.item.get", "batch-voucher-storage.export-configurations.credentials.item.post", "batch-voucher-storage.export-configurations.credentials.item.put", "batch-voucher-storage.export-configurations.credentials.item.delete" ],
+    "visible" : false
+  }, {
+    "permissionName" : "batch-group-storage.module.all",
+    "displayName" : "Batch group storage - all permissions",
+    "description" : "Entire set of permissions needed to use batch groups",
+    "subPermissions" : [ "batch-group-storage.batch-groups.collection.get", "batch-group-storage.batch-groups.item.get", "batch-group-storage.batch-groups.item.post", "batch-group-storage.batch-groups.item.put", "batch-group-storage.batch-groups.item.delete" ],
+    "visible" : false
+  }, {
+    "permissionName" : "invoice-storage.module.all",
+    "displayName" : "Invoice storage module - all permissions",
+    "description" : "Entire set of permissions needed to use the invoice module",
+    "subPermissions" : [ "invoice-storage.invoices.collection.get", "invoice-storage.invoices.item.get", "invoice-storage.invoices.item.post", "invoice-storage.invoices.item.put", "invoice-storage.invoices.item.delete", "invoice-storage.invoices.documents.collection.get", "invoice-storage.invoices.documents.item.get", "invoice-storage.invoices.documents.item.post", "invoice-storage.invoices.documents.item.delete", "invoice-storage.invoice-lines.collection.get", "invoice-storage.invoice-lines.item.get", "invoice-storage.invoice-lines.item.post", "invoice-storage.invoice-lines.item.put", "invoice-storage.invoice-lines.item.delete", "invoice-storage.invoice-number.get", "invoice-storage.invoice-line-number.get", "voucher-storage.module.all", "batch-group-storage.module.all", "batch-voucher-storage.module.all" ],
+    "visible" : false
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-invoice-storage:4.0.1",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    }, {
+      "name" : "DB_HOST",
+      "value" : "postgres"
+    }, {
+      "name" : "DB_PORT",
+      "value" : "5432"
+    }, {
+      "name" : "DB_USERNAME",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_PASSWORD",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_DATABASE",
+      "value" : "okapi_modules"
+    }, {
+      "name" : "DB_QUERYTIMEOUT",
+      "value" : "60000"
+    }, {
+      "name" : "DB_CHARSET",
+      "value" : "UTF-8"
+    }, {
+      "name" : "DB_MAXPOOLSIZE",
+      "value" : "5"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-kb-ebsco-java-3.5.3",
+  "name" : "kb-ebsco",
+  "requires" : [ {
+    "id" : "users",
+    "version" : "15.0"
+  } ],
+  "provides" : [ {
+    "id" : "eholdings",
+    "version" : "2.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/eholdings/kb-credentials",
+      "permissionsRequired" : [ "kb-ebsco.kb-credentials.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/eholdings/kb-credentials",
+      "permissionsRequired" : [ "kb-ebsco.kb-credentials.collection.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/eholdings/kb-credentials/{credentialsId}",
+      "permissionsRequired" : [ "kb-ebsco.kb-credentials.item.get" ]
+    }, {
+      "methods" : [ "PATCH" ],
+      "pathPattern" : "/eholdings/kb-credentials/{credentialsId}",
+      "permissionsRequired" : [ "kb-ebsco.kb-credentials.item.patch" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/eholdings/kb-credentials/{credentialsId}",
+      "permissionsRequired" : [ "kb-ebsco.kb-credentials.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/eholdings/kb-credentials/{credentialsId}",
+      "permissionsRequired" : [ "kb-ebsco.kb-credentials.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/eholdings/user-kb-credential",
+      "permissionsRequired" : [ "kb-ebsco.user-kb-credential.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/eholdings/kb-credentials/{credentialsId}/users",
+      "permissionsRequired" : [ "kb-ebsco.kb-credentials.users.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/eholdings/kb-credentials/{credentialsId}/users",
+      "permissionsRequired" : [ "kb-ebsco.kb-credentials.users.collection.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/eholdings/kb-credentials/{credentialsId}/users/{userId}",
+      "permissionsRequired" : [ "kb-ebsco.kb-credentials.users.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/eholdings/kb-credentials/{credentialsId}/users/{userId}",
+      "permissionsRequired" : [ "kb-ebsco.kb-credentials.users.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/eholdings/kb-credentials/{credentialsId}/custom-labels",
+      "permissionsRequired" : [ "kb-ebsco.kb-credentials.custom-labels.collection.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/eholdings/kb-credentials/{credentialsId}/custom-labels",
+      "permissionsRequired" : [ "kb-ebsco.kb-credentials.custom-labels.collection.put" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/eholdings/packages",
+      "permissionsRequired" : [ "kb-ebsco.packages.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/eholdings/packages/bulk/fetch",
+      "permissionsRequired" : [ "kb-ebsco.packages-bulk.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/eholdings/packages",
+      "permissionsRequired" : [ "kb-ebsco.packages.collection.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/eholdings/packages/{packageId}",
+      "permissionsRequired" : [ "kb-ebsco.packages.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/eholdings/packages/{packageId}",
+      "permissionsRequired" : [ "kb-ebsco.packages.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/eholdings/packages/{packageId}",
+      "permissionsRequired" : [ "kb-ebsco.packages.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/eholdings/packages/{packageId}/resources",
+      "permissionsRequired" : [ "kb-ebsco.package-resources.collection.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/eholdings/packages/{packageId}/tags",
+      "permissionsRequired" : [ "kb-ebsco.package-tags.put" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/eholdings/providers",
+      "permissionsRequired" : [ "kb-ebsco.providers.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/eholdings/providers/{providerId}",
+      "permissionsRequired" : [ "kb-ebsco.providers.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/eholdings/providers/{providerId}",
+      "permissionsRequired" : [ "kb-ebsco.providers.item.put" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/eholdings/providers/{providerId}/packages",
+      "permissionsRequired" : [ "kb-ebsco.provider-packages.collection.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/eholdings/providers/{providerId}/tags",
+      "permissionsRequired" : [ "kb-ebsco.provider-tags.put" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/eholdings/resources",
+      "permissionsRequired" : [ "kb-ebsco.resources.collection.post" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/eholdings/resources/bulk/fetch",
+      "permissionsRequired" : [ "kb-ebsco.resources-bulk.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/eholdings/resources/{resourceId}",
+      "permissionsRequired" : [ "kb-ebsco.resources.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/eholdings/resources/{resourceId}",
+      "permissionsRequired" : [ "kb-ebsco.resources.item.put" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/eholdings/resources/{resourceId}/tags",
+      "permissionsRequired" : [ "kb-ebsco.resource-tags.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/eholdings/resources/{resourceId}",
+      "permissionsRequired" : [ "kb-ebsco.resources.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/eholdings/titles",
+      "permissionsRequired" : [ "kb-ebsco.titles.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/eholdings/titles",
+      "permissionsRequired" : [ "kb-ebsco.titles.collection.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/eholdings/titles/{titleId}",
+      "permissionsRequired" : [ "kb-ebsco.titles.item.put" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/eholdings/titles/{titleId}",
+      "permissionsRequired" : [ "kb-ebsco.titles.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/eholdings/kb-credentials/{id}/proxy-types",
+      "permissionsRequired" : [ "kb-ebsco.kb-credentials.proxy-types.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/eholdings/proxy-types",
+      "permissionsRequired" : [ "kb-ebsco.proxy-types.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/eholdings/root-proxy",
+      "permissionsRequired" : [ "kb-ebsco.root-proxy.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/eholdings/kb-credentials/{id}/root-proxy",
+      "permissionsRequired" : [ "kb-ebsco.kb-credentials.root-proxy.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/eholdings/kb-credentials/{id}/root-proxy",
+      "permissionsRequired" : [ "kb-ebsco.kb-credentials.root-proxy.put" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/eholdings/configuration",
+      "permissionsRequired" : [ "kb-ebsco.configuration.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/eholdings/configuration",
+      "permissionsRequired" : [ "kb-ebsco.configuration.put" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/eholdings/status",
+      "permissionsRequired" : [ "kb-ebsco.status.get" ],
+      "modulePermissions" : [ "configuration.entries.collection.get" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/eholdings/cache",
+      "permissionsRequired" : [ "kb-ebsco.cache.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/eholdings/tags",
+      "permissionsRequired" : [ "kb-ebsco.tags.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/eholdings/tags/summary",
+      "permissionsRequired" : [ "kb-ebsco.unique.tags.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/eholdings/loading/kb-credentials",
+      "permissionsRequired" : [ "kb-ebsco.kb-credentials.holdings-load-all.post" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/eholdings/loading/kb-credentials/{id}",
+      "permissionsRequired" : [ "kb-ebsco.kb-credentials.holdings-load.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/eholdings/loading/kb-credentials/{credentialsId}/status",
+      "permissionsRequired" : [ "kb-ebsco.kb-credentials.holdings-load.status.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/eholdings/custom-labels",
+      "permissionsRequired" : [ "kb-ebsco.custom-labels.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/eholdings/access-types",
+      "permissionsRequired" : [ "kb-ebsco.access-types.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/eholdings/access-types/{accessTypeId}",
+      "permissionsRequired" : [ "kb-ebsco.access-types.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/eholdings/kb-credentials/{credentialsId}/access-types",
+      "permissionsRequired" : [ "kb-ebsco.kb-credentials.access-types.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/eholdings/kb-credentials/{credentialsId}/access-types",
+      "permissionsRequired" : [ "kb-ebsco.kb-credentials.access-types.collection.post" ],
+      "modulePermissions" : [ "users.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/eholdings/kb-credentials/{credentialsId}/access-types/{accessTypeId}",
+      "permissionsRequired" : [ "kb-ebsco.kb-credentials.access-types.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/eholdings/kb-credentials/{credentialsId}/access-types/{accessTypeId}",
+      "permissionsRequired" : [ "kb-ebsco.kb-credentials.access-types.item.put" ],
+      "modulePermissions" : [ "users.item.get" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/eholdings/kb-credentials/{credentialsId}/access-types/{accessTypeId}",
+      "permissionsRequired" : [ "kb-ebsco.kb-credentials.access-types.item.delete" ]
+    } ]
+  }, {
+    "id" : "_jsonSchemas",
+    "version" : "1.0",
+    "interfaceType" : "multiple",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/_/jsonSchemas",
+      "permissionsRequired" : [ ]
+    } ]
+  }, {
+    "id" : "_ramls",
+    "version" : "1.0",
+    "interfaceType" : "multiple",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/_/ramls",
+      "permissionsRequired" : [ ]
+    } ]
+  }, {
+    "id" : "_tenant",
+    "version" : "1.0",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST", "DELETE" ],
+      "pathPattern" : "/_/tenant"
+    } ]
+  }, {
+    "id" : "_timer",
+    "version" : "1.0",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/eholdings/loading/kb-credentials",
+      "unit" : "day",
+      "delay" : "5"
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "kb-ebsco.configuration.get",
+    "displayName" : "get RM API configuration",
+    "description" : "Get RM API configuration"
+  }, {
+    "permissionName" : "kb-ebsco.configuration.put",
+    "displayName" : "put RM API configuration",
+    "description" : "Put RM API configuration"
+  }, {
+    "permissionName" : "kb-ebsco.status.get",
+    "displayName" : "get RM API configuration status",
+    "description" : "Get RM API configuration status"
+  }, {
+    "permissionName" : "kb-ebsco.cache.delete",
+    "displayName" : "delete RM API configuration cache",
+    "description" : "Delete RM API configuration cache"
+  }, {
+    "permissionName" : "kb-ebsco.providers.collection.get",
+    "displayName" : "get providers",
+    "description" : "Get providers"
+  }, {
+    "permissionName" : "kb-ebsco.providers.item.get",
+    "displayName" : "get single provider",
+    "description" : "Get single provider"
+  }, {
+    "permissionName" : "kb-ebsco.providers.item.put",
+    "displayName" : "put single provider",
+    "description" : "Put single provider"
+  }, {
+    "permissionName" : "kb-ebsco.provider-tags.put",
+    "displayName" : "update tags for a single provider",
+    "description" : "Update tags for a single provider"
+  }, {
+    "permissionName" : "kb-ebsco.provider-packages.collection.get",
+    "displayName" : "get packages for a single provider",
+    "description" : "get packages for a single provider"
+  }, {
+    "permissionName" : "kb-ebsco.titles.item.get",
+    "displayName" : "get single title",
+    "description" : "Get single title"
+  }, {
+    "permissionName" : "kb-ebsco.titles.collection.get",
+    "displayName" : "get titles",
+    "description" : "Get titles"
+  }, {
+    "permissionName" : "kb-ebsco.titles.collection.post",
+    "displayName" : "post title",
+    "description" : "Post title"
+  }, {
+    "permissionName" : "kb-ebsco.titles.item.put",
+    "displayName" : "put single title",
+    "description" : "Put single title"
+  }, {
+    "permissionName" : "kb-ebsco.resources.item.get",
+    "displayName" : "get single resource",
+    "description" : "Get single resource"
+  }, {
+    "permissionName" : "kb-ebsco.resources.collection.post",
+    "displayName" : "post resource",
+    "description" : "Post resource"
+  }, {
+    "permissionName" : "kb-ebsco.resources.item.put",
+    "displayName" : "put single resource",
+    "description" : "Put single resource"
+  }, {
+    "permissionName" : "kb-ebsco.resources.item.delete",
+    "displayName" : "delete single resource",
+    "description" : "Delete single resource"
+  }, {
+    "permissionName" : "kb-ebsco.resource-tags.put",
+    "displayName" : "put tags to a single resource",
+    "description" : "Put tags to a single resource"
+  }, {
+    "permissionName" : "kb-ebsco.resources-bulk.collection.get",
+    "displayName" : "get resources collection with limited fields set",
+    "description" : "Get resources collection with limited fields set"
+  }, {
+    "permissionName" : "kb-ebsco.packages.collection.get",
+    "displayName" : "get packages",
+    "description" : "Get packages"
+  }, {
+    "permissionName" : "kb-ebsco.packages-bulk.collection.get",
+    "displayName" : "get packages collection with limited fields set",
+    "description" : "Get packages collection with limited fields set"
+  }, {
+    "permissionName" : "kb-ebsco.packages.item.get",
+    "displayName" : "get package",
+    "description" : "Get package"
+  }, {
+    "permissionName" : "kb-ebsco.packages.collection.post",
+    "displayName" : "post package",
+    "description" : "Post package"
+  }, {
+    "permissionName" : "kb-ebsco.packages.item.put",
+    "displayName" : "put package",
+    "description" : "Put package"
+  }, {
+    "permissionName" : "kb-ebsco.packages.item.delete",
+    "displayName" : "delete custom package",
+    "description" : "Delete custom package"
+  }, {
+    "permissionName" : "kb-ebsco.package-resources.collection.get",
+    "displayName" : "get resources for a single package",
+    "description" : "get resources for a single package"
+  }, {
+    "permissionName" : "kb-ebsco.package-tags.put",
+    "displayName" : "update tags for a single package",
+    "description" : "Update tags for a single package"
+  }, {
+    "permissionName" : "kb-ebsco.kb-credentials.proxy-types.collection.get",
+    "displayName" : "get proxy types collection by KB credentials",
+    "description" : "Get proxy types collection by KB credentials"
+  }, {
+    "permissionName" : "kb-ebsco.proxy-types.collection.get",
+    "displayName" : "get proxy types",
+    "description" : "Get proxy types"
+  }, {
+    "permissionName" : "kb-ebsco.kb-credentials.root-proxy.get",
+    "displayName" : "get root proxy by KB credentials",
+    "description" : "Get root proxy by KB credentials"
+  }, {
+    "permissionName" : "kb-ebsco.root-proxy.get",
+    "displayName" : "get root proxy",
+    "description" : "Get root proxy"
+  }, {
+    "permissionName" : "kb-ebsco.kb-credentials.root-proxy.put",
+    "displayName" : "put root proxy by KB credentials",
+    "description" : "Put root proxy by KB credentials"
+  }, {
+    "permissionName" : "kb-ebsco.tags.collection.get",
+    "displayName" : "get record tags",
+    "description" : "Get record tags"
+  }, {
+    "permissionName" : "kb-ebsco.unique.tags.collection.get",
+    "displayName" : "get record unique tags",
+    "description" : "Get record unique tags"
+  }, {
+    "permissionName" : "kb-ebsco.kb-credentials.holdings-load-all.post",
+    "displayName" : "permission to run load of holdings",
+    "description" : "One-time load of holdings"
+  }, {
+    "permissionName" : "kb-ebsco.kb-credentials.holdings-load.post",
+    "displayName" : "permission to run load of holdings for certain credentials",
+    "description" : "One-time load of holdings based on credentials"
+  }, {
+    "permissionName" : "kb-ebsco.kb-credentials.holdings-load.status.item.get",
+    "displayName" : "get current status of holdings loading by credentials id",
+    "description" : "Get current status of holdings loading by credentials id"
+  }, {
+    "permissionName" : "kb-ebsco.custom-labels.collection.get",
+    "displayName" : "get Custom Labels collection",
+    "description" : "Get Custom Labels collection"
+  }, {
+    "permissionName" : "kb-ebsco.kb-credentials.custom-labels.collection.get",
+    "displayName" : "get Custom Labels collection related to kb credentials",
+    "description" : "Get Custom Labels collection related to KB Credentials"
+  }, {
+    "permissionName" : "kb-ebsco.kb-credentials.custom-labels.collection.put",
+    "displayName" : "put Custom Labels collection related to kb credentials",
+    "description" : "Put Custom Labels collection related to KB Credentials"
+  }, {
+    "permissionName" : "kb-ebsco.access-types.collection.get",
+    "displayName" : "get Access Types collection",
+    "description" : "Get Access Types collection"
+  }, {
+    "permissionName" : "kb-ebsco.access-types.item.get",
+    "displayName" : "get Access Type collection item",
+    "description" : "Get Access Type collection item"
+  }, {
+    "permissionName" : "kb-ebsco.kb-credentials.access-types.collection.get",
+    "displayName" : "get Access Types collection by kb credentials",
+    "description" : "Get Access Types collection KB credentials"
+  }, {
+    "permissionName" : "kb-ebsco.kb-credentials.access-types.collection.post",
+    "displayName" : "post Access Type collection item",
+    "description" : "Post Access Type collection item"
+  }, {
+    "permissionName" : "kb-ebsco.kb-credentials.access-types.item.get",
+    "displayName" : "get Access Type collection item",
+    "description" : "Get Access Type collection item"
+  }, {
+    "permissionName" : "kb-ebsco.kb-credentials.access-types.item.put",
+    "displayName" : "put Access Type collection item",
+    "description" : "Put Access Type collection item"
+  }, {
+    "permissionName" : "kb-ebsco.kb-credentials.access-types.item.delete",
+    "displayName" : "delete Access Type collection item",
+    "description" : "Delete Access Type collection item"
+  }, {
+    "permissionName" : "kb-ebsco.kb-credentials.collection.get",
+    "displayName" : "get KB credentials collection",
+    "description" : "Get KB credentials collection"
+  }, {
+    "permissionName" : "kb-ebsco.kb-credentials.collection.post",
+    "displayName" : "post KB credentials",
+    "description" : "Post KB credentials"
+  }, {
+    "permissionName" : "kb-ebsco.kb-credentials.item.get",
+    "displayName" : "get KB credentials collection item",
+    "description" : "Get KB credentials collection item"
+  }, {
+    "permissionName" : "kb-ebsco.kb-credentials.item.patch",
+    "displayName" : "patch KB credentials collection item",
+    "description" : "Patch KB credentials collection item"
+  }, {
+    "permissionName" : "kb-ebsco.kb-credentials.item.put",
+    "displayName" : "put KB credentials collection item",
+    "description" : "Put KB credentials collection item"
+  }, {
+    "permissionName" : "kb-ebsco.kb-credentials.item.delete",
+    "displayName" : "delete KB credentials collection item",
+    "description" : "Delete KB credentials collection item"
+  }, {
+    "permissionName" : "kb-ebsco.kb-credentials.all",
+    "displayName" : "EBSCO KB Broker Credentials - all permissions",
+    "description" : "All permissions for managing EBSCO KB Credentials",
+    "subPermissions" : [ "kb-ebsco.kb-credentials.collection.get", "kb-ebsco.kb-credentials.collection.post", "kb-ebsco.kb-credentials.item.get", "kb-ebsco.kb-credentials.item.patch", "kb-ebsco.kb-credentials.item.put", "kb-ebsco.kb-credentials.item.delete", "kb-ebsco.kb-credentials.custom-labels.collection.get", "kb-ebsco.kb-credentials.custom-labels.collection.put", "kb-ebsco.kb-credentials.proxy-types.collection.get", "kb-ebsco.kb-credentials.root-proxy.get", "kb-ebsco.kb-credentials.root-proxy.put", "kb-ebsco.kb-credentials.access-types.collection.get", "kb-ebsco.kb-credentials.access-types.collection.post", "kb-ebsco.kb-credentials.access-types.item.get", "kb-ebsco.kb-credentials.access-types.item.put", "kb-ebsco.kb-credentials.access-types.item.delete" ]
+  }, {
+    "permissionName" : "kb-ebsco.kb-credentials.users.collection.get",
+    "displayName" : "get assigned users to KB credentials",
+    "description" : "Get assigned users to KB credentials"
+  }, {
+    "permissionName" : "kb-ebsco.kb-credentials.users.collection.post",
+    "displayName" : "post assigned users to KB credentials",
+    "description" : "Post assigned users to KB credentials"
+  }, {
+    "permissionName" : "kb-ebsco.kb-credentials.users.item.delete",
+    "displayName" : "delete association between user and KB credentials",
+    "description" : "delete association between user and KB credentials"
+  }, {
+    "permissionName" : "kb-ebsco.kb-credentials.users.item.put",
+    "displayName" : "put assigned users collection item",
+    "description" : "Put assigned users collection item"
+  }, {
+    "permissionName" : "kb-ebsco.kb-credentials.users.all",
+    "displayName" : "EBSCO KB Broker users assigned to credentials - all permissions",
+    "description" : "All permissions for manging users assigned to EBSCO KB Credentials",
+    "subPermissions" : [ "kb-ebsco.kb-credentials.users.collection.get", "kb-ebsco.kb-credentials.users.collection.post", "kb-ebsco.kb-credentials.users.item.put", "kb-ebsco.kb-credentials.users.item.delete" ]
+  }, {
+    "permissionName" : "kb-ebsco.all",
+    "displayName" : "EBSCO KB Broker - all permissions",
+    "description" : "All permissions for EBSCO KB module",
+    "subPermissions" : [ "kb-ebsco.kb-credentials.all", "kb-ebsco.kb-credentials.users.all", "kb-ebsco.configuration.get", "kb-ebsco.configuration.put", "kb-ebsco.status.get", "kb-ebsco.cache.delete", "kb-ebsco.providers.collection.get", "kb-ebsco.providers.item.get", "kb-ebsco.providers.item.put", "kb-ebsco.provider-packages.collection.get", "kb-ebsco.provider-tags.put", "kb-ebsco.titles.collection.get", "kb-ebsco.titles.collection.post", "kb-ebsco.titles.item.put", "kb-ebsco.packages.collection.get", "kb-ebsco.packages-bulk.collection.get", "kb-ebsco.packages.collection.post", "kb-ebsco.packages.item.delete", "kb-ebsco.package-resources.collection.get", "kb-ebsco.package-tags.put", "kb-ebsco.titles.item.get", "kb-ebsco.packages.item.get", "kb-ebsco.packages.item.put", "kb-ebsco.resources.item.get", "kb-ebsco.resources.collection.post", "kb-ebsco.resources-bulk.collection.get", "kb-ebsco.resources.item.put", "kb-ebsco.resources.item.delete", "kb-ebsco.resource-tags.put", "kb-ebsco.proxy-types.collection.get", "kb-ebsco.root-proxy.get", "kb-ebsco.tags.collection.get", "kb-ebsco.unique.tags.collection.get", "kb-ebsco.kb-credentials.holdings-load.status.item.get", "kb-ebsco.custom-labels.collection.get", "kb-ebsco.access-types.collection.get", "kb-ebsco.access-types.item.get" ]
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-kb-ebsco-java:3.5.3",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    }, {
+      "name" : "DB_HOST",
+      "value" : "postgres"
+    }, {
+      "name" : "DB_PORT",
+      "value" : "5432"
+    }, {
+      "name" : "DB_USERNAME",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_PASSWORD",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_DATABASE",
+      "value" : "okapi_modules"
+    }, {
+      "name" : "DB_QUERYTIMEOUT",
+      "value" : "60000"
+    }, {
+      "name" : "DB_CHARSET",
+      "value" : "UTF-8"
+    }, {
+      "name" : "DB_MAXPOOLSIZE",
+      "value" : "5"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-licenses-2.2.3",
+  "name" : "mod-licenses",
+  "provides" : [ {
+    "id" : "licenses",
+    "version" : "2.2",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/licenses/licenses",
+      "permissionsRequired" : [ "licenses.licenses.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/licenses/licenses/{id}",
+      "permissionsRequired" : [ "licenses.licenses.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/licenses/licenses/{id}/linkedAgreements",
+      "permissionsRequired" : [ "licenses.licenses.item.linkedAgreements.get", "licenses.agreements.linkedLicenses.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/licenses/licenses",
+      "permissionsRequired" : [ "licenses.licenses.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/licenses/licenses/{id}",
+      "permissionsRequired" : [ "licenses.licenses.item.put" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/licenses/licenses/{id}/clone",
+      "permissionsRequired" : [ "licenses.licenses.item.clone" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/licenses/licenses/{id}",
+      "permissionsRequired" : [ "licenses.licenses.item.delete" ],
+      "modulePermissions" : [ "erm.agreements.linkedLicenses.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/licenses/files",
+      "permissionsRequired" : [ "licenses.files.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/licenses/files/{id}",
+      "permissionsRequired" : [ "licenses.files.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/licenses/files/{id}/*",
+      "permissionsRequired" : [ "licenses.files.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/licenses/files",
+      "permissionsRequired" : [ "licenses.files.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/licenses/files/{id}",
+      "permissionsRequired" : [ "licenses.files.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/licenses/files/{id}",
+      "permissionsRequired" : [ "licenses.files.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/licenses/contacts",
+      "permissionsRequired" : [ "licenses.contacts.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/licenses/contacts/{id}",
+      "permissionsRequired" : [ "licenses.contacts.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/licenses/org",
+      "permissionsRequired" : [ "licenses.orgs.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/licenses/org/{id}",
+      "permissionsRequired" : [ "licenses.orgs.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/licenses/refdata",
+      "permissionsRequired" : [ "licenses.refdata.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/licenses/refdata/{domain}/{property}",
+      "permissionsRequired" : [ "licenses.refdata.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/licenses/refdata/{id}",
+      "permissionsRequired" : [ "licenses.refdata.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/licenses/refdata",
+      "permissionsRequired" : [ "licenses.refdata.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/licenses/refdata/{id}",
+      "permissionsRequired" : [ "licenses.refdata.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/licenses/refdata/{id}",
+      "permissionsRequired" : [ "licenses.refdata.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/licenses/custprops",
+      "permissionsRequired" : [ "licenses.custprops.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/licenses/custprops/{id}",
+      "permissionsRequired" : [ "licenses.custprops.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/licenses/custprops",
+      "permissionsRequired" : [ "licenses.custprops.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/licenses/custprops/{id}",
+      "permissionsRequired" : [ "licenses.custprops.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/licenses/custprops/{id}",
+      "permissionsRequired" : [ "licenses.custprops.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/licenses/licenseLinks",
+      "permissionsRequired" : [ "licenses.licenseLinks.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/licenses/licenseLinks/{id}",
+      "permissionsRequired" : [ "licenses.licenseLinks.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/licenses/licenses/compareTerms",
+      "permissionsRequired" : [ "licenses.compareTerms" ]
+    } ]
+  }, {
+    "id" : "_tenant",
+    "version" : "1.2",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST", "DELETE" ],
+      "pathPattern" : "/_/tenant"
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/_/tenant/disable"
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "licenses.licenses.view",
+    "subPermissions" : [ "licenses.licenses.collection.get", "licenses.licenses.item.get", "licenses.licenses.item.linkedAgreements.get", "licenses.agreements.linkedLicenses.get", "licenses.compareTerms" ]
+  }, {
+    "permissionName" : "licenses.licenses.edit",
+    "subPermissions" : [ "licenses.licenses.view", "licenses.licenses.item.post", "licenses.licenses.item.put", "licenses.licenses.item.clone" ]
+  }, {
+    "permissionName" : "licenses.licenses.manage",
+    "subPermissions" : [ "licenses.licenses.edit", "licenses.licenses.item.delete" ]
+  }, {
+    "permissionName" : "licenses.files.view",
+    "subPermissions" : [ "licenses.files.collection.get", "licenses.files.item.get" ]
+  }, {
+    "permissionName" : "licenses.files.edit",
+    "subPermissions" : [ "licenses.files.view", "licenses.files.item.post", "licenses.files.item.put" ]
+  }, {
+    "permissionName" : "licenses.files.manage",
+    "subPermissions" : [ "licenses.files.edit", "licenses.files.item.delete" ]
+  }, {
+    "permissionName" : "licenses.contacts.view",
+    "subPermissions" : [ "licenses.contacts.collection.get", "licenses.contacts.item.get" ]
+  }, {
+    "permissionName" : "licenses.orgs.view",
+    "subPermissions" : [ "licenses.orgs.collection.get", "licenses.orgs.item.get" ]
+  }, {
+    "permissionName" : "licenses.refdata.view",
+    "subPermissions" : [ "licenses.refdata.collection.get", "licenses.refdata.item.get" ]
+  }, {
+    "permissionName" : "licenses.refdata.edit",
+    "subPermissions" : [ "licenses.refdata.view", "licenses.refdata.item.post", "licenses.refdata.item.put" ]
+  }, {
+    "permissionName" : "licenses.refdata.manage",
+    "subPermissions" : [ "licenses.refdata.edit", "licenses.refdata.item.delete" ]
+  }, {
+    "permissionName" : "licenses.contacts.view",
+    "subPermissions" : [ "licenses.contacts.collection.get", "licenses.contacts.item.get" ]
+  }, {
+    "permissionName" : "licenses.licenseLinks.view",
+    "subPermissions" : [ "licenses.licenseLinks.collection.get", "licenses.licenseLinks.item.get" ]
+  }, {
+    "permissionName" : "licenses.custprops.view",
+    "subPermissions" : [ "licenses.custprops.collection.get", "licenses.custprops.item.get" ]
+  }, {
+    "permissionName" : "licenses.custprops.edit",
+    "subPermissions" : [ "licenses.custprops.view", "licenses.custprops.item.post", "licenses.custprops.item.put" ]
+  }, {
+    "permissionName" : "licenses.custprops.manage",
+    "subPermissions" : [ "licenses.custprops.edit", "licenses.custprops.item.delete" ]
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-licenses:2.2.3",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-server -XX:+UseContainerSupport -XX:MaxRAMPercentage=50.0 -XX:+PrintFlagsFinal"
+    }, {
+      "name" : "DB_HOST",
+      "value" : "postgres"
+    }, {
+      "name" : "DB_PORT",
+      "value" : "5432"
+    }, {
+      "name" : "DB_USERNAME",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_PASSWORD",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_DATABASE",
+      "value" : "okapi_modules"
+    }, {
+      "name" : "DB_MAXPOOLSIZE",
+      "value" : "50"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 805306368,
+        "PortBindings" : {
+          "8080/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-login-7.0.1",
+  "name" : "login",
+  "requires" : [ {
+    "id" : "users",
+    "version" : "15.0"
+  } ],
+  "provides" : [ {
+    "id" : "login",
+    "version" : "7.0",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/authn/log/events",
+      "permissionsRequired" : [ "login.event.collection.post" ],
+      "modulePermissions" : [ "users.collection.get", "configuration.entries.collection.get", "configuration.entries.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/authn/log/events",
+      "permissionsRequired" : [ "login.event.collection.get" ],
+      "modulePermissions" : [ "configuration.entries.item.get" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/authn/log/events/{id}",
+      "permissionsRequired" : [ "login.event.delete" ],
+      "modulePermissions" : [ "configuration.entries.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/authn/login",
+      "permissionsRequired" : [ ],
+      "modulePermissions" : [ "auth.signtoken", "auth.signrefreshtoken", "users.collection.get", "users.item.put", "users.item.get", "configuration.entries.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/authn/loginAttempts/{id}",
+      "permissionsRequired" : [ "login.attempts.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/authn/credentials",
+      "permissionsRequired" : [ "login.item.post" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/authn/credentials",
+      "permissionsRequired" : [ "login.item.delete" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/authn/update",
+      "permissionsRequired" : [ ],
+      "modulePermissions" : [ "users.collection.get", "configuration.entries.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/authn/password/repeatable",
+      "permissionsRequired" : [ "login.password.validate" ],
+      "modulePermissions" : [ "configuration.entries.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/authn/password-reset-action",
+      "permissionsRequired" : [ "login.password-reset-action.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/authn/password-reset-action/{actionId}",
+      "permissionsRequired" : [ "login.password-reset-action.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/authn/reset-password",
+      "permissionsRequired" : [ "login.password-reset.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/authn/credentials-existence",
+      "permissionsRequired" : [ "login.credentials-existence.get" ]
+    } ]
+  }, {
+    "id" : "_tenant",
+    "version" : "1.2",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST", "DELETE" ],
+      "pathPattern" : "/_/tenant"
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "login.item.post",
+    "displayName" : "login item post",
+    "description" : "Add New Login"
+  }, {
+    "permissionName" : "login.item.delete",
+    "displayName" : "login item delete",
+    "description" : "Remove existing login credentials"
+  }, {
+    "permissionName" : "login.attempts.item.get",
+    "displayName" : "login attempt item get",
+    "description" : "Read a login attempt entity for user"
+  }, {
+    "permissionName" : "login.password.validate",
+    "displayName" : "login password validate",
+    "description" : "Validate password for repeatability"
+  }, {
+    "permissionName" : "login.password-reset-action.post",
+    "displayName" : "login create a new action",
+    "description" : "Saves action to storage"
+  }, {
+    "permissionName" : "login.password-reset-action.get",
+    "displayName" : "login get the action by id",
+    "description" : "Retrieves action record by id"
+  }, {
+    "permissionName" : "login.password-reset.post",
+    "displayName" : "login password reset",
+    "description" : "Resets password for user in record and deletes action record"
+  }, {
+    "permissionName" : "login.event.collection.post",
+    "displayName" : "login save log event",
+    "description" : "Saves received event into the storage"
+  }, {
+    "permissionName" : "login.event.collection.get",
+    "displayName" : "login get a list of events",
+    "description" : "Get a list of events from storage"
+  }, {
+    "permissionName" : "login.event.delete",
+    "displayName" : "login delete event",
+    "description" : "Delete log event"
+  }, {
+    "permissionName" : "login.credentials-existence.get",
+    "displayName" : "Credentials existence get",
+    "description" : "Get credentials existence"
+  }, {
+    "permissionName" : "login.all",
+    "displayName" : "login credentials",
+    "description" : "All permissions for login credentials",
+    "subPermissions" : [ "login.item.post", "login.item.delete", "login.attempts.item.get", "login.password.validate", "login.password-reset-action.get", "login.password-reset-action.post", "login.password-reset.post", "login.password.validate", "login.event.collection.post", "login.event.collection.get", "login.event.delete", "login.credentials-existence.get" ]
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-login:7.0.1",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    }, {
+      "name" : "DB_HOST",
+      "value" : "postgres"
+    }, {
+      "name" : "DB_PORT",
+      "value" : "5432"
+    }, {
+      "name" : "DB_USERNAME",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_PASSWORD",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_DATABASE",
+      "value" : "okapi_modules"
+    }, {
+      "name" : "DB_QUERYTIMEOUT",
+      "value" : "60000"
+    }, {
+      "name" : "DB_CHARSET",
+      "value" : "UTF-8"
+    }, {
+      "name" : "DB_MAXPOOLSIZE",
+      "value" : "5"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    },
+    "dockerCMD" : [ "verify.user=true" ]
+  }
+}, {
+  "id" : "mod-login-saml-2.0.1",
+  "name" : "SAML login",
+  "requires" : [ {
+    "id" : "authtoken",
+    "version" : "1.0 2.0"
+  }, {
+    "id" : "users",
+    "version" : "14.0 15.0"
+  }, {
+    "id" : "configuration",
+    "version" : "2.0"
+  } ],
+  "provides" : [ {
+    "id" : "login-saml",
+    "version" : "2.0",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/saml/login",
+      "permissionsRequired" : [ ],
+      "modulePermissions" : [ "configuration.entries.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/saml/callback",
+      "permissionsRequired" : [ ],
+      "modulePermissions" : [ "auth.signtoken", "configuration.entries.collection.get", "users.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/saml/regenerate",
+      "permissionsRequired" : [ "login-saml.regenerate" ],
+      "modulePermissions" : [ "configuration.entries.collection.get", "configuration.entries.item.post", "configuration.entries.item.put" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/saml/check",
+      "permissionsRequired" : [ ],
+      "modulePermissions" : [ "configuration.entries.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/saml/configuration",
+      "permissionsRequired" : [ "login-saml.configuration.get" ],
+      "modulePermissions" : [ "configuration.entries.collection.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/saml/configuration",
+      "permissionsRequired" : [ "login-saml.configuration.put" ],
+      "modulePermissions" : [ "configuration.entries.collection.get", "configuration.entries.item.post", "configuration.entries.item.put" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/saml/validate",
+      "permissionsRequired" : [ ]
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "login-saml.regenerate",
+    "displayName" : "SAML sp-metadata regeneration",
+    "description" : ""
+  }, {
+    "permissionName" : "login-saml.configuration.get",
+    "displayName" : "SAML configuration: view",
+    "description" : "Grants the ability to view SAML configuration",
+    "visible" : true
+  }, {
+    "permissionName" : "login-saml.configuration.put",
+    "displayName" : "SAML configuration: modify",
+    "description" : "Grants the ability to modify SAML configuration",
+    "visible" : true
+  }, {
+    "permissionName" : "login-saml.all",
+    "displayName" : "Login-SAML: administration",
+    "description" : "",
+    "subPermissions" : [ "login-saml.regenerate", "login-saml.configuration.get", "login-saml.configuration.put" ],
+    "visible" : true
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-login-saml:2.0.1",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-ncip-1.4.2",
+  "name" : "NCIP",
+  "requires" : [ {
+    "id" : "instance-types",
+    "version" : "2.0"
+  }, {
+    "id" : "configuration",
+    "version" : "2.0"
+  }, {
+    "id" : "identifier-types",
+    "version" : "1.2"
+  }, {
+    "id" : "material-types",
+    "version" : "2.2"
+  }, {
+    "id" : "locations",
+    "version" : "3.0"
+  }, {
+    "id" : "service-points",
+    "version" : "3.2"
+  }, {
+    "id" : "loan-types",
+    "version" : "2.2"
+  }, {
+    "id" : "holdings-storage",
+    "version" : "4.0"
+  }, {
+    "id" : "inventory",
+    "version" : "10.2"
+  }, {
+    "id" : "circulation",
+    "version" : "9.2"
+  } ],
+  "provides" : [ {
+    "id" : "ncip",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/ncip",
+      "permissionsRequired" : [ "ncip.post" ],
+      "modulePermissions" : [ "users.collection.get", "automated-patron-blocks.collection.get", "addresstypes.collection.get", "circulation.requests.item.post", "ui-circulation.settings.overdue-fines-policies", "ui-circulation.settings.lost-item-fees-policies", "inventory-storage.all", "inventory-storage.items.collection.get", "inventory-storage.service-points.collection.get", "inventory-storage.instance-types.collection.get", "inventory-storage.identifier-types.collection.get", "inventory-storage.material-types.collection.get", "inventory-storage.loan-types.collection.get", "inventory-storage.locations.collection.get", "configuration.entries.collection.get", "configuration.entries.item.get", "usergroups.item.get", "manualblocks.collection.get", "accounts.collection.get", "circulation.check-out-by-barcode.post", "circulation.check-in-by-barcode.post", "circulation.loans.collection.get", "inventory.instances.item.post", "inventory-storage.holdings.item.delete", "inventory.items.item.delete", "inventory.instances.item.delete", "inventory-storage.holdings.item.post", "inventory-storage.service-points-users.collection.get", "inventory.items.item.post", "inventory-storage.service-points.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/ncipconfigcheck",
+      "permissionsRequired" : [ "ncip.ncipconfigcheck.get" ],
+      "modulePermissions" : [ "inventory-storage.all", "inventory-storage.service-points.collection.get", "inventory-storage.instance-types.collection.get", "inventory-storage.identifier-types.collection.get", "inventory-storage.material-types.collection.get", "configuration.entries.collection.get", "configuration.entries.item.get", "inventory-storage.loan-types.collection.get" ]
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "ncip.post",
+    "displayName" : "NCIP Request",
+    "description" : "Post NCIP request"
+  }, {
+    "permissionName" : "ncip.ncipconfigcheck.get",
+    "displayName" : "NCIP - configuration check",
+    "description" : "Check NCIP configuraitons"
+  }, {
+    "permissionName" : "ncip.all",
+    "displayName" : "NCIP - all permissions",
+    "description" : "Entire set of permissions needed to use NCIP",
+    "subPermissions" : [ "ncip.post", "ncip.ncipconfigcheck.get" ]
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-ncip:1.4.2",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-notes-2.9.0",
+  "name" : "Notes",
+  "requires" : [ {
+    "id" : "users",
+    "version" : "15.1"
+  }, {
+    "id" : "configuration",
+    "version" : "2.0"
+  } ],
+  "provides" : [ {
+    "id" : "notes",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/notes",
+      "permissionsRequired" : [ "notes.collection.get", "notes.domain.all" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/notes",
+      "permissionsRequired" : [ "notes.item.post", "notes.domain.all" ],
+      "modulePermissions" : [ "users.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/notes/{id}",
+      "permissionsRequired" : [ "notes.item.get", "notes.domain.all" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/notes/{id}",
+      "permissionsRequired" : [ "notes.item.put", "notes.domain.all" ],
+      "modulePermissions" : [ "users.item.get" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/notes/{id}",
+      "permissionsRequired" : [ "notes.item.delete", "notes.domain.all" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/note-types",
+      "permissionsRequired" : [ "note.types.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/note-types/{typeId}",
+      "permissionsRequired" : [ "note.types.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/note-types",
+      "permissionsRequired" : [ "note.types.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/note-types/{id}",
+      "permissionsRequired" : [ "note.types.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/note-types/{id}",
+      "permissionsRequired" : [ "note.types.item.delete" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/note-links/type/{type}/id/{id}",
+      "permissionsRequired" : [ "note.links.collection.put" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/note-links/domain/{domain}/type/{type}/id/{id}",
+      "permissionsRequired" : [ "notes.collection.get.by.status" ]
+    } ]
+  }, {
+    "id" : "_jsonSchemas",
+    "version" : "1.0",
+    "interfaceType" : "multiple",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/_/jsonSchemas",
+      "permissionsRequired" : [ ]
+    } ]
+  }, {
+    "id" : "_ramls",
+    "version" : "1.0",
+    "interfaceType" : "multiple",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/_/ramls",
+      "permissionsRequired" : [ ]
+    } ]
+  }, {
+    "id" : "_tenant",
+    "version" : "1.0",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/_/tenant"
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/_/tenant"
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "notes.collection.get",
+    "displayName" : "Notes - get notes collection",
+    "description" : "Get notes collection"
+  }, {
+    "permissionName" : "notes.item.get",
+    "displayName" : "Notes - get individual note from storage",
+    "description" : "Get individual note"
+  }, {
+    "permissionName" : "notes.item.post",
+    "displayName" : "Notes - create note",
+    "description" : "Create note"
+  }, {
+    "permissionName" : "notes.item.put",
+    "displayName" : "Notes - modify note",
+    "description" : "Modify note"
+  }, {
+    "permissionName" : "notes.item.delete",
+    "displayName" : "Notes - delete note",
+    "description" : "Delete note"
+  }, {
+    "permissionName" : "notes.domain.all",
+    "displayName" : "Notes - allow access to all domains",
+    "description" : "All domains"
+  }, {
+    "permissionName" : "note.types.item.get",
+    "displayName" : "Note types - get individual note type from storage",
+    "description" : "Get individual note type"
+  }, {
+    "permissionName" : "note.types.item.post",
+    "displayName" : "Note types - create note type",
+    "description" : "Create note type"
+  }, {
+    "permissionName" : "note.types.item.put",
+    "displayName" : "Note types - modify note type",
+    "description" : "Modify note type"
+  }, {
+    "permissionName" : "note.types.item.delete",
+    "displayName" : "Note types - delete note type",
+    "description" : "Delete note type"
+  }, {
+    "permissionName" : "note.links.collection.put",
+    "displayName" : "Note links - update note links",
+    "description" : "Update note links"
+  }, {
+    "permissionName" : "notes.collection.get.by.status",
+    "displayName" : "Notes - get notes collection sorted by status",
+    "description" : "Get notes collection by status and domain"
+  }, {
+    "permissionName" : "notes.allops",
+    "displayName" : "Notes module - all CRUD permissions",
+    "description" : "Entire set of permissions needed to use the notes modules, but no domain permissions",
+    "subPermissions" : [ "notes.collection.get", "notes.item.get", "notes.item.post", "notes.item.put", "notes.item.delete", "note.links.collection.put", "notes.collection.get.by.status" ],
+    "visible" : false
+  }, {
+    "permissionName" : "note.types.allops",
+    "displayName" : "Note types - all CRUD permissions",
+    "description" : "Entire set of permissions needed to use the note type for note module",
+    "subPermissions" : [ "note.types.item.get", "note.types.collection.get", "note.types.item.post", "note.types.item.put", "note.types.item.delete" ],
+    "visible" : false
+  }, {
+    "permissionName" : "notes.all",
+    "displayName" : "Notes module - all permissions and all domains",
+    "description" : "Entire set of permissions needed to use the notes modules on any domain",
+    "subPermissions" : [ "notes.allops", "notes.domain.all", "note.types.allops" ],
+    "visible" : false
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-notes:2.9.0",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    }, {
+      "name" : "DB_HOST",
+      "value" : "postgres"
+    }, {
+      "name" : "DB_PORT",
+      "value" : "5432"
+    }, {
+      "name" : "DB_USERNAME",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_PASSWORD",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_DATABASE",
+      "value" : "okapi_modules"
+    }, {
+      "name" : "DB_QUERYTIMEOUT",
+      "value" : "60000"
+    }, {
+      "name" : "DB_CHARSET",
+      "value" : "UTF-8"
+    }, {
+      "name" : "DB_MAXPOOLSIZE",
+      "value" : "5"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-notify-2.6.0",
+  "name" : "Notify",
+  "requires" : [ {
+    "id" : "users",
+    "version" : "15.0"
+  }, {
+    "id" : "mod-event",
+    "version" : "1.0"
+  }, {
+    "id" : "template-engine",
+    "version" : "2.0"
+  }, {
+    "id" : "message-delivery",
+    "version" : "1.0"
+  } ],
+  "provides" : [ {
+    "id" : "notify",
+    "version" : "2.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/notify",
+      "permissionsRequired" : [ "notify.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/notify",
+      "permissionsRequired" : [ "notify.item.post" ],
+      "modulePermissions" : [ "event.config.collection.get", "template-request.post", "sender.message-delivery" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/notify/_username/{uid}",
+      "permissionsRequired" : [ "notify.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/notify/{id}",
+      "permissionsRequired" : [ "notify.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/notify/{id}",
+      "permissionsRequired" : [ "notify.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/notify/{id}",
+      "permissionsRequired" : [ "notify.item.delete" ]
+    } ]
+  }, {
+    "id" : "patron-notice",
+    "version" : "1.1",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/patron-notice",
+      "permissionsRequired" : [ "patron-notice.post" ],
+      "modulePermissions" : [ "template-request.post", "sender.message-delivery" ]
+    } ]
+  }, {
+    "id" : "_jsonSchemas",
+    "version" : "1.0",
+    "interfaceType" : "multiple",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/_/jsonSchemas",
+      "permissionsRequired" : [ ]
+    } ]
+  }, {
+    "id" : "_ramls",
+    "version" : "1.0",
+    "interfaceType" : "multiple",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/_/ramls",
+      "permissionsRequired" : [ ]
+    } ]
+  }, {
+    "id" : "_tenant",
+    "version" : "1.0",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/_/tenant"
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/_/tenant"
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "notify.collection.get",
+    "displayName" : "Notifications - get notify collection",
+    "description" : "Get notify collection"
+  }, {
+    "permissionName" : "notify.item.get",
+    "displayName" : "Notifications- get individual notification from storage",
+    "description" : "Get individual notification"
+  }, {
+    "permissionName" : "notify.item.post",
+    "displayName" : "Notifications - create notification",
+    "description" : "Create notification"
+  }, {
+    "permissionName" : "notify.item.put",
+    "displayName" : "Notifications - modify notification",
+    "description" : "Modify notification"
+  }, {
+    "permissionName" : "notify.item.delete",
+    "displayName" : "Notifications - delete notification",
+    "description" : "Delete notification"
+  }, {
+    "permissionName" : "patron-notice.post",
+    "displayName" : "Patron Notice",
+    "description" : "Post Patron Notice"
+  }, {
+    "permissionName" : "notify.all",
+    "displayName" : "Notifications module - all permissions",
+    "description" : "Entire set of permissions needed to use the notify modules",
+    "subPermissions" : [ "notify.collection.get", "notify.item.get", "notify.item.post", "notify.item.put", "notify.item.delete" ],
+    "visible" : false
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-notify:2.6.0",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    }, {
+      "name" : "DB_HOST",
+      "value" : "postgres"
+    }, {
+      "name" : "DB_PORT",
+      "value" : "5432"
+    }, {
+      "name" : "DB_USERNAME",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_PASSWORD",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_DATABASE",
+      "value" : "okapi_modules"
+    }, {
+      "name" : "DB_QUERYTIMEOUT",
+      "value" : "60000"
+    }, {
+      "name" : "DB_CHARSET",
+      "value" : "UTF-8"
+    }, {
+      "name" : "DB_MAXPOOLSIZE",
+      "value" : "5"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-oai-pmh-3.1.3",
+  "name" : "OAI-PMH Repository Module",
+  "requires" : [ {
+    "id" : "instance-storage",
+    "version" : "6.0 7.0"
+  }, {
+    "id" : "source-storage-records",
+    "version" : "2.0"
+  }, {
+    "id" : "source-storage-source-records",
+    "version" : "2.0"
+  }, {
+    "id" : "configuration",
+    "version" : "2.0"
+  }, {
+    "id" : "oaipmhview",
+    "version" : "1.1"
+  } ],
+  "provides" : [ {
+    "id" : "oai-pmh",
+    "version" : "3.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/oai/records",
+      "permissionsRequired" : [ "oai-pmh.records.collection.get" ],
+      "modulePermissions" : [ "inventory-storage.instances.collection.get", "inventory-storage.instances.item.get", "inventory-storage.instances.source-record.marc-json.get", "source-storage.records.get", "source-storage.sourceRecords.get", "configuration.entries.collection.get", "inventory-storage.oai-pmh-view.instances.collection.get", "inventory-storage.oai-pmh-view.updatedinstanceids.collection.get", "inventory-storage.oai-pmh-view.enrichedinstances.collection.post" ]
+    } ]
+  }, {
+    "id" : "_tenant",
+    "version" : "1.2",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/_/tenant",
+      "modulePermissions" : [ "configuration.entries.collection.get", "configuration.entries.item.post" ]
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "oai-pmh.records.collection.get",
+    "displayName" : "OAI-PMH - get list of records",
+    "description" : "Get records from repository"
+  }, {
+    "permissionName" : "oai-pmh.all",
+    "displayName" : "OAI-PMH - all permissions",
+    "description" : "Entire set of permissions needed to use OAI-PMH",
+    "subPermissions" : [ "oai-pmh.records.collection.get" ]
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-oai-pmh:3.1.3",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    }, {
+      "name" : "DB_HOST",
+      "value" : "postgres"
+    }, {
+      "name" : "DB_PORT",
+      "value" : "5432"
+    }, {
+      "name" : "DB_USERNAME",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_PASSWORD",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_DATABASE",
+      "value" : "okapi_modules"
+    }, {
+      "name" : "DB_QUERYTIMEOUT",
+      "value" : "604800000"
+    }, {
+      "name" : "DB_CHARSET",
+      "value" : "UTF-8"
+    }, {
+      "name" : "DB_MAXPOOLSIZE",
+      "value" : "20"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-orders-11.0.6",
+  "name" : "Orders Business Logic Module",
+  "requires" : [ {
+    "id" : "acquisitions-units-storage.units",
+    "version" : "1.1"
+  }, {
+    "id" : "acquisitions-units-storage.memberships",
+    "version" : "1.0"
+  }, {
+    "id" : "configuration",
+    "version" : "2.0"
+  }, {
+    "id" : "orders-storage.purchase-orders",
+    "version" : "7.1"
+  }, {
+    "id" : "orders-storage.alerts",
+    "version" : "3.0"
+  }, {
+    "id" : "orders-storage.pieces",
+    "version" : "4.0"
+  }, {
+    "id" : "orders-storage.receiving-history",
+    "version" : "3.2"
+  }, {
+    "id" : "orders-storage.reporting-codes",
+    "version" : "3.0"
+  }, {
+    "id" : "orders-storage.po-lines",
+    "version" : "9.3"
+  }, {
+    "id" : "orders-storage.order-templates",
+    "version" : "1.0"
+  }, {
+    "id" : "holdings-storage",
+    "version" : "3.1 4.1"
+  }, {
+    "id" : "orders-storage.po-number",
+    "version" : "2.0"
+  }, {
+    "id" : "inventory",
+    "version" : "9.6 10.2"
+  }, {
+    "id" : "instance-types",
+    "version" : "2.0"
+  }, {
+    "id" : "instance-statuses",
+    "version" : "1.0"
+  }, {
+    "id" : "item-storage",
+    "version" : "7.8 8.2"
+  }, {
+    "id" : "identifier-types",
+    "version" : "1.2"
+  }, {
+    "id" : "isbn-utils",
+    "version" : "2.0"
+  }, {
+    "id" : "loan-types",
+    "version" : "2.2"
+  }, {
+    "id" : "organizations-storage.organizations",
+    "version" : "3.1"
+  }, {
+    "id" : "finance.funds",
+    "version" : "1.1"
+  }, {
+    "id" : "finance.transactions",
+    "version" : "3.0"
+  }, {
+    "id" : "finance.order-transaction-summaries",
+    "version" : "1.1"
+  }, {
+    "id" : "finance.ledgers",
+    "version" : "1.4"
+  }, {
+    "id" : "finance.budgets",
+    "version" : "1.1"
+  }, {
+    "id" : "orders-storage.titles",
+    "version" : "1.1"
+  }, {
+    "id" : "orders-storage.configuration.reasons-for-closure",
+    "version" : "1.0"
+  }, {
+    "id" : "orders-storage.configuration.prefixes",
+    "version" : "1.0"
+  }, {
+    "id" : "orders-storage.configuration.suffixes",
+    "version" : "1.0"
+  }, {
+    "id" : "circulation",
+    "version" : "9.3"
+  } ],
+  "provides" : [ {
+    "id" : "orders",
+    "version" : "10.4",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders/composite-orders",
+      "permissionsRequired" : [ "orders.collection.get" ],
+      "modulePermissions" : [ "acquisitions-units-storage.units.collection.get", "acquisitions-units-storage.memberships.collection.get", "orders-storage.purchase-orders.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/orders/composite-orders",
+      "permissionsRequired" : [ "orders.item.post" ],
+      "permissionsDesired" : [ "orders.acquisitions-units-assignments.assign", "orders.item.approve" ],
+      "modulePermissions" : [ "modperms.orders.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders/composite-orders/{id}",
+      "permissionsRequired" : [ "orders.item.get" ],
+      "modulePermissions" : [ "orders-storage.purchase-orders.item.get", "orders-storage.po-lines.collection.get", "orders-storage.alerts.item.get", "orders-storage.titles.collection.get", "orders-storage.reporting-codes.item.get", "configuration.entries.collection.get", "acquisitions-units-storage.units.collection.get", "acquisitions-units-storage.memberships.collection.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/orders/composite-orders/{id}",
+      "permissionsRequired" : [ "orders.item.put" ],
+      "permissionsDesired" : [ "orders.acquisitions-units-assignments.manage", "orders.item.approve", "orders.item.unopen" ],
+      "modulePermissions" : [ "modperms.orders.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/orders/composite-orders/{id}",
+      "permissionsRequired" : [ "orders.item.delete" ],
+      "modulePermissions" : [ "finance.transactions.collection.get", "finance.encumbrances.item.post", "finance.release-encumbrance.item.post", "finance.order-transaction-summaries.item.put", "orders-storage.purchase-orders.item.get", "orders-storage.purchase-orders.item.delete", "orders-storage.po-lines.collection.get", "orders-storage.po-lines.item.delete", "orders-storage.alerts.item.delete", "orders-storage.reporting-codes.item.delete", "acquisitions-units-storage.units.collection.get", "acquisitions-units-storage.memberships.collection.get" ]
+    } ]
+  }, {
+    "id" : "order-lines",
+    "version" : "1.4",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders/order-lines",
+      "permissionsRequired" : [ "orders.po-lines.collection.get" ],
+      "modulePermissions" : [ "acquisitions-units-storage.units.collection.get", "acquisitions-units-storage.memberships.collection.get", "orders-storage.po-lines.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/orders/order-lines",
+      "permissionsRequired" : [ "orders.po-lines.item.post" ],
+      "modulePermissions" : [ "orders-storage.purchase-orders.item.get", "orders-storage.po-line-number.get", "orders-storage.po-lines.collection.get", "orders-storage.po-lines.item.post", "orders-storage.alerts.item.post", "orders-storage.reporting-codes.item.post", "configuration.entries.collection.get", "acquisitions-units-storage.units.collection.get", "acquisitions-units-storage.memberships.collection.get", "inventory-storage.identifier-types.collection.get", "isbn-utils.convert-to-13.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders/order-lines/{id}",
+      "permissionsRequired" : [ "orders.po-lines.item.get" ],
+      "modulePermissions" : [ "orders-storage.po-lines.item.get", "orders-storage.alerts.item.get", "orders-storage.reporting-codes.item.get", "orders-storage.purchase-orders.item.get", "orders-storage.titles.collection.get", "configuration.entries.collection.get", "acquisitions-units-storage.units.collection.get", "acquisitions-units-storage.memberships.collection.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/orders/order-lines/{id}",
+      "permissionsRequired" : [ "orders.po-lines.item.put" ],
+      "modulePermissions" : [ "orders-storage.alerts.item.post", "orders-storage.alerts.item.put", "orders-storage.alerts.item.delete", "orders-storage.pieces.collection.get", "orders-storage.pieces.item.post", "orders-storage.po-lines.collection.get", "finance.funds.collection.get", "finance.transactions.collection.get", "finance.budgets.collection.get", "finance.ledgers.collection.get", "finance.encumbrances.item.post", "finance.ledgers.current-fiscal-year.item.get", "finance.order-transaction-summaries.item.post", "finance.order-transaction-summaries.item.put", "finance.release-encumbrance.item.post", "finance-storage.transactions.item.put", "inventory.instances.collection.get", "inventory.instances.item.post", "inventory-storage.holdings.item.post", "inventory-storage.holdings.collection.get", "inventory-storage.items.collection.get", "inventory-storage.items.item.post", "orders-storage.po-lines.item.get", "orders-storage.po-lines.item.put", "orders-storage.purchase-orders.item.get", "orders-storage.purchase-orders.item.put", "orders-storage.reporting-codes.item.post", "orders-storage.reporting-codes.item.put", "orders-storage.reporting-codes.item.delete", "orders-storage.titles.collection.get", "configuration.entries.collection.get", "inventory-storage.identifier-types.collection.get", "inventory.items.item.put", "inventory.items.collection.get", "isbn-utils.convert-to-13.get", "acquisitions-units-storage.units.collection.get", "acquisitions-units-storage.memberships.collection.get", "organizations-storage.organizations.collection.get" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/orders/order-lines/{id}",
+      "permissionsRequired" : [ "orders.po-lines.item.delete" ],
+      "modulePermissions" : [ "finance.transactions.collection.get", "finance.encumbrances.item.post", "finance.release-encumbrance.item.post", "finance.order-transaction-summaries.item.put", "orders-storage.purchase-orders.item.get", "orders-storage.po-lines.item.get", "orders-storage.po-lines.item.delete", "orders-storage.alerts.item.delete", "orders-storage.reporting-codes.item.delete", "acquisitions-units-storage.units.collection.get", "acquisitions-units-storage.memberships.collection.get" ]
+    } ]
+  }, {
+    "id" : "po-number",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/orders/po-number/validate",
+      "permissionsRequired" : [ "orders.po-number.item.post" ],
+      "modulePermissions" : [ "orders-storage.purchase-orders.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders/po-number",
+      "permissionsRequired" : [ "orders.po-number.item.get" ],
+      "modulePermissions" : [ "orders-storage.po-number.get" ]
+    } ]
+  }, {
+    "id" : "receiving",
+    "version" : "1.1",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/orders/receive",
+      "permissionsRequired" : [ "orders.receiving.collection.post" ],
+      "modulePermissions" : [ "orders-storage.pieces.collection.get", "orders-storage.pieces.item.put", "orders-storage.po-lines.collection.get", "orders-storage.po-lines.item.put", "orders-storage.purchase-orders.item.get", "orders-storage.purchase-orders.item.put", "orders-storage.titles.collection.get", "inventory.items.collection.get", "inventory.items.item.put", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.post", "acquisitions-units-storage.units.collection.get", "acquisitions-units-storage.memberships.collection.get", "orders-storage.purchase-orders.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/orders/check-in",
+      "permissionsRequired" : [ "orders.check-in.collection.post" ],
+      "modulePermissions" : [ "orders-storage.pieces.collection.get", "orders-storage.pieces.item.put", "orders-storage.po-lines.collection.get", "orders-storage.po-lines.item.put", "orders-storage.purchase-orders.item.get", "orders-storage.purchase-orders.item.put", "orders-storage.titles.collection.get", "inventory.items.collection.get", "inventory.items.item.put", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.post", "acquisitions-units-storage.units.collection.get", "acquisitions-units-storage.memberships.collection.get", "orders-storage.purchase-orders.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders/receiving-history",
+      "permissionsRequired" : [ "orders.receiving-history.collection.get" ],
+      "modulePermissions" : [ "acquisitions-units-storage.units.collection.get", "acquisitions-units-storage.memberships.collection.get", "orders-storage.receiving-history.collection.get" ]
+    } ]
+  }, {
+    "id" : "pieces",
+    "version" : "2.0",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/orders/pieces",
+      "permissionsRequired" : [ "orders.pieces.item.post" ],
+      "modulePermissions" : [ "orders-storage.pieces.item.post", "orders-storage.po-lines.item.get", "orders-storage.purchase-orders.item.get", "inventory.items.item.put", "inventory.items.collection.get", "inventory.instances.item.post", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.post", "inventory-storage.loan-types.collection.get", "inventory-storage.items.item.post", "inventory-storage.instance-types.collection.get", "inventory-storage.instance-statuses.collection.get", "acquisitions-units-storage.units.collection.get", "acquisitions-units-storage.memberships.collection.get", "orders-storage.titles.item.get", "orders-storage.titles.item.put", "orders-storage.alerts.item.get", "orders-storage.reporting-codes.item.get", "configuration.entries.collection.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/orders/pieces/{id}",
+      "permissionsRequired" : [ "orders.pieces.item.put" ],
+      "modulePermissions" : [ "orders-storage.pieces.item.put", "orders-storage.pieces.item.get", "orders-storage.po-lines.item.get", "orders-storage.purchase-orders.item.get", "acquisitions-units-storage.units.collection.get", "acquisitions-units-storage.memberships.collection.get", "inventory.items.item.put", "inventory.items.collection.get" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/orders/pieces/{id}",
+      "permissionsRequired" : [ "orders.pieces.item.delete" ],
+      "modulePermissions" : [ "orders-storage.pieces.item.delete", "orders-storage.pieces.item.get", "orders-storage.po-lines.item.get", "orders-storage.purchase-orders.item.get", "orders-storage.alerts.item.get", "orders-storage.reporting-codes.item.get", "acquisitions-units-storage.units.collection.get", "acquisitions-units-storage.memberships.collection.get", "circulation.requests.collection.get", "inventory.items.item.delete" ]
+    } ]
+  }, {
+    "id" : "order-templates",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders/order-templates",
+      "permissionsRequired" : [ "orders.order-templates.collection.get" ],
+      "modulePermissions" : [ "orders-storage.order-templates.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/orders/order-templates",
+      "permissionsRequired" : [ "orders.order-templates.item.post" ],
+      "modulePermissions" : [ "orders-storage.order-templates.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders/order-templates/{id}",
+      "permissionsRequired" : [ "orders.order-templates.item.get" ],
+      "modulePermissions" : [ "orders-storage.order-templates.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/orders/order-templates/{id}",
+      "permissionsRequired" : [ "orders.order-templates.item.put" ],
+      "modulePermissions" : [ "orders-storage.order-templates.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/orders/order-templates/{id}",
+      "permissionsRequired" : [ "orders.order-templates.item.delete" ],
+      "modulePermissions" : [ "orders-storage.order-templates.item.delete" ]
+    } ]
+  }, {
+    "id" : "acquisitions-units",
+    "version" : "1.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/acquisitions-units/units",
+      "permissionsRequired" : [ "acquisitions-units.units.collection.get" ],
+      "modulePermissions" : [ "acquisitions-units-storage.units.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/acquisitions-units/units",
+      "permissionsRequired" : [ "acquisitions-units.units.item.post" ],
+      "modulePermissions" : [ "acquisitions-units-storage.units.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/acquisitions-units/units/{id}",
+      "permissionsRequired" : [ "acquisitions-units.units.item.get" ],
+      "modulePermissions" : [ "acquisitions-units-storage.units.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/acquisitions-units/units/{id}",
+      "permissionsRequired" : [ "acquisitions-units.units.item.put" ],
+      "modulePermissions" : [ "acquisitions-units-storage.units.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/acquisitions-units/units/{id}",
+      "permissionsRequired" : [ "acquisitions-units.units.item.delete" ],
+      "modulePermissions" : [ "acquisitions-units-storage.units.item.get", "acquisitions-units-storage.units.item.put" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/acquisitions-units/memberships",
+      "permissionsRequired" : [ "acquisitions-units.memberships.collection.get" ],
+      "modulePermissions" : [ "acquisitions-units-storage.memberships.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/acquisitions-units/memberships",
+      "permissionsRequired" : [ "acquisitions-units.memberships.item.post" ],
+      "modulePermissions" : [ "acquisitions-units-storage.memberships.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/acquisitions-units/memberships/{id}",
+      "permissionsRequired" : [ "acquisitions-units.memberships.item.get" ],
+      "modulePermissions" : [ "acquisitions-units-storage.memberships.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/acquisitions-units/memberships/{id}",
+      "permissionsRequired" : [ "acquisitions-units.memberships.item.put" ],
+      "modulePermissions" : [ "acquisitions-units-storage.memberships.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/acquisitions-units/memberships/{id}",
+      "permissionsRequired" : [ "acquisitions-units.memberships.item.delete" ],
+      "modulePermissions" : [ "acquisitions-units-storage.memberships.item.delete" ]
+    } ]
+  }, {
+    "id" : "titles",
+    "version" : "1.2",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders/titles",
+      "permissionsRequired" : [ "orders.titles.collection.get" ],
+      "modulePermissions" : [ "orders-storage.titles.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/orders/titles",
+      "permissionsRequired" : [ "orders.titles.item.post" ],
+      "modulePermissions" : [ "orders-storage.titles.collection.get", "orders-storage.titles.item.post", "orders-storage.po-lines.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders/titles/{id}",
+      "permissionsRequired" : [ "orders.titles.item.get" ],
+      "modulePermissions" : [ "orders-storage.titles.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/orders/titles/{id}",
+      "permissionsRequired" : [ "orders.titles.item.put" ],
+      "modulePermissions" : [ "orders-storage.titles.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/orders/titles/{id}",
+      "permissionsRequired" : [ "orders.titles.item.delete" ],
+      "modulePermissions" : [ "orders-storage.titles.item.delete" ]
+    } ]
+  }, {
+    "id" : "configuration.reasons-for-closure",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders/configuration/reasons-for-closure",
+      "permissionsRequired" : [ "orders.configuration.reasons-for-closure.collection.get" ],
+      "modulePermissions" : [ "orders-storage.configuration.reasons-for-closure.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/orders/configuration/reasons-for-closure",
+      "permissionsRequired" : [ "orders.configuration.reasons-for-closure.item.post" ],
+      "modulePermissions" : [ "orders-storage.configuration.reasons-for-closure.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders/configuration/reasons-for-closure/{id}",
+      "permissionsRequired" : [ "orders.configuration.reasons-for-closure.item.get" ],
+      "modulePermissions" : [ "orders-storage.configuration.reasons-for-closure.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/orders/configuration/reasons-for-closure/{id}",
+      "permissionsRequired" : [ "orders.configuration.reasons-for-closure.item.put" ],
+      "modulePermissions" : [ "orders-storage.configuration.reasons-for-closure.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/orders/configuration/reasons-for-closure/{id}",
+      "permissionsRequired" : [ "orders.configuration.reasons-for-closure.item.delete" ],
+      "modulePermissions" : [ "orders-storage.configuration.reasons-for-closure.item.delete" ]
+    } ]
+  }, {
+    "id" : "configuration.prefixes",
+    "version" : "1.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders/configuration/prefixes",
+      "permissionsRequired" : [ "orders.configuration.prefixes.collection.get" ],
+      "modulePermissions" : [ "orders-storage.configuration.prefixes.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/orders/configuration/prefixes",
+      "permissionsRequired" : [ "orders.configuration.prefixes.item.post" ],
+      "modulePermissions" : [ "orders-storage.configuration.prefixes.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders/configuration/prefixes/{id}",
+      "permissionsRequired" : [ "orders.configuration.prefixes.item.get" ],
+      "modulePermissions" : [ "orders-storage.configuration.prefixes.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/orders/configuration/prefixes/{id}",
+      "permissionsRequired" : [ "orders.configuration.prefixes.item.put" ],
+      "modulePermissions" : [ "orders-storage.configuration.prefixes.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/orders/configuration/prefixes/{id}",
+      "permissionsRequired" : [ "orders.configuration.prefixes.item.delete" ],
+      "modulePermissions" : [ "orders-storage.configuration.prefixes.item.delete", "orders-storage.configuration.prefixes.item.get", "orders-storage.purchase-orders.collection.get" ]
+    } ]
+  }, {
+    "id" : "configuration.suffixes",
+    "version" : "1.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders/configuration/suffixes",
+      "permissionsRequired" : [ "orders.configuration.suffixes.collection.get" ],
+      "modulePermissions" : [ "orders-storage.configuration.suffixes.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/orders/configuration/suffixes",
+      "permissionsRequired" : [ "orders.configuration.suffixes.item.post" ],
+      "modulePermissions" : [ "orders-storage.configuration.suffixes.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders/configuration/suffixes/{id}",
+      "permissionsRequired" : [ "orders.configuration.suffixes.item.get" ],
+      "modulePermissions" : [ "orders-storage.configuration.suffixes.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/orders/configuration/suffixes/{id}",
+      "permissionsRequired" : [ "orders.configuration.suffixes.item.put" ],
+      "modulePermissions" : [ "orders-storage.configuration.suffixes.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/orders/configuration/suffixes/{id}",
+      "permissionsRequired" : [ "orders.configuration.suffixes.item.delete" ],
+      "modulePermissions" : [ "orders-storage.configuration.suffixes.item.delete", "orders-storage.configuration.suffixes.item.get", "orders-storage.purchase-orders.collection.get" ]
+    } ]
+  }, {
+    "id" : "_jsonSchemas",
+    "version" : "1.0",
+    "interfaceType" : "multiple",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/_/jsonSchemas",
+      "permissionsRequired" : [ ]
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "orders.collection.get",
+    "displayName" : "orders - get orders collection",
+    "description" : "Get orders collection"
+  }, {
+    "permissionName" : "orders.item.post",
+    "displayName" : "orders - create a new order",
+    "description" : "Create a new order"
+  }, {
+    "permissionName" : "orders.item.get",
+    "displayName" : "orders - get an existing order",
+    "description" : "Get an existing order"
+  }, {
+    "permissionName" : "orders.item.put",
+    "displayName" : "orders - modify an existing order",
+    "description" : "Modify an existing order"
+  }, {
+    "permissionName" : "orders.item.delete",
+    "displayName" : "orders - delete an existing order",
+    "description" : "Delete an existing order"
+  }, {
+    "permissionName" : "orders.po-lines.collection.get",
+    "displayName" : "Orders - get collection of PO lines",
+    "description" : "Get collection of PO lines"
+  }, {
+    "permissionName" : "orders.po-lines.item.post",
+    "displayName" : "Orders - create a new PO line",
+    "description" : "Create a new PO line"
+  }, {
+    "permissionName" : "orders.po-lines.item.get",
+    "displayName" : "Orders - get an existing PO line",
+    "description" : "Get an existing PO line"
+  }, {
+    "permissionName" : "orders.po-lines.item.put",
+    "displayName" : "Orders - modify an existing PO line",
+    "description" : "Modify an existing PO line"
+  }, {
+    "permissionName" : "orders.po-lines.item.delete",
+    "displayName" : "Orders - delete an existing PO line",
+    "description" : "Delete an existing PO line"
+  }, {
+    "permissionName" : "orders.po-number.item.get",
+    "displayName" : "Orders - generate a PO Number",
+    "description" : "Generate a PO Number"
+  }, {
+    "permissionName" : "orders.po-number.item.post",
+    "displayName" : "Orders - validate a PO Number",
+    "description" : "Validate a PO Number"
+  }, {
+    "permissionName" : "orders.receiving.collection.post",
+    "displayName" : "Orders - Receive items",
+    "description" : "Receive items spanning one or more po-lines in this order"
+  }, {
+    "permissionName" : "orders.check-in.collection.post",
+    "displayName" : "Orders - Check-in items",
+    "description" : "Check-in items spanning one or more po-lines in this order"
+  }, {
+    "permissionName" : "orders.receiving-history.collection.get",
+    "displayName" : "Orders - Receiving history",
+    "description" : "Get receiving history matching the provided criteria"
+  }, {
+    "permissionName" : "orders.pieces.item.post",
+    "displayName" : "Orders - Piece",
+    "description" : "Create piece record"
+  }, {
+    "permissionName" : "orders.pieces.item.put",
+    "displayName" : "orders - modify an existing piece record",
+    "description" : "Modify an existing piece"
+  }, {
+    "permissionName" : "orders.pieces.item.delete",
+    "displayName" : "orders - delete an existing piece record",
+    "description" : "Delete an existing piece"
+  }, {
+    "permissionName" : "orders.order-templates.collection.get",
+    "displayName" : "Orders - Get template collection",
+    "description" : "Get a collection of order templates"
+  }, {
+    "permissionName" : "orders.order-templates.item.post",
+    "displayName" : "Orders - Create an order template",
+    "description" : "Create a new order template"
+  }, {
+    "permissionName" : "orders.order-templates.item.get",
+    "displayName" : "Orders - Get an order template",
+    "description" : "Fetch an order templates"
+  }, {
+    "permissionName" : "orders.order-templates.item.put",
+    "displayName" : "Orders - Update an order template",
+    "description" : "Update an order template"
+  }, {
+    "permissionName" : "orders.order-templates.item.delete",
+    "displayName" : "Orders - Delete an order template",
+    "description" : "Delete an order template"
+  }, {
+    "permissionName" : "orders.order-templates.all",
+    "displayName" : "All order-templates permissions",
+    "description" : "All permissions for the order-templates",
+    "subPermissions" : [ "orders.order-templates.collection.get", "orders.order-templates.item.post", "orders.order-templates.item.get", "orders.order-templates.item.put", "orders.order-templates.item.delete" ]
+  }, {
+    "permissionName" : "acquisitions-units.units.collection.get",
+    "displayName" : "Acquisitions units - get units",
+    "description" : "Get a collection of acquisitions units"
+  }, {
+    "permissionName" : "acquisitions-units.units.item.post",
+    "displayName" : "Acquisitions units - create unit",
+    "description" : "Create a new acquisitions unit"
+  }, {
+    "permissionName" : "acquisitions-units.units.item.get",
+    "displayName" : "Acquisitions units - get unit",
+    "description" : "Fetch an acquisitions unit"
+  }, {
+    "permissionName" : "acquisitions-units.units.item.put",
+    "displayName" : "Acquisitions units - update unit",
+    "description" : "Update an acquisitions unit"
+  }, {
+    "permissionName" : "acquisitions-units.units.item.delete",
+    "displayName" : "Acquisitions units - delete unit",
+    "description" : "Delete an acquisitions unit"
+  }, {
+    "permissionName" : "acquisitions-units.units.all",
+    "displayName" : "All acquisitions-units perms",
+    "description" : "All permissions for the acquisitions-units",
+    "subPermissions" : [ "acquisitions-units.units.collection.get", "acquisitions-units.units.item.post", "acquisitions-units.units.item.get", "acquisitions-units.units.item.put", "acquisitions-units.units.item.delete" ]
+  }, {
+    "permissionName" : "orders.acquisitions-units-assignments.assign",
+    "displayName" : "Acquisitions unit assignment - create unit assignment",
+    "description" : "Assign new order to acquisitions units"
+  }, {
+    "permissionName" : "orders.acquisitions-units-assignments.manage",
+    "displayName" : "Acquisitions units assignment - manage unit assignments",
+    "description" : "Manage unit assignments during orders update"
+  }, {
+    "permissionName" : "orders.acquisitions-units-assignments.all",
+    "displayName" : "All order acquisitions-unit-assignments permissions",
+    "description" : "All permissions for the acquisitions-unit-assignments",
+    "subPermissions" : [ "orders.acquisitions-units-assignments.assign", "orders.acquisitions-units-assignments.manage" ]
+  }, {
+    "permissionName" : "acquisitions-units.memberships.collection.get",
+    "displayName" : "Acquisitions units memberships - get units memberships",
+    "description" : "Get a collection of acquisitions units memberships"
+  }, {
+    "permissionName" : "acquisitions-units.memberships.item.post",
+    "displayName" : "Acquisitions units memberships - create units membership",
+    "description" : "Create a new acquisitions units membership"
+  }, {
+    "permissionName" : "acquisitions-units.memberships.item.get",
+    "displayName" : "Acquisitions units memberships - get units membership",
+    "description" : "Fetch an acquisitions units membership"
+  }, {
+    "permissionName" : "acquisitions-units.memberships.item.put",
+    "displayName" : "Acquisitions units memberships - update units membership",
+    "description" : "Update an acquisitions units membership"
+  }, {
+    "permissionName" : "acquisitions-units.memberships.item.delete",
+    "displayName" : "Acquisitions units memberships - delete units membership",
+    "description" : "Delete an acquisitions units membership"
+  }, {
+    "permissionName" : "acquisitions-units.memberships.all",
+    "displayName" : "All acquisitions-units perms",
+    "description" : "All permissions for the acquisitions-units memberships",
+    "subPermissions" : [ "acquisitions-units.memberships.collection.get", "acquisitions-units.memberships.item.post", "acquisitions-units.memberships.item.get", "acquisitions-units.memberships.item.put", "acquisitions-units.memberships.item.delete" ]
+  }, {
+    "permissionName" : "orders.titles.collection.get",
+    "displayName" : "Titles - get titles collection",
+    "description" : "Get titles collection"
+  }, {
+    "permissionName" : "orders.titles.item.post",
+    "displayName" : "Titles - create a new title",
+    "description" : "Create a new title"
+  }, {
+    "permissionName" : "orders.titles.item.get",
+    "displayName" : "Titles - get an existing title",
+    "description" : "Get an existing title"
+  }, {
+    "permissionName" : "orders.titles.item.put",
+    "displayName" : "Titles - modify an existing title",
+    "description" : "Modify an existing title"
+  }, {
+    "permissionName" : "orders.titles.item.delete",
+    "displayName" : "Titles - delete an existing title",
+    "description" : "Delete an existing title"
+  }, {
+    "permissionName" : "orders.titles.all",
+    "displayName" : "All titles perms",
+    "description" : "All permissions for the titles",
+    "subPermissions" : [ "orders.titles.collection.get", "orders.titles.item.post", "orders.titles.item.get", "orders.titles.item.put", "orders.titles.item.delete" ]
+  }, {
+    "permissionName" : "orders.configuration.reasons-for-closure.collection.get",
+    "displayName" : "orders-configuration-reasons-for-closure-collection get",
+    "description" : "Get a collection of reasons for closure"
+  }, {
+    "permissionName" : "orders.configuration.reasons-for-closure.item.post",
+    "displayName" : "orders-configuration-reasons-for-closure-item post",
+    "description" : "Create a new reason for closure"
+  }, {
+    "permissionName" : "orders.configuration.reasons-for-closure.item.get",
+    "displayName" : "orders-configuration-reasons-for-closure-item get",
+    "description" : "Fetch a reason for closure"
+  }, {
+    "permissionName" : "orders.configuration.reasons-for-closure.item.put",
+    "displayName" : "orders-configuration-reasons-for-closure-item put",
+    "description" : "Update a reason for closure"
+  }, {
+    "permissionName" : "orders.configuration.reasons-for-closure.item.delete",
+    "displayName" : "orders-configuration-reasons-for-closure-item delete",
+    "description" : "Delete a reason for closure"
+  }, {
+    "permissionName" : "orders.configuration.reasons-for-closure.all",
+    "displayName" : "All orders reasons for closure perms",
+    "description" : "All permissions for the orders configuration - reasons for closure",
+    "subPermissions" : [ "orders.configuration.reasons-for-closure.collection.get", "orders.configuration.reasons-for-closure.item.post", "orders.configuration.reasons-for-closure.item.get", "orders.configuration.reasons-for-closure.item.put", "orders.configuration.reasons-for-closure.item.delete" ]
+  }, {
+    "permissionName" : "orders.configuration.prefixes.collection.get",
+    "displayName" : "orders-configuration-prefix-collection get",
+    "description" : "Get a collection of prefixes"
+  }, {
+    "permissionName" : "orders.configuration.prefixes.item.post",
+    "displayName" : "orders-configuration-prefixes-item post",
+    "description" : "Create a new prefix"
+  }, {
+    "permissionName" : "orders.configuration.prefixes.item.get",
+    "displayName" : "orders-configuration-prefixes-item get",
+    "description" : "Fetch a prefix"
+  }, {
+    "permissionName" : "orders.configuration.prefixes.item.put",
+    "displayName" : "orders-configuration-prefix-item put",
+    "description" : "Update a prefix"
+  }, {
+    "permissionName" : "orders.configuration.prefixes.item.delete",
+    "displayName" : "orders-configuration-prefixes-item delete",
+    "description" : "Delete a prefix"
+  }, {
+    "permissionName" : "orders.configuration.prefixes.all",
+    "displayName" : "All orders prefixes perms",
+    "description" : "All permissions for the orders configuration - prefixes",
+    "subPermissions" : [ "orders.configuration.prefixes.collection.get", "orders.configuration.prefixes.item.post", "orders.configuration.prefixes.item.get", "orders.configuration.prefixes.item.put", "orders.configuration.prefixes.item.delete" ]
+  }, {
+    "permissionName" : "orders.configuration.suffixes.collection.get",
+    "displayName" : "orders-configuration-suffixes-collection get",
+    "description" : "Get a collection of suffixes"
+  }, {
+    "permissionName" : "orders.configuration.suffixes.item.post",
+    "displayName" : "orders-configuration-suffixes-item post",
+    "description" : "Create a new suffix"
+  }, {
+    "permissionName" : "orders.configuration.suffixes.item.get",
+    "displayName" : "orders-configuration-suffixes-item get",
+    "description" : "Fetch a suffix"
+  }, {
+    "permissionName" : "orders.configuration.suffixes.item.put",
+    "displayName" : "orders-configuration-suffix-item put",
+    "description" : "Update a suffix"
+  }, {
+    "permissionName" : "orders.configuration.suffixes.item.delete",
+    "displayName" : "orders-configuration-suffixes-item delete",
+    "description" : "Delete a suffix"
+  }, {
+    "permissionName" : "orders.configuration.suffixes.all",
+    "displayName" : "All orders suffixes perms",
+    "description" : "All permissions for the orders configuration - suffixes",
+    "subPermissions" : [ "orders.configuration.suffixes.collection.get", "orders.configuration.suffixes.item.post", "orders.configuration.suffixes.item.get", "orders.configuration.suffixes.item.put", "orders.configuration.suffixes.item.delete" ]
+  }, {
+    "permissionName" : "orders.all",
+    "displayName" : "orders - all permissions",
+    "description" : "Entire set of permissions needed to use orders",
+    "subPermissions" : [ "orders.collection.get", "orders.item.post", "orders.item.get", "orders.item.put", "orders.item.delete", "orders.po-lines.collection.get", "orders.po-lines.item.post", "orders.po-lines.item.get", "orders.po-lines.item.put", "orders.po-lines.item.delete", "orders.po-number.item.get", "orders.po-number.item.post", "orders.receiving.collection.post", "orders.check-in.collection.post", "orders.receiving-history.collection.get", "orders.pieces.item.post", "orders.pieces.item.put", "orders.pieces.item.delete", "orders.acquisitions-units-assignments.all", "orders.order-templates.all", "orders.titles.all", "orders.configuration.reasons-for-closure.all", "orders.configuration.prefixes.all", "orders.configuration.suffixes.all" ]
+  }, {
+    "permissionName" : "modperms.orders.item.put",
+    "displayName" : "module permissions for put purchase order",
+    "description" : "to reduce X-Okapi-Token size",
+    "subPermissions" : [ "orders-storage.purchase-orders.collection.get", "orders-storage.purchase-orders.item.put", "orders-storage.purchase-orders.item.get", "orders-storage.po-lines.collection.get", "orders-storage.po-lines.item.post", "orders-storage.po-lines.item.put", "orders-storage.po-lines.item.delete", "orders-storage.alerts.item.post", "orders-storage.alerts.item.get", "orders-storage.alerts.item.put", "orders-storage.alerts.item.delete", "orders-storage.pieces.item.post", "orders-storage.pieces.collection.get", "orders-storage.po-line-number.get", "orders-storage.reporting-codes.item.post", "orders-storage.reporting-codes.item.get", "orders-storage.reporting-codes.item.put", "orders-storage.reporting-codes.item.delete", "orders-storage.titles.collection.get", "configuration.entries.collection.get", "finance.funds.collection.get", "finance.budgets.collection.get", "finance.ledgers.collection.get", "finance.encumbrances.item.post", "finance.transactions.collection.get", "finance.transactions.item.get", "finance.ledgers.current-fiscal-year.item.get", "finance.order-transaction-summaries.item.post", "finance.order-transaction-summaries.item.put", "finance.release-encumbrance.item.post", "finance-storage.transactions.item.put", "inventory.instances.collection.get", "inventory.instances.item.post", "inventory.items.collection.get", "inventory.items.item.put", "inventory-storage.instance-types.collection.get", "inventory-storage.instance-statuses.collection.get", "inventory-storage.holdings.item.post", "inventory-storage.holdings.collection.get", "inventory-storage.items.collection.get", "inventory-storage.items.item.post", "inventory.items.item.put", "inventory-storage.loan-types.collection.get", "inventory-storage.contributor-name-types.collection.get", "organizations-storage.organizations.collection.get", "organizations-storage.organizations.item.get", "isbn-utils.convert-to-13.get", "inventory-storage.identifier-types.collection.get", "acquisitions-units-storage.units.collection.get", "acquisitions-units-storage.memberships.collection.get" ],
+    "visible" : false
+  }, {
+    "permissionName" : "modperms.orders.item.post",
+    "displayName" : "module permissions for post purchase order",
+    "description" : "to reduce X-Okapi-Token size",
+    "subPermissions" : [ "orders-storage.purchase-orders.collection.get", "orders-storage.purchase-orders.item.post", "orders-storage.purchase-orders.item.put", "orders-storage.alerts.item.post", "orders-storage.alerts.item.put", "orders-storage.po-lines.item.post", "orders-storage.po-lines.item.put", "orders-storage.po-lines.collection.get", "orders-storage.pieces.item.post", "orders-storage.pieces.collection.get", "orders-storage.po-line-number.get", "orders-storage.po-number.get", "orders-storage.reporting-codes.item.post", "orders-storage.reporting-codes.item.put", "orders-storage.titles.collection.get", "orders-storage.titles.item.put", "configuration.entries.collection.get", "finance.encumbrances.item.post", "finance.funds.collection.get", "finance.budgets.collection.get", "finance.ledgers.collection.get", "finance.ledgers.current-fiscal-year.item.get", "finance.transactions.collection.get", "finance.transactions.item.get", "finance.order-transaction-summaries.item.post", "finance.order-transaction-summaries.item.put", "finance.release-encumbrance.item.post", "finance-storage.transactions.item.put", "inventory.instances.collection.get", "inventory.instances.item.post", "inventory.items.collection.get", "inventory-storage.instance-types.collection.get", "inventory-storage.instance-statuses.collection.get", "inventory-storage.holdings.item.post", "inventory-storage.holdings.collection.get", "inventory-storage.items.collection.get", "inventory-storage.items.item.post", "inventory.items.item.put", "inventory-storage.loan-types.collection.get", "inventory-storage.contributor-name-types.collection.get", "organizations-storage.organizations.collection.get", "organizations-storage.organizations.item.get", "acquisitions-units-storage.units.collection.get", "acquisitions-units-storage.memberships.collection.get", "inventory-storage.identifier-types.collection.get", "isbn-utils.convert-to-13.get" ],
+    "visible" : false
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-orders:11.0.6",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-orders-storage-11.0.3",
+  "name" : "Orders CRUD module",
+  "provides" : [ {
+    "id" : "orders-storage.alerts",
+    "version" : "3.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders-storage/alerts",
+      "permissionsRequired" : [ "orders-storage.alerts.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/orders-storage/alerts",
+      "permissionsRequired" : [ "orders-storage.alerts.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders-storage/alerts/{id}",
+      "permissionsRequired" : [ "orders-storage.alerts.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/orders-storage/alerts/{id}",
+      "permissionsRequired" : [ "orders-storage.alerts.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/orders-storage/alerts/{id}",
+      "permissionsRequired" : [ "orders-storage.alerts.item.delete" ]
+    } ]
+  }, {
+    "id" : "orders-storage.pieces",
+    "version" : "4.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders-storage/pieces",
+      "permissionsRequired" : [ "orders-storage.pieces.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/orders-storage/pieces",
+      "permissionsRequired" : [ "orders-storage.pieces.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders-storage/pieces/{id}",
+      "permissionsRequired" : [ "orders-storage.pieces.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/orders-storage/pieces/{id}",
+      "permissionsRequired" : [ "orders-storage.pieces.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/orders-storage/pieces/{id}",
+      "permissionsRequired" : [ "orders-storage.pieces.item.delete" ]
+    } ]
+  }, {
+    "id" : "orders-storage.titles",
+    "version" : "1.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders-storage/titles",
+      "permissionsRequired" : [ "orders-storage.titles.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/orders-storage/titles",
+      "permissionsRequired" : [ "orders-storage.titles.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders-storage/titles/{id}",
+      "permissionsRequired" : [ "orders-storage.titles.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/orders-storage/titles/{id}",
+      "permissionsRequired" : [ "orders-storage.titles.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/orders-storage/titles/{id}",
+      "permissionsRequired" : [ "orders-storage.titles.item.delete" ]
+    } ]
+  }, {
+    "id" : "orders-storage.po-lines",
+    "version" : "9.3",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders-storage/po-lines",
+      "permissionsRequired" : [ "orders-storage.po-lines.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/orders-storage/po-lines",
+      "permissionsRequired" : [ "orders-storage.po-lines.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders-storage/po-lines/{id}",
+      "permissionsRequired" : [ "orders-storage.po-lines.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/orders-storage/po-lines/{id}",
+      "permissionsRequired" : [ "orders-storage.po-lines.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/orders-storage/po-lines/{id}",
+      "permissionsRequired" : [ "orders-storage.po-lines.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders-storage/order-lines",
+      "permissionsRequired" : [ "orders-storage.po-lines.collection.get" ]
+    } ]
+  }, {
+    "id" : "orders-storage.purchase-orders",
+    "version" : "7.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders-storage/purchase-orders",
+      "permissionsRequired" : [ "orders-storage.purchase-orders.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/orders-storage/purchase-orders",
+      "permissionsRequired" : [ "orders-storage.purchase-orders.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders-storage/purchase-orders/{id}",
+      "permissionsRequired" : [ "orders-storage.purchase-orders.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/orders-storage/purchase-orders/{id}",
+      "permissionsRequired" : [ "orders-storage.purchase-orders.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/orders-storage/purchase-orders/{id}",
+      "permissionsRequired" : [ "orders-storage.purchase-orders.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders-storage/orders",
+      "permissionsRequired" : [ "orders-storage.purchase-orders.collection.get" ]
+    } ]
+  }, {
+    "id" : "orders-storage.receiving-history",
+    "version" : "3.2",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders-storage/receiving-history",
+      "permissionsRequired" : [ "orders-storage.receiving-history.collection.get" ]
+    } ]
+  }, {
+    "id" : "orders-storage.reporting-codes",
+    "version" : "3.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders-storage/reporting-codes",
+      "permissionsRequired" : [ "orders-storage.reporting-codes.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/orders-storage/reporting-codes",
+      "permissionsRequired" : [ "orders-storage.reporting-codes.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders-storage/reporting-codes/{id}",
+      "permissionsRequired" : [ "orders-storage.reporting-codes.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/orders-storage/reporting-codes/{id}",
+      "permissionsRequired" : [ "orders-storage.reporting-codes.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/orders-storage/reporting-codes/{id}",
+      "permissionsRequired" : [ "orders-storage.reporting-codes.item.delete" ]
+    } ]
+  }, {
+    "id" : "orders-storage.po-number",
+    "version" : "2.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders-storage/po-number",
+      "permissionsRequired" : [ "orders-storage.po-number.get" ]
+    } ]
+  }, {
+    "id" : "orders-storage.po-line-number",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders-storage/po-line-number",
+      "permissionsRequired" : [ "orders-storage.po-line-number.get" ]
+    } ]
+  }, {
+    "id" : "orders-storage.order-invoice-relationships",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders-storage/order-invoice-relns",
+      "permissionsRequired" : [ "orders-storage.order-invoice-relationships.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/orders-storage/order-invoice-relns",
+      "permissionsRequired" : [ "orders-storage.order-invoice-relationships.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders-storage/order-invoice-relns/{id}",
+      "permissionsRequired" : [ "orders-storage.order-invoice-relationships.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/orders-storage/order-invoice-relns/{id}",
+      "permissionsRequired" : [ "orders-storage.order-invoice-relationships.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/orders-storage/order-invoice-relns/{id}",
+      "permissionsRequired" : [ "orders-storage.order-invoice-relationships.item.delete" ]
+    } ]
+  }, {
+    "id" : "orders-storage.order-templates",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders-storage/order-templates",
+      "permissionsRequired" : [ "orders-storage.order-templates.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/orders-storage/order-templates",
+      "permissionsRequired" : [ "orders-storage.order-templates.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders-storage/order-templates/{id}",
+      "permissionsRequired" : [ "orders-storage.order-templates.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/orders-storage/order-templates/{id}",
+      "permissionsRequired" : [ "orders-storage.order-templates.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/orders-storage/order-templates/{id}",
+      "permissionsRequired" : [ "orders-storage.order-templates.item.delete" ]
+    } ]
+  }, {
+    "id" : "acquisitions-units-storage.units",
+    "version" : "1.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/acquisitions-units-storage/units",
+      "permissionsRequired" : [ "acquisitions-units-storage.units.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/acquisitions-units-storage/units",
+      "permissionsRequired" : [ "acquisitions-units-storage.units.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/acquisitions-units-storage/units/{id}",
+      "permissionsRequired" : [ "acquisitions-units-storage.units.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/acquisitions-units-storage/units/{id}",
+      "permissionsRequired" : [ "acquisitions-units-storage.units.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/acquisitions-units-storage/units/{id}",
+      "permissionsRequired" : [ "acquisitions-units-storage.units.item.delete" ]
+    } ]
+  }, {
+    "id" : "acquisitions-units-storage.memberships",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/acquisitions-units-storage/memberships",
+      "permissionsRequired" : [ "acquisitions-units-storage.memberships.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/acquisitions-units-storage/memberships",
+      "permissionsRequired" : [ "acquisitions-units-storage.memberships.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/acquisitions-units-storage/memberships/{id}",
+      "permissionsRequired" : [ "acquisitions-units-storage.memberships.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/acquisitions-units-storage/memberships/{id}",
+      "permissionsRequired" : [ "acquisitions-units-storage.memberships.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/acquisitions-units-storage/memberships/{id}",
+      "permissionsRequired" : [ "acquisitions-units-storage.memberships.item.delete" ]
+    } ]
+  }, {
+    "id" : "orders-storage.configuration.reasons-for-closure",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders-storage/configuration/reasons-for-closure",
+      "permissionsRequired" : [ "orders-storage.configuration.reasons-for-closure.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/orders-storage/configuration/reasons-for-closure",
+      "permissionsRequired" : [ "orders-storage.configuration.reasons-for-closure.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders-storage/configuration/reasons-for-closure/{id}",
+      "permissionsRequired" : [ "orders-storage.configuration.reasons-for-closure.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/orders-storage/configuration/reasons-for-closure/{id}",
+      "permissionsRequired" : [ "orders-storage.configuration.reasons-for-closure.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/orders-storage/configuration/reasons-for-closure/{id}",
+      "permissionsRequired" : [ "orders-storage.configuration.reasons-for-closure.item.delete" ]
+    } ]
+  }, {
+    "id" : "orders-storage.configuration.prefixes",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders-storage/configuration/prefixes",
+      "permissionsRequired" : [ "orders-storage.configuration.prefixes.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/orders-storage/configuration/prefixes",
+      "permissionsRequired" : [ "orders-storage.configuration.prefixes.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders-storage/configuration/prefixes/{id}",
+      "permissionsRequired" : [ "orders-storage.configuration.prefixes.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/orders-storage/configuration/prefixes/{id}",
+      "permissionsRequired" : [ "orders-storage.configuration.prefixes.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/orders-storage/configuration/prefixes/{id}",
+      "permissionsRequired" : [ "orders-storage.configuration.prefixes.item.delete" ]
+    } ]
+  }, {
+    "id" : "orders-storage.configuration.suffixes",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders-storage/configuration/suffixes",
+      "permissionsRequired" : [ "orders-storage.configuration.suffixes.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/orders-storage/configuration/suffixes",
+      "permissionsRequired" : [ "orders-storage.configuration.suffixes.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/orders-storage/configuration/suffixes/{id}",
+      "permissionsRequired" : [ "orders-storage.configuration.suffixes.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/orders-storage/configuration/suffixes/{id}",
+      "permissionsRequired" : [ "orders-storage.configuration.suffixes.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/orders-storage/configuration/suffixes/{id}",
+      "permissionsRequired" : [ "orders-storage.configuration.suffixes.item.delete" ]
+    } ]
+  }, {
+    "id" : "_tenant",
+    "version" : "1.2",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST", "DELETE" ],
+      "pathPattern" : "/_/tenant"
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "orders-storage.alerts.collection.get",
+    "displayName" : "alert-collection get",
+    "description" : "Get a collection of alerts"
+  }, {
+    "permissionName" : "orders-storage.alerts.item.post",
+    "displayName" : "alert-item post",
+    "description" : "Create a new alert"
+  }, {
+    "permissionName" : "orders-storage.alerts.item.get",
+    "displayName" : "alert-item get",
+    "description" : "Fetch an alert"
+  }, {
+    "permissionName" : "orders-storage.alerts.item.put",
+    "displayName" : "alert-item put",
+    "description" : "Update an alert"
+  }, {
+    "permissionName" : "orders-storage.alerts.item.delete",
+    "displayName" : "alert-item delete",
+    "description" : "Delete an alert"
+  }, {
+    "permissionName" : "orders-storage.alerts.all",
+    "displayName" : "All alert perms",
+    "description" : "All permissions for the alert",
+    "subPermissions" : [ "orders-storage.alerts.collection.get", "orders-storage.alerts.item.post", "orders-storage.alerts.item.get", "orders-storage.alerts.item.put", "orders-storage.alerts.item.delete" ]
+  }, {
+    "permissionName" : "orders-storage.pieces.collection.get",
+    "displayName" : "orders-storage.pieces-collection get",
+    "description" : "Get a collection of pieces"
+  }, {
+    "permissionName" : "orders-storage.pieces.item.post",
+    "displayName" : "orders-storage.pieces-item post",
+    "description" : "Create a new pieces"
+  }, {
+    "permissionName" : "orders-storage.pieces.item.get",
+    "displayName" : "orders-storage.pieces-item get",
+    "description" : "Fetch a piece"
+  }, {
+    "permissionName" : "orders-storage.pieces.item.put",
+    "displayName" : "orders-storage.pieces-item put",
+    "description" : "Update a piece"
+  }, {
+    "permissionName" : "orders-storage.pieces.item.delete",
+    "displayName" : "orders-storage.pieces-item delete",
+    "description" : "Delete a piece"
+  }, {
+    "permissionName" : "orders-storage.pieces.all",
+    "displayName" : "All orders-storage pieces perms",
+    "description" : "All permissions for the orders-storage-pieces",
+    "subPermissions" : [ "orders-storage.pieces.collection.get", "orders-storage.pieces.item.post", "orders-storage.pieces.item.get", "orders-storage.pieces.item.put", "orders-storage.pieces.item.delete" ]
+  }, {
+    "permissionName" : "orders-storage.titles.collection.get",
+    "displayName" : "orders-storage.titles-collection get",
+    "description" : "Get a collection of titles"
+  }, {
+    "permissionName" : "orders-storage.titles.item.post",
+    "displayName" : "orders-storage.titles-item post",
+    "description" : "Create a new title"
+  }, {
+    "permissionName" : "orders-storage.titles.item.get",
+    "displayName" : "orders-storage.titles-item get",
+    "description" : "Fetch a title"
+  }, {
+    "permissionName" : "orders-storage.titles.item.put",
+    "displayName" : "orders-storage.titles-item put",
+    "description" : "Update a title"
+  }, {
+    "permissionName" : "orders-storage.titles.item.delete",
+    "displayName" : "orders-storage.titles-item delete",
+    "description" : "Delete a title"
+  }, {
+    "permissionName" : "orders-storage.titles.all",
+    "displayName" : "All orders-storage titles perms",
+    "description" : "All permissions for the orders-storage-titles",
+    "subPermissions" : [ "orders-storage.titles.collection.get", "orders-storage.titles.item.post", "orders-storage.titles.item.get", "orders-storage.titles.item.put", "orders-storage.titles.item.delete" ]
+  }, {
+    "permissionName" : "orders-storage.po-lines.collection.get",
+    "displayName" : "po-line-collection get",
+    "description" : "Get a collection of po-lines"
+  }, {
+    "permissionName" : "orders-storage.po-lines.item.post",
+    "displayName" : "po-line-item post",
+    "description" : "Create a new po-line"
+  }, {
+    "permissionName" : "orders-storage.po-lines.item.get",
+    "displayName" : "po-line-item get",
+    "description" : "Fetch a po-line"
+  }, {
+    "permissionName" : "orders-storage.po-lines.item.put",
+    "displayName" : "po-line-item put",
+    "description" : "Update a purchase order line"
+  }, {
+    "permissionName" : "orders-storage.po-lines.item.delete",
+    "displayName" : "po-line-item delete",
+    "description" : "Delete a po line"
+  }, {
+    "permissionName" : "orders-storage.po-lines.all",
+    "displayName" : "All po line perms",
+    "description" : "All permissions for the po line",
+    "subPermissions" : [ "orders-storage.po-lines.collection.get", "orders-storage.po-lines.item.post", "orders-storage.po-lines.item.get", "orders-storage.po-lines.item.put", "orders-storage.po-lines.item.delete" ]
+  }, {
+    "permissionName" : "orders-storage.purchase-orders.collection.get",
+    "displayName" : "purchase-order-collection get",
+    "description" : "Get a collection of purchase orders"
+  }, {
+    "permissionName" : "orders-storage.purchase-orders.item.post",
+    "displayName" : "purchase-order-item post",
+    "description" : "Create a new purchase-order"
+  }, {
+    "permissionName" : "orders-storage.purchase-orders.item.get",
+    "displayName" : "purchase-order-item get",
+    "description" : "Fetch a purchase-order"
+  }, {
+    "permissionName" : "orders-storage.purchase-orders.item.put",
+    "displayName" : "purchase-order-item put",
+    "description" : "Update a purchase order"
+  }, {
+    "permissionName" : "orders-storage.purchase-orders.item.delete",
+    "displayName" : "purchase-order-item delete",
+    "description" : "Delete a purchase order"
+  }, {
+    "permissionName" : "orders-storage.purchase-orders.all",
+    "displayName" : "All purchase order perms",
+    "description" : "All permissions for the purchase order",
+    "subPermissions" : [ "orders-storage.purchase-orders.collection.get", "orders-storage.purchase-orders.item.post", "orders-storage.purchase-orders.item.get", "orders-storage.purchase-orders.item.put", "orders-storage.purchase-orders.item.delete" ]
+  }, {
+    "permissionName" : "orders-storage.receiving-history.collection.get",
+    "displayName" : "orders-storage.receiving-history-collection get",
+    "description" : "Get a collection of receiving-history"
+  }, {
+    "permissionName" : "orders-storage.receiving-history.all",
+    "displayName" : "All orders-storage receiving-history perms",
+    "description" : "All permissions for the orders-storage-receiving-history",
+    "subPermissions" : [ "orders-storage.receiving-history.collection.get" ]
+  }, {
+    "permissionName" : "orders-storage.reporting-codes.collection.get",
+    "displayName" : "reporting-code-collection get",
+    "description" : "Get a collection of reporting-codes"
+  }, {
+    "permissionName" : "orders-storage.reporting-codes.item.post",
+    "displayName" : "reporting-code-item post",
+    "description" : "Create a new reporting-code"
+  }, {
+    "permissionName" : "orders-storage.reporting-codes.item.get",
+    "displayName" : "reporting-code-item get",
+    "description" : "Fetch a reporting-code"
+  }, {
+    "permissionName" : "orders-storage.reporting-codes.item.put",
+    "displayName" : "reporting-code-item put",
+    "description" : "Update a reporting-code"
+  }, {
+    "permissionName" : "orders-storage.reporting-codes.item.delete",
+    "displayName" : "reporting_code-item delete",
+    "description" : "Delete a reporting-code"
+  }, {
+    "permissionName" : "orders-storage.reporting-codes.all",
+    "displayName" : "All reporting_code perms",
+    "description" : "All permissions for the reporting-code",
+    "subPermissions" : [ "orders-storage.reporting-codes.collection.get", "orders-storage.reporting-codes.item.post", "orders-storage.reporting-codes.item.get", "orders-storage.reporting-codes.item.put", "orders-storage.reporting-codes.item.delete" ]
+  }, {
+    "permissionName" : "orders-storage.po-number.get",
+    "displayName" : "po-number get",
+    "description" : "Get a generated PO number"
+  }, {
+    "permissionName" : "orders-storage.po-number.all",
+    "displayName" : "All po-number perms",
+    "description" : "All permissions for the PO number",
+    "subPermissions" : [ "orders-storage.po-number.get" ]
+  }, {
+    "permissionName" : "orders-storage.po-line-number.get",
+    "displayName" : "po-line-number get",
+    "description" : "Get a POLine number"
+  }, {
+    "permissionName" : "orders-storage.po-line-number.all",
+    "displayName" : "All po-line-number perms",
+    "description" : "All permissions for the POLine number",
+    "subPermissions" : [ "orders-storage.po-line-number.get" ]
+  }, {
+    "permissionName" : "orders-storage.order-invoice-relationships.collection.get",
+    "displayName" : "order-invoice-relationships-collection get",
+    "description" : "Get a collection of order-invoice-relationship"
+  }, {
+    "permissionName" : "orders-storage.order-invoice-relationships.item.post",
+    "displayName" : "order-invoice-relationships post",
+    "description" : "Create a new relationship between order and invoice"
+  }, {
+    "permissionName" : "orders-storage.order-invoice-relationships.item.get",
+    "displayName" : "order-invoice-relationships-item get",
+    "description" : "Fetch an order-invoice-relationship"
+  }, {
+    "permissionName" : "orders-storage.order-invoice-relationships.item.put",
+    "displayName" : "order-invoice-relationships-item put",
+    "description" : "Update an order-invoice-relationship"
+  }, {
+    "permissionName" : "orders-storage.order-invoice-relationships.item.delete",
+    "displayName" : "order-invoice-relationships-item delete",
+    "description" : "Delete an order-invoice-relationship"
+  }, {
+    "permissionName" : "orders-storage.order-invoice-relationships.all",
+    "displayName" : "All order-invoice-relationships perms",
+    "description" : "All permissions for the order-invoice-relationship",
+    "subPermissions" : [ "orders-storage.order-invoice-relationships.collection.get", "orders-storage.order-invoice-relationships.item.post", "orders-storage.order-invoice-relationships.item.get", "orders-storage.order-invoice-relationships.item.put", "orders-storage.order-invoice-relationships.item.delete" ]
+  }, {
+    "permissionName" : "orders-storage.order-templates.collection.get",
+    "displayName" : "order-order-templates-collection get",
+    "description" : "Get a collection of order templates"
+  }, {
+    "permissionName" : "orders-storage.order-templates.item.post",
+    "displayName" : "order-templates post",
+    "description" : "Create a new order template"
+  }, {
+    "permissionName" : "orders-storage.order-templates.item.get",
+    "displayName" : "order-templates-item get",
+    "description" : "Fetch an order templates"
+  }, {
+    "permissionName" : "orders-storage.order-templates.item.put",
+    "displayName" : "order-templates-item put",
+    "description" : "Update an order template"
+  }, {
+    "permissionName" : "orders-storage.order-templates.item.delete",
+    "displayName" : "order-templates-item delete",
+    "description" : "Delete an order template"
+  }, {
+    "permissionName" : "orders-storage.order-templates.all",
+    "displayName" : "All order-templates perms",
+    "description" : "All permissions for the order-templates",
+    "subPermissions" : [ "orders-storage.order-templates.collection.get", "orders-storage.order-templates.item.post", "orders-storage.order-templates.item.get", "orders-storage.order-templates.item.put", "orders-storage.order-templates.item.delete" ]
+  }, {
+    "permissionName" : "acquisitions-units-storage.units.collection.get",
+    "displayName" : "acquisitions-units-collection get",
+    "description" : "Get a collection of acquisitions units"
+  }, {
+    "permissionName" : "acquisitions-units-storage.units.item.post",
+    "displayName" : "acquisitions-units-item post",
+    "description" : "Create a new acquisitions unit"
+  }, {
+    "permissionName" : "acquisitions-units-storage.units.item.get",
+    "displayName" : "acquisitions-units-item get",
+    "description" : "Fetch an acquisitions unit"
+  }, {
+    "permissionName" : "acquisitions-units-storage.units.item.put",
+    "displayName" : "acquisitions-units-item put",
+    "description" : "Update an acquisitions unit"
+  }, {
+    "permissionName" : "acquisitions-units-storage.units.item.delete",
+    "displayName" : "acquisitions-units-item delete",
+    "description" : "Delete an acquisitions unit"
+  }, {
+    "permissionName" : "acquisitions-units-storage.units.all",
+    "displayName" : "All acquisitions-units perms",
+    "description" : "All permissions for the acquisitions-units",
+    "subPermissions" : [ "acquisitions-units-storage.units.collection.get", "acquisitions-units-storage.units.item.post", "acquisitions-units-storage.units.item.get", "acquisitions-units-storage.units.item.put", "acquisitions-units-storage.units.item.delete" ]
+  }, {
+    "permissionName" : "acquisitions-units-storage.memberships.collection.get",
+    "displayName" : "acquisitions-units-memberships-collection get",
+    "description" : "Get a collection of acquisitions units memberships"
+  }, {
+    "permissionName" : "acquisitions-units-storage.memberships.item.post",
+    "displayName" : "acquisitions-units-memberships-item post",
+    "description" : "Create a new acquisitions unit membership"
+  }, {
+    "permissionName" : "acquisitions-units-storage.memberships.item.get",
+    "displayName" : "acquisitions-units-memberships-item get",
+    "description" : "Fetch an acquisitions unit membership"
+  }, {
+    "permissionName" : "acquisitions-units-storage.memberships.item.put",
+    "displayName" : "acquisitions-units-memberships-item put",
+    "description" : "Update an acquisitions unit membership"
+  }, {
+    "permissionName" : "acquisitions-units-storage.memberships.item.delete",
+    "displayName" : "acquisitions-units-memberships-item delete",
+    "description" : "Delete an acquisitions unit membership"
+  }, {
+    "permissionName" : "acquisitions-units-storage.memberships.all",
+    "displayName" : "All acquisitions-units-memberships perms",
+    "description" : "All permissions for the acquisitions-units memberships",
+    "subPermissions" : [ "acquisitions-units-storage.memberships.collection.get", "acquisitions-units-storage.memberships.item.post", "acquisitions-units-storage.memberships.item.get", "acquisitions-units-storage.memberships.item.put", "acquisitions-units-storage.memberships.item.delete" ]
+  }, {
+    "permissionName" : "orders-storage.configuration.reasons-for-closure.collection.get",
+    "displayName" : "orders-storage-configuration-reasons-for-closure-collection get",
+    "description" : "Get a collection of reasons for closure"
+  }, {
+    "permissionName" : "orders-storage.configuration.reasons-for-closure.item.post",
+    "displayName" : "orders-storage-configuration-reasons-for-closure-item post",
+    "description" : "Create a new reason for closure"
+  }, {
+    "permissionName" : "orders-storage.configuration.reasons-for-closure.item.get",
+    "displayName" : "orders-storage-configuration-reasons-for-closure-item get",
+    "description" : "Fetch a reason for closure"
+  }, {
+    "permissionName" : "orders-storage.configuration.reasons-for-closure.item.put",
+    "displayName" : "orders-storage-configuration-reasons-for-closure-item put",
+    "description" : "Update a reason for closure"
+  }, {
+    "permissionName" : "orders-storage.configuration.reasons-for-closure.item.delete",
+    "displayName" : "orders-storage-configuration-reasons-for-closure-item delete",
+    "description" : "Delete a reason for closure"
+  }, {
+    "permissionName" : "orders-storage.configuration.reasons-for-closure.all",
+    "displayName" : "All orders-storage reasons for closure perms",
+    "description" : "All permissions for the orders-storage configuration - reasons for closure",
+    "subPermissions" : [ "orders-storage.configuration.reasons-for-closure.collection.get", "orders-storage.configuration.reasons-for-closure.item.post", "orders-storage.configuration.reasons-for-closure.item.get", "orders-storage.configuration.reasons-for-closure.item.put", "orders-storage.configuration.reasons-for-closure.item.delete" ]
+  }, {
+    "permissionName" : "orders-storage.configuration.prefixes.collection.get",
+    "displayName" : "orders-storage-configuration-prefix-collection get",
+    "description" : "Get a collection of prefixes"
+  }, {
+    "permissionName" : "orders-storage.configuration.prefixes.item.post",
+    "displayName" : "orders-storage-configuration-prefixes-item post",
+    "description" : "Create a new prefix"
+  }, {
+    "permissionName" : "orders-storage.configuration.prefixes.item.get",
+    "displayName" : "orders-storage-configuration-prefixes-item get",
+    "description" : "Fetch a prefix"
+  }, {
+    "permissionName" : "orders-storage.configuration.prefixes.item.put",
+    "displayName" : "orders-storage-configuration-prefix-item put",
+    "description" : "Update a prefix"
+  }, {
+    "permissionName" : "orders-storage.configuration.prefixes.item.delete",
+    "displayName" : "orders-storage-configuration-prefixes-item delete",
+    "description" : "Delete a prefix"
+  }, {
+    "permissionName" : "orders-storage.configuration.prefixes.all",
+    "displayName" : "All orders-storage prefixes perms",
+    "description" : "All permissions for the orders-storage configuration - prefixes",
+    "subPermissions" : [ "orders-storage.configuration.prefixes.collection.get", "orders-storage.configuration.prefixes.item.post", "orders-storage.configuration.prefixes.item.get", "orders-storage.configuration.prefixes.item.put", "orders-storage.configuration.prefixes.item.delete" ]
+  }, {
+    "permissionName" : "orders-storage.configuration.suffixes.collection.get",
+    "displayName" : "orders-storage-configuration-suffixes-collection get",
+    "description" : "Get a collection of suffixes"
+  }, {
+    "permissionName" : "orders-storage.configuration.suffixes.item.post",
+    "displayName" : "orders-storage-configuration-suffixes-item post",
+    "description" : "Create a new suffix"
+  }, {
+    "permissionName" : "orders-storage.configuration.suffixes.item.get",
+    "displayName" : "orders-storage-configuration-suffixes-item get",
+    "description" : "Fetch a suffix"
+  }, {
+    "permissionName" : "orders-storage.configuration.suffixes.item.put",
+    "displayName" : "orders-storage-configuration-suffix-item put",
+    "description" : "Update a suffix"
+  }, {
+    "permissionName" : "orders-storage.configuration.suffixes.item.delete",
+    "displayName" : "orders-storage-configuration-suffixes-item delete",
+    "description" : "Delete a suffix"
+  }, {
+    "permissionName" : "orders-storage.configuration.suffixes.all",
+    "displayName" : "All orders-storage suffixes perms",
+    "description" : "All permissions for the orders-storage configuration - suffixes",
+    "subPermissions" : [ "orders-storage.configuration.suffixes.collection.get", "orders-storage.configuration.suffixes.item.post", "orders-storage.configuration.suffixes.item.get", "orders-storage.configuration.suffixes.item.put", "orders-storage.configuration.suffixes.item.delete" ]
+  }, {
+    "permissionName" : "orders-storage.module.all",
+    "displayName" : "All orders-storage-module perms",
+    "description" : "All permissions for the orders-storage module",
+    "subPermissions" : [ "orders-storage.alerts.all", "orders-storage.pieces.all", "orders-storage.titles.all", "orders-storage.po-lines.all", "orders-storage.po-number.all", "orders-storage.po-line-number.all", "orders-storage.purchase-orders.all", "orders-storage.receiving-history.all", "orders-storage.reporting-codes.all", "orders-storage.order-invoice-relationships.all", "orders-storage.order-templates.all", "acquisitions-units-storage.units.all", "acquisitions-units-storage.memberships.all", "orders-storage.configuration.reasons-for-closure.all", "orders-storage.configuration.prefixes.all", "orders-storage.configuration.suffixes.all" ]
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-orders-storage:11.0.3",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    }, {
+      "name" : "DB_HOST",
+      "value" : "postgres"
+    }, {
+      "name" : "DB_PORT",
+      "value" : "5432"
+    }, {
+      "name" : "DB_USERNAME",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_PASSWORD",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_DATABASE",
+      "value" : "okapi_modules"
+    }, {
+      "name" : "DB_QUERYTIMEOUT",
+      "value" : "60000"
+    }, {
+      "name" : "DB_CHARSET",
+      "value" : "UTF-8"
+    }, {
+      "name" : "DB_MAXPOOLSIZE",
+      "value" : "5"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-organizations-1.0.0",
+  "name" : "Organizations business logic module",
+  "requires" : [ {
+    "id" : "organizations-storage.organizations",
+    "version" : "3.1"
+  } ],
+  "provides" : [ {
+    "id" : "organizations.organizations",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/organizations/organizations",
+      "permissionsRequired" : [ "organizations.organizations.collection.get" ],
+      "modulePermissions" : [ "organizations-storage.organizations.collection.get", "acquisitions-units-storage.units.collection.get", "acquisitions-units-storage.memberships.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/organizations/organizations",
+      "permissionsRequired" : [ "organizations.organizations.item.post" ],
+      "modulePermissions" : [ "organizations-storage.organizations.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/organizations/organizations/{id}",
+      "permissionsRequired" : [ "organizations.organizations.item.get" ],
+      "modulePermissions" : [ "organizations-storage.organizations.item.get", "acquisitions-units-storage.units.collection.get", "acquisitions-units-storage.memberships.collection.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/organizations/organizations/{id}",
+      "permissionsRequired" : [ "organizations.organizations.item.put" ],
+      "permissionsDesired" : [ "organizations.acquisitions-units-assignments.manage" ],
+      "modulePermissions" : [ "organizations-storage.organizations.item.get", "organizations-storage.organizations.item.put", "acquisitions-units-storage.units.collection.get", "acquisitions-units-storage.memberships.collection.get" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/organizations/organizations/{id}",
+      "permissionsRequired" : [ "organizations.organizations.item.delete" ],
+      "modulePermissions" : [ "organizations-storage.organizations.item.delete" ]
+    } ]
+  }, {
+    "id" : "_jsonSchemas",
+    "version" : "1.0",
+    "interfaceType" : "multiple",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/_/jsonSchemas",
+      "permissionsRequired" : [ ]
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "organizations.organizations.collection.get",
+    "displayName" : "Organizations collection get",
+    "description" : "Get a collection of organizations"
+  }, {
+    "permissionName" : "organizations.organizations.item.post",
+    "displayName" : "Organizations post",
+    "description" : "Create a new organization"
+  }, {
+    "permissionName" : "organizations.organizations.item.get",
+    "displayName" : "Organizations get",
+    "description" : "Fetch an organization"
+  }, {
+    "permissionName" : "organizations.organizations.item.put",
+    "displayName" : "Organizations put",
+    "description" : "Update an organization"
+  }, {
+    "permissionName" : "organizations.organizations.item.delete",
+    "displayName" : "Organizations delete",
+    "description" : "Delete an organizations"
+  }, {
+    "permissionName" : "organizations.organizations.all",
+    "displayName" : "Organizations all",
+    "description" : "All permissions for organizations",
+    "subPermissions" : [ "organizations.organizations.collection.get", "organizations.organizations.item.post", "organizations.organizations.item.get", "organizations.organizations.item.put", "organizations.organizations.item.delete" ]
+  }, {
+    "permissionName" : "organizations.module.all",
+    "displayName" : "Organizations-module all",
+    "description" : "All permissions for the organizations module",
+    "subPermissions" : [ "organizations.organizations.all" ]
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-organizations:1.0.0",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-organizations-storage-3.1.1",
+  "name" : "Organizations CRUD module",
+  "provides" : [ {
+    "id" : "organizations-storage.addresses",
+    "version" : "1.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/organizations-storage/addresses",
+      "permissionsRequired" : [ "organizations-storage.addresses.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/organizations-storage/addresses",
+      "permissionsRequired" : [ "organizations-storage.addresses.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/organizations-storage/addresses/{id}",
+      "permissionsRequired" : [ "organizations-storage.addresses.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/organizations-storage/addresses/{id}",
+      "permissionsRequired" : [ "organizations-storage.addresses.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/organizations-storage/addresses/{id}",
+      "permissionsRequired" : [ "organizations-storage.addresses.item.delete" ]
+    } ]
+  }, {
+    "id" : "organizations-storage.categories",
+    "version" : "1.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/organizations-storage/categories",
+      "permissionsRequired" : [ "organizations-storage.categories.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/organizations-storage/categories",
+      "permissionsRequired" : [ "organizations-storage.categories.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/organizations-storage/categories/{id}",
+      "permissionsRequired" : [ "organizations-storage.categories.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/organizations-storage/categories/{id}",
+      "permissionsRequired" : [ "organizations-storage.categories.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/organizations-storage/categories/{id}",
+      "permissionsRequired" : [ "organizations-storage.categories.item.delete" ]
+    } ]
+  }, {
+    "id" : "organizations-storage.contacts",
+    "version" : "2.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/organizations-storage/contacts",
+      "permissionsRequired" : [ "organizations-storage.contacts.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/organizations-storage/contacts",
+      "permissionsRequired" : [ "organizations-storage.contacts.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/organizations-storage/contacts/{id}",
+      "permissionsRequired" : [ "organizations-storage.contacts.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/organizations-storage/contacts/{id}",
+      "permissionsRequired" : [ "organizations-storage.contacts.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/organizations-storage/contacts/{id}",
+      "permissionsRequired" : [ "organizations-storage.contacts.item.delete" ]
+    } ]
+  }, {
+    "id" : "organizations-storage.emails",
+    "version" : "1.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/organizations-storage/emails",
+      "permissionsRequired" : [ "organizations-storage.emails.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/organizations-storage/emails",
+      "permissionsRequired" : [ "organizations-storage.emails.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/organizations-storage/emails/{id}",
+      "permissionsRequired" : [ "organizations-storage.emails.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/organizations-storage/emails/{id}",
+      "permissionsRequired" : [ "organizations-storage.emails.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/organizations-storage/emails/{id}",
+      "permissionsRequired" : [ "organizations-storage.emails.item.delete" ]
+    } ]
+  }, {
+    "id" : "organizations-storage.interfaces",
+    "version" : "2.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/organizations-storage/interfaces",
+      "permissionsRequired" : [ "organizations-storage.interfaces.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/organizations-storage/interfaces",
+      "permissionsRequired" : [ "organizations-storage.interfaces.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/organizations-storage/interfaces/{id}",
+      "permissionsRequired" : [ "organizations-storage.interfaces.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/organizations-storage/interfaces/{id}",
+      "permissionsRequired" : [ "organizations-storage.interfaces.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/organizations-storage/interfaces/{id}",
+      "permissionsRequired" : [ "organizations-storage.interfaces.item.delete" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/organizations-storage/interfaces/{id}/credentials",
+      "permissionsRequired" : [ "organizations-storage.interfaces.credentials.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/organizations-storage/interfaces/{id}/credentials",
+      "permissionsRequired" : [ "organizations-storage.interfaces.credentials.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/organizations-storage/interfaces/{id}/credentials",
+      "permissionsRequired" : [ "organizations-storage.interfaces.credentials.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/organizations-storage/interfaces/{id}/credentials",
+      "permissionsRequired" : [ "organizations-storage.interfaces.credentials.item.delete" ]
+    } ]
+  }, {
+    "id" : "organizations-storage.phone-numbers",
+    "version" : "2.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/organizations-storage/phone-numbers",
+      "permissionsRequired" : [ "organizations-storage.phone-numbers.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/organizations-storage/phone-numbers",
+      "permissionsRequired" : [ "organizations-storage.phone-numbers.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/organizations-storage/phone-numbers/{id}",
+      "permissionsRequired" : [ "organizations-storage.phone-numbers.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/organizations-storage/phone-numbers/{id}",
+      "permissionsRequired" : [ "organizations-storage.phone-numbers.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/organizations-storage/phone-numbers/{id}",
+      "permissionsRequired" : [ "organizations-storage.phone-numbers.item.delete" ]
+    } ]
+  }, {
+    "id" : "organizations-storage.urls",
+    "version" : "1.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/organizations-storage/urls",
+      "permissionsRequired" : [ "organizations-storage.urls.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/organizations-storage/urls",
+      "permissionsRequired" : [ "organizations-storage.urls.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/organizations-storage/urls/{id}",
+      "permissionsRequired" : [ "organizations-storage.urls.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/organizations-storage/urls/{id}",
+      "permissionsRequired" : [ "organizations-storage.urls.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/organizations-storage/urls/{id}",
+      "permissionsRequired" : [ "organizations-storage.urls.item.delete" ]
+    } ]
+  }, {
+    "id" : "organizations-storage.organizations",
+    "version" : "3.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/organizations-storage/organizations",
+      "permissionsRequired" : [ "organizations-storage.organizations.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/organizations-storage/organizations",
+      "permissionsRequired" : [ "organizations-storage.organizations.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/organizations-storage/organizations/{organizations_id}",
+      "permissionsRequired" : [ "organizations-storage.organizations.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/organizations-storage/organizations/{organizations_id}",
+      "permissionsRequired" : [ "organizations-storage.organizations.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/organizations-storage/organizations/{organizations_id}",
+      "permissionsRequired" : [ "organizations-storage.organizations.item.delete" ]
+    } ]
+  }, {
+    "id" : "_tenant",
+    "version" : "1.2",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST", "DELETE" ],
+      "pathPattern" : "/_/tenant"
+    } ]
+  }, {
+    "id" : "_jsonSchemas",
+    "version" : "1.0",
+    "interfaceType" : "multiple",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/_/jsonSchemas",
+      "permissionsRequired" : [ ]
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "organizations-storage.addresses.collection.get",
+    "displayName" : "address collection get",
+    "description" : "Get a collection of addresses"
+  }, {
+    "permissionName" : "organizations-storage.addresses.item.post",
+    "displayName" : "address post",
+    "description" : "Create a new address"
+  }, {
+    "permissionName" : "organizations-storage.addresses.item.get",
+    "displayName" : "address get",
+    "description" : "Fetch a address"
+  }, {
+    "permissionName" : "organizations-storage.addresses.item.put",
+    "displayName" : "address put",
+    "description" : "Update a address"
+  }, {
+    "permissionName" : "organizations-storage.addresses.item.delete",
+    "displayName" : "address delete",
+    "description" : "Delete a address"
+  }, {
+    "permissionName" : "organizations-storage.addresses.all",
+    "displayName" : "address all",
+    "description" : "All permissions for address",
+    "subPermissions" : [ "organizations-storage.addresses.collection.get", "organizations-storage.addresses.item.post", "organizations-storage.addresses.item.get", "organizations-storage.addresses.item.put", "organizations-storage.addresses.item.delete" ]
+  }, {
+    "permissionName" : "organizations-storage.categories.collection.get",
+    "displayName" : "category collection get",
+    "description" : "Get a collection of categories"
+  }, {
+    "permissionName" : "organizations-storage.categories.item.post",
+    "displayName" : "category post",
+    "description" : "Create a new category"
+  }, {
+    "permissionName" : "organizations-storage.categories.item.get",
+    "displayName" : "category get",
+    "description" : "Fetch a category"
+  }, {
+    "permissionName" : "organizations-storage.categories.item.put",
+    "displayName" : "category put",
+    "description" : "Update a category"
+  }, {
+    "permissionName" : "organizations-storage.categories.item.delete",
+    "displayName" : "category delete",
+    "description" : "Delete a category"
+  }, {
+    "permissionName" : "organizations-storage.categories.all",
+    "displayName" : "category all",
+    "description" : "All permissions for category",
+    "subPermissions" : [ "organizations-storage.categories.collection.get", "organizations-storage.categories.item.post", "organizations-storage.categories.item.get", "organizations-storage.categories.item.put", "organizations-storage.categories.item.delete" ]
+  }, {
+    "permissionName" : "organizations-storage.contacts.collection.get",
+    "displayName" : "contact collection get",
+    "description" : "Get a collection of contacts"
+  }, {
+    "permissionName" : "organizations-storage.contacts.item.post",
+    "displayName" : "contact post",
+    "description" : "Create a new contact"
+  }, {
+    "permissionName" : "organizations-storage.contacts.item.get",
+    "displayName" : "contact get",
+    "description" : "Fetch a contact"
+  }, {
+    "permissionName" : "organizations-storage.contacts.item.put",
+    "displayName" : "contact put",
+    "description" : "Update a contact"
+  }, {
+    "permissionName" : "organizations-storage.contacts.item.delete",
+    "displayName" : "contact delete",
+    "description" : "Delete a contact"
+  }, {
+    "permissionName" : "organizations-storage.contacts.all",
+    "displayName" : "contact all",
+    "description" : "All permissions for contact",
+    "subPermissions" : [ "organizations-storage.contacts.collection.get", "organizations-storage.contacts.item.post", "organizations-storage.contacts.item.get", "organizations-storage.contacts.item.put", "organizations-storage.contacts.item.delete" ]
+  }, {
+    "permissionName" : "organizations-storage.emails.collection.get",
+    "displayName" : "email collection get",
+    "description" : "Get a collection of emails"
+  }, {
+    "permissionName" : "organizations-storage.emails.item.post",
+    "displayName" : "email post",
+    "description" : "Create a new email"
+  }, {
+    "permissionName" : "organizations-storage.emails.item.get",
+    "displayName" : "email get",
+    "description" : "Fetch a email"
+  }, {
+    "permissionName" : "organizations-storage.emails.item.put",
+    "displayName" : "email put",
+    "description" : "Update a email"
+  }, {
+    "permissionName" : "organizations-storage.emails.item.delete",
+    "displayName" : "email delete",
+    "description" : "Delete a email"
+  }, {
+    "permissionName" : "organizations-storage.emails.all",
+    "displayName" : "email all",
+    "description" : "All permissions for email",
+    "subPermissions" : [ "organizations-storage.emails.collection.get", "organizations-storage.emails.item.post", "organizations-storage.emails.item.get", "organizations-storage.emails.item.put", "organizations-storage.emails.item.delete" ]
+  }, {
+    "permissionName" : "organizations-storage.interfaces.collection.get",
+    "displayName" : "interface collection get",
+    "description" : "Get a collection of interface"
+  }, {
+    "permissionName" : "organizations-storage.interfaces.item.post",
+    "displayName" : "interface post",
+    "description" : "Create a new interface"
+  }, {
+    "permissionName" : "organizations-storage.interfaces.item.get",
+    "displayName" : "interface get",
+    "description" : "Fetch a interface"
+  }, {
+    "permissionName" : "organizations-storage.interfaces.item.put",
+    "displayName" : "interface put",
+    "description" : "Update a interface"
+  }, {
+    "permissionName" : "organizations-storage.interfaces.item.delete",
+    "displayName" : "interface delete",
+    "description" : "Delete a interface"
+  }, {
+    "permissionName" : "organizations-storage.interfaces.all",
+    "displayName" : "interface all",
+    "description" : "All permissions for interface",
+    "subPermissions" : [ "organizations-storage.interfaces.collection.get", "organizations-storage.interfaces.item.post", "organizations-storage.interfaces.item.get", "organizations-storage.interfaces.item.put", "organizations-storage.interfaces.item.delete" ]
+  }, {
+    "permissionName" : "organizations-storage.interfaces.credentials.item.post",
+    "displayName" : "interface credentials post",
+    "description" : "Create a new interface credentials"
+  }, {
+    "permissionName" : "organizations-storage.interfaces.credentials.item.get",
+    "displayName" : "interface credentials get",
+    "description" : "Fetch an interface credentials"
+  }, {
+    "permissionName" : "organizations-storage.interfaces.credentials.item.put",
+    "displayName" : "interface credentials put",
+    "description" : "Update an interface credentials"
+  }, {
+    "permissionName" : "organizations-storage.interfaces.credentials.item.delete",
+    "displayName" : "interface credentials delete",
+    "description" : "Delete an interface credentials"
+  }, {
+    "permissionName" : "organizations-storage.interfaces.credentials.all",
+    "displayName" : "interface credentials all",
+    "description" : "All permissions for interface credentials",
+    "subPermissions" : [ "organizations-storage.interfaces.credentials.item.post", "organizations-storage.interfaces.credentials.item.get", "organizations-storage.interfaces.credentials.item.put", "organizations-storage.interfaces.credentials.item.delete" ]
+  }, {
+    "permissionName" : "organizations-storage.phone-numbers.collection.get",
+    "displayName" : "phone_number collection get",
+    "description" : "Get a collection of phone_numbers"
+  }, {
+    "permissionName" : "organizations-storage.phone-numbers.item.post",
+    "displayName" : "phone_number post",
+    "description" : "Create a new phone_number"
+  }, {
+    "permissionName" : "organizations-storage.phone-numbers.item.get",
+    "displayName" : "phone_number get",
+    "description" : "Fetch a phone_number"
+  }, {
+    "permissionName" : "organizations-storage.phone-numbers.item.put",
+    "displayName" : "phone_number put",
+    "description" : "Update a phone_number"
+  }, {
+    "permissionName" : "organizations-storage.phone-numbers.item.delete",
+    "displayName" : "phone_number delete",
+    "description" : "Delete a phone_number"
+  }, {
+    "permissionName" : "organizations-storage.phone-numbers.all",
+    "displayName" : "phone_number all",
+    "description" : "All permissions for phone_number",
+    "subPermissions" : [ "organizations-storage.phone-numbers.collection.get", "organizations-storage.phone-numbers.item.post", "organizations-storage.phone-numbers.item.get", "organizations-storage.phone-numbers.item.put", "organizations-storage.phone-numbers.item.delete" ]
+  }, {
+    "permissionName" : "organizations-storage.urls.collection.get",
+    "displayName" : "url collection get",
+    "description" : "Get a collection of urls"
+  }, {
+    "permissionName" : "organizations-storage.urls.item.post",
+    "displayName" : "url post",
+    "description" : "Create a new url"
+  }, {
+    "permissionName" : "organizations-storage.urls.item.get",
+    "displayName" : "url get",
+    "description" : "Fetch a url"
+  }, {
+    "permissionName" : "organizations-storage.urls.item.put",
+    "displayName" : "url put",
+    "description" : "Update a url"
+  }, {
+    "permissionName" : "organizations-storage.urls.item.delete",
+    "displayName" : "url delete",
+    "description" : "Delete a url"
+  }, {
+    "permissionName" : "organizations-storage.urls.all",
+    "displayName" : "url all",
+    "description" : "All permissions for url",
+    "subPermissions" : [ "organizations-storage.urls.collection.get", "organizations-storage.urls.item.post", "organizations-storage.urls.item.get", "organizations-storage.urls.item.put", "organizations-storage.urls.item.delete" ]
+  }, {
+    "permissionName" : "organizations-storage.organizations.collection.get",
+    "displayName" : "organizations collection get",
+    "description" : "Get a collection of organizations"
+  }, {
+    "permissionName" : "organizations-storage.organizations.item.post",
+    "displayName" : "organizations post",
+    "description" : "Create a new organizations"
+  }, {
+    "permissionName" : "organizations-storage.organizations.item.get",
+    "displayName" : "organizations get",
+    "description" : "Fetch a organizations"
+  }, {
+    "permissionName" : "organizations-storage.organizations.item.put",
+    "displayName" : "organizations put",
+    "description" : "Update a organizations"
+  }, {
+    "permissionName" : "organizations-storage.organizations.item.delete",
+    "displayName" : "organizations delete",
+    "description" : "Delete a organizations"
+  }, {
+    "permissionName" : "organizations-storage.organizations.all",
+    "displayName" : "organizations all",
+    "description" : "All permissions for organizations",
+    "subPermissions" : [ "organizations-storage.organizations.collection.get", "organizations-storage.organizations.item.post", "organizations-storage.organizations.item.get", "organizations-storage.organizations.item.put", "organizations-storage.organizations.item.delete" ]
+  }, {
+    "permissionName" : "organizations-storage.module.all",
+    "displayName" : "organizations-storage-module all",
+    "description" : "All permissions for the organizations module",
+    "subPermissions" : [ "organizations-storage.addresses.all", "organizations-storage.categories.all", "organizations-storage.contacts.all", "organizations-storage.emails.all", "organizations-storage.interfaces.all", "organizations-storage.interfaces.credentials.all", "organizations-storage.phone-numbers.all", "organizations-storage.urls.all", "organizations-storage.organizations.all" ]
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-organizations-storage:3.1.1",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    }, {
+      "name" : "DB_HOST",
+      "value" : "postgres"
+    }, {
+      "name" : "DB_PORT",
+      "value" : "5432"
+    }, {
+      "name" : "DB_USERNAME",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_PASSWORD",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_DATABASE",
+      "value" : "okapi_modules"
+    }, {
+      "name" : "DB_QUERYTIMEOUT",
+      "value" : "60000"
+    }, {
+      "name" : "DB_CHARSET",
+      "value" : "UTF-8"
+    }, {
+      "name" : "DB_MAXPOOLSIZE",
+      "value" : "5"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-password-validator-1.7.0",
+  "name" : "Password Validator Module",
+  "requires" : [ {
+    "id" : "users",
+    "version" : "15.0"
+  } ],
+  "provides" : [ {
+    "id" : "password-validator",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/password/validate",
+      "permissionsRequired" : [ "validation.validate.post" ],
+      "modulePermissions" : [ "login.password.validate", "users.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/tenant/rules",
+      "permissionsRequired" : [ "validation.rules.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/tenant/rules",
+      "permissionsRequired" : [ "validation.rules.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/tenant/rules",
+      "permissionsRequired" : [ "validation.rules.item.put" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/tenant/rules/{ruleId}",
+      "permissionsRequired" : [ " validation.rules.item.get" ]
+    } ]
+  }, {
+    "id" : "_tenant",
+    "version" : "1.2",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/_/tenant"
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/_/tenant"
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "validation.rules.collection.get",
+    "displayName" : "get validation rules collection",
+    "description" : "Get a list of validators"
+  }, {
+    "permissionName" : "validation.validate.post",
+    "displayName" : "validate password post",
+    "description" : "Validate a password"
+  }, {
+    "permissionName" : "validation.rules.item.post",
+    "displayName" : "create validation rule",
+    "description" : "Add a new rule"
+  }, {
+    "permissionName" : "validation.rules.item.put",
+    "displayName" : "modify validation rule",
+    "description" : "Modify the rule info"
+  }, {
+    "permissionName" : "validation.rules.item.get",
+    "displayName" : "get validation rule",
+    "description" : "Get a rule by id"
+  }, {
+    "permissionName" : "validation.all",
+    "displayName" : "password validator module - all permissions",
+    "description" : "All permissions for password validation",
+    "subPermissions" : [ "validation.rules.collection.get", "validation.validate.post", "validation.rules.item.post", "validation.rules.item.put", "validation.rules.item.get" ]
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-password-validator:1.7.0",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    }, {
+      "name" : "DB_HOST",
+      "value" : "postgres"
+    }, {
+      "name" : "DB_PORT",
+      "value" : "5432"
+    }, {
+      "name" : "DB_USERNAME",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_PASSWORD",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_DATABASE",
+      "value" : "okapi_modules"
+    }, {
+      "name" : "DB_QUERYTIMEOUT",
+      "value" : "60000"
+    }, {
+      "name" : "DB_CHARSET",
+      "value" : "UTF-8"
+    }, {
+      "name" : "DB_MAXPOOLSIZE",
+      "value" : "5"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-patron-4.2.0",
+  "name" : "Patron Services Module",
+  "requires" : [ {
+    "id" : "users",
+    "version" : "15.0"
+  }, {
+    "id" : "circulation",
+    "version" : "8.0 9.0"
+  }, {
+    "id" : "feesfines",
+    "version" : "14.0 15.0"
+  }, {
+    "id" : "inventory",
+    "version" : "5.2 6.0 7.0 8.0 9.0 10.0"
+  }, {
+    "id" : "holdings-storage",
+    "version" : "1.2 2.0 3.0 4.0"
+  } ],
+  "provides" : [ {
+    "id" : "patron",
+    "version" : "4.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/patron/account/{accountId}",
+      "permissionsRequired" : [ "patron.account.item.get" ],
+      "modulePermissions" : [ "users.item.get", "circulation.loans.collection.get", "circulation.requests.collection.get", "accounts.collection.get", "inventory.items.item.get", "inventory-storage.items.collection.get", "inventory-storage.holdings.item.get", "inventory.instances.item.get", "feefines.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/patron/account/{accountId}/item/{itemId}/renew",
+      "permissionsRequired" : [ "patron.renew.item.post" ],
+      "modulePermissions" : [ "circulation.renew-by-id.post" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/patron/account/{accountId}/item/{itemId}/hold",
+      "permissionsRequired" : [ "patron.hold.item.post" ],
+      "modulePermissions" : [ "circulation.requests.item.post" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/patron/account/{accountId}/instance/{instanceId}/hold",
+      "permissionsRequired" : [ "patron.hold.instance.item.post" ],
+      "modulePermissions" : [ "circulation.requests.instances.item.post" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/patron/account/{accountId}/hold/{holdId}/cancel",
+      "permissionsRequired" : [ "patron.hold.cancel.item.post" ],
+      "modulePermissions" : [ "circulation.requests.item.put", "circulation.requests.item.get" ]
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "patron.account.item.get",
+    "displayName" : "patron - get account details",
+    "description" : "Get user account details"
+  }, {
+    "permissionName" : "patron.renew.item.post",
+    "displayName" : "patron - renew a loan",
+    "description" : "Renew a loan for this patron"
+  }, {
+    "permissionName" : "patron.hold.item.post",
+    "displayName" : "patron - create a hold",
+    "description" : "Creates a hold on the specified item for this patron"
+  }, {
+    "permissionName" : "patron.hold.instance.item.post",
+    "displayName" : "patron - create an instance level hold",
+    "description" : "Creates a hold on an item from the specified instance for this patron"
+  }, {
+    "permissionName" : "patron.hold.cancel.item.post",
+    "displayName" : "patron - remove a hold",
+    "description" : "Removes the specified hold"
+  }, {
+    "permissionName" : "patron.all",
+    "displayName" : "patron - all permissions",
+    "description" : "Entire set of permissions needed to use patron",
+    "subPermissions" : [ "patron.account.item.get", "patron.renew.item.post", "patron.hold.item.post", "patron.hold.instance.item.post", "patron.hold.cancel.item.post" ]
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-patron:4.2.0",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-patron-blocks-1.0.7",
+  "name" : "Patron Blocks Module",
+  "requires" : [ {
+    "id" : "pubsub-event-types",
+    "version" : "0.1"
+  }, {
+    "id" : "pubsub-publishers",
+    "version" : "0.1"
+  }, {
+    "id" : "pubsub-subscribers",
+    "version" : "0.1"
+  } ],
+  "provides" : [ {
+    "id" : "automated-patron-blocks",
+    "version" : "0.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/automated-patron-blocks/{userId}",
+      "permissionsRequired" : [ "automated-patron-blocks.collection.get" ]
+    } ]
+  }, {
+    "id" : "user-summary",
+    "version" : "0.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/user-summary/{userId}",
+      "permissionsRequired" : [ "user-summary.item.get" ]
+    } ]
+  }, {
+    "id" : "patron-blocks-event-handlers",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/automated-patron-blocks/handlers/fee-fine-balance-changed",
+      "permissionsRequired" : [ "patron-blocks.events.post" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/automated-patron-blocks/handlers/item-checked-out",
+      "permissionsRequired" : [ "patron-blocks.events.post" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/automated-patron-blocks/handlers/item-checked-in",
+      "permissionsRequired" : [ "patron-blocks.events.post" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/automated-patron-blocks/handlers/item-declared-lost",
+      "permissionsRequired" : [ "patron-blocks.events.post" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/automated-patron-blocks/handlers/loan-due-date-changed",
+      "permissionsRequired" : [ "patron-blocks.events.post" ]
+    } ]
+  }, {
+    "id" : "_tenant",
+    "version" : "1.0",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/_/tenant",
+      "modulePermissions" : [ "pubsub.event-types.post", "pubsub.publishers.post", "pubsub.subscribers.post" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/_/tenant",
+      "modulePermissions" : [ "pubsub.publishers.delete", "pubsub.subscribers.delete" ]
+    } ]
+  }, {
+    "id" : "patron-block-conditions",
+    "version" : "0.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/patron-block-conditions",
+      "permissionsRequired" : [ "patron-block-conditions.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/patron-block-conditions/{id}",
+      "permissionsRequired" : [ "patron-block-conditions.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/patron-block-conditions/{id}",
+      "permissionsRequired" : [ "patron-block-conditions.item.put" ]
+    } ]
+  }, {
+    "id" : "patron-block-limits",
+    "version" : "0.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/patron-block-limits",
+      "permissionsRequired" : [ "patron-block-limits.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/patron-block-limits/{id}",
+      "permissionsRequired" : [ "patron-block-limits.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/patron-block-limits",
+      "permissionsRequired" : [ "patron-block-limits.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/patron-block-limits/{id}",
+      "permissionsRequired" : [ "patron-block-limits.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/patron-block-limits/{id}",
+      "permissionsRequired" : [ "patron-block-limits.item.delete" ]
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "patron-blocks.events.post",
+    "displayName" : "Patron blocks - post event",
+    "description" : "Post an event able to affect the state of automated patron blocks"
+  }, {
+    "permissionName" : "patron-block-conditions.collection.get",
+    "displayName" : "Patron block conditions - get patron block condition collection",
+    "description" : "Get patron block condition collection"
+  }, {
+    "permissionName" : "patron-block-conditions.item.get",
+    "displayName" : "Patron block conditions - get patron block condition",
+    "description" : "Get patron block condition by id"
+  }, {
+    "permissionName" : "patron-block-conditions.item.put",
+    "displayName" : "Patron block conditions - put patron block condition",
+    "description" : "Put patron block condition by id"
+  }, {
+    "permissionName" : "patron-block-limits.collection.get",
+    "displayName" : "Patron block limits - get patron block limit collection",
+    "description" : "Get patron block limit collection"
+  }, {
+    "permissionName" : "patron-block-limits.item.get",
+    "displayName" : "Patron block limits - get patron block limit",
+    "description" : "Get patron block limit by id"
+  }, {
+    "permissionName" : "patron-block-limits.item.post",
+    "displayName" : "Patron block limits - post patron block limit",
+    "description" : "Create patron block limit"
+  }, {
+    "permissionName" : "patron-block-limits.item.put",
+    "displayName" : "Patron block limits - put patron block limit",
+    "description" : "Put patron block limit by id"
+  }, {
+    "permissionName" : "patron-block-limits.item.delete",
+    "displayName" : "Patron block limits - delete patron block limit",
+    "description" : "Delete patron block limit by id"
+  }, {
+    "permissionName" : "automated-patron-blocks.collection.get",
+    "displayName" : "Patron blocks - get blocks for patron",
+    "description" : "Get automated patron blocks by user ID"
+  }, {
+    "permissionName" : "user-summary.item.get",
+    "displayName" : "User summary - get UserSummary object",
+    "description" : "Get UserSummary object by user ID"
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-patron-blocks:1.0.7",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    }, {
+      "name" : "DB_HOST",
+      "value" : "postgres"
+    }, {
+      "name" : "DB_PORT",
+      "value" : "5432"
+    }, {
+      "name" : "DB_USERNAME",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_PASSWORD",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_DATABASE",
+      "value" : "okapi_modules"
+    }, {
+      "name" : "DB_QUERYTIMEOUT",
+      "value" : "60000"
+    }, {
+      "name" : "DB_CHARSET",
+      "value" : "UTF-8"
+    }, {
+      "name" : "DB_MAXPOOLSIZE",
+      "value" : "5"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-permissions-5.11.4",
+  "name" : "permissions",
+  "provides" : [ {
+    "id" : "permissions",
+    "version" : "5.3",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/perms/users*",
+      "permissionsRequired" : [ "perms.users.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/perms/users*",
+      "permissionsRequired" : [ "perms.users.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/perms/users/{id}",
+      "permissionsRequired" : [ "perms.users.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/perms/users/{id}",
+      "permissionsRequired" : [ "perms.users.item.delete" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/perms/users/{id}/permissions/{perm}",
+      "permissionsRequired" : [ "perms.users.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/perms/permissions",
+      "permissionsRequired" : [ "perms.permissions.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/perms/permissions/{id}",
+      "permissionsRequired" : [ "perms.permissions.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/perms/permissions/{id}",
+      "permissionsRequired" : [ "perms.permissions.item.put" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/perms/permissions",
+      "permissionsRequired" : [ "perms.permissions.item.post" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/perms/permissions/{id}",
+      "permissionsRequired" : [ "perms.permissions.item.delete " ]
+    } ]
+  }, {
+    "id" : "_tenant",
+    "version" : "1.2",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST", "DELETE" ],
+      "pathPattern" : "/_/tenant"
+    } ]
+  }, {
+    "id" : "_tenantPermissions",
+    "version" : "1.1",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/_/tenantpermissions"
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "perms.users.get",
+    "displayName" : "permission users read",
+    "description" : "Read or list permissions user(s)"
+  }, {
+    "permissionName" : "perms.users.item.post",
+    "displayName" : "permission users item create",
+    "description" : "Add a new permissions user"
+  }, {
+    "permissionName" : "perms.users.item.put",
+    "displayName" : "permission users item modify",
+    "description" : "Modify a permissions user"
+  }, {
+    "permissionName" : "perms.users.item.delete",
+    "displayName" : "permission users item delete",
+    "description" : "Remove a permissions user or remove permissions from a user"
+  }, {
+    "permissionName" : "perms.permissions.get",
+    "displayName" : "permission read",
+    "description" : "Read or list permissions"
+  }, {
+    "permissionName" : "perms.permissions.item.post",
+    "displayName" : "permission item create",
+    "description" : "Add a new permission"
+  }, {
+    "permissionName" : "perms.permissions.item.put",
+    "displayName" : "permission item modify",
+    "description" : "Modify a permission"
+  }, {
+    "permissionName" : "perms.permissions.item.delete",
+    "displayName" : "permission item delete",
+    "description" : "Remove a permission"
+  }, {
+    "permissionName" : "perms.permissions",
+    "displayName" : "permissions",
+    "description" : "All permissions for permission objects",
+    "subPermissions" : [ "perms.permissions.get", "perms.permissions.item.post", "perms.permissions.item.put", "perms.permissions.item.delete" ]
+  }, {
+    "permissionName" : "perms.users",
+    "displayName" : "permission users",
+    "description" : "All permissions for permission user objects",
+    "subPermissions" : [ "perms.users.get", "perms.users.item.post", "perms.users.item.put", "perms.users.item.delete" ]
+  }, {
+    "permissionName" : "perms.all",
+    "displayName" : "perms all",
+    "description" : "All permissions for the permissions module",
+    "subPermissions" : [ "perms.users", "perms.permissions" ]
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-permissions:5.11.4",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    }, {
+      "name" : "DB_HOST",
+      "value" : "postgres"
+    }, {
+      "name" : "DB_PORT",
+      "value" : "5432"
+    }, {
+      "name" : "DB_USERNAME",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_PASSWORD",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_DATABASE",
+      "value" : "okapi_modules"
+    }, {
+      "name" : "DB_QUERYTIMEOUT",
+      "value" : "60000"
+    }, {
+      "name" : "DB_CHARSET",
+      "value" : "UTF-8"
+    }, {
+      "name" : "DB_MAXPOOLSIZE",
+      "value" : "5"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 715827883,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-pubsub-1.2.5",
+  "name" : "Pubsub",
+  "requires" : [ {
+    "id" : "users",
+    "version" : "15.1"
+  }, {
+    "id" : "login",
+    "version" : "6.0 7.0"
+  }, {
+    "id" : "permissions",
+    "version" : "5.2"
+  } ],
+  "provides" : [ {
+    "id" : "pubsub-event-types",
+    "version" : "0.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/pubsub/event-types",
+      "permissionsRequired" : [ "pubsub.event-types.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/pubsub/event-types",
+      "permissionsRequired" : [ "pubsub.event-types.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/pubsub/event-types/{eventTypeName}",
+      "permissionsRequired" : [ "pubsub.event-types.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/pubsub/event-types/{eventTypeName}",
+      "permissionsRequired" : [ "pubsub.event-types.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/pubsub/event-types/{eventTypeName}",
+      "permissionsRequired" : [ "pubsub.event-types.delete" ]
+    } ]
+  }, {
+    "id" : "pubsub-publishers",
+    "version" : "0.1",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/pubsub/event-types/declare/publisher",
+      "permissionsRequired" : [ "pubsub.publishers.post" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/pubsub/event-types/{eventTypeName}/publishers",
+      "permissionsRequired" : [ "pubsub.publishers.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/pubsub/event-types/{eventTypeName}/publishers",
+      "permissionsRequired" : [ "pubsub.publishers.get" ]
+    } ]
+  }, {
+    "id" : "pubsub-subscribers",
+    "version" : "0.1",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/pubsub/event-types/declare/subscriber",
+      "permissionsRequired" : [ "pubsub.subscribers.post" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/pubsub/event-types/{eventTypeName}/subscribers",
+      "permissionsRequired" : [ "pubsub.subscribers.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/pubsub/event-types/{eventTypeName}/subscribers",
+      "permissionsRequired" : [ "pubsub.subscribers.get" ]
+    } ]
+  }, {
+    "id" : "pubsub-audit",
+    "version" : "0.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/pubsub/history",
+      "permissionsRequired" : [ "pubsub.audit.history.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/pubsub/audit-messages/{eventId}/payload",
+      "permissionsRequired" : [ "pubsub.audit.message.payload.get" ]
+    } ]
+  }, {
+    "id" : "pubsub-publish",
+    "version" : "0.1",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/pubsub/publish",
+      "permissionsRequired" : [ "pubsub.publish.post" ]
+    } ]
+  }, {
+    "id" : "_tenant",
+    "version" : "1.2",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/_/tenant",
+      "modulePermissions" : [ "users.collection.get", "users.item.post", "login.item.post", "perms.users.item.post" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/_/tenant"
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "pubsub.event-types.get",
+    "displayName" : "PubSub - get Event Descriptor",
+    "description" : "Get Event Descriptor"
+  }, {
+    "permissionName" : "pubsub.event-types.post",
+    "displayName" : "PubSub - create new Event Type",
+    "description" : "Post Event Descriptor"
+  }, {
+    "permissionName" : "pubsub.event-types.put",
+    "displayName" : "PubSub - update Event Descriptor for Event Type",
+    "description" : "Put Event Descriptor"
+  }, {
+    "permissionName" : "pubsub.event-types.delete",
+    "displayName" : "PubSub - delete Event Type",
+    "description" : "Delete Event Descriptor"
+  }, {
+    "permissionName" : "pubsub.publishers.post",
+    "displayName" : "PubSub - declare publisher",
+    "description" : "Post Publisher Descriptor"
+  }, {
+    "permissionName" : "pubsub.publishers.delete",
+    "displayName" : "PubSub - delete publisher declaration",
+    "description" : "Delete Publisher"
+  }, {
+    "permissionName" : "pubsub.publishers.get",
+    "displayName" : "PubSub - get publishers",
+    "description" : "Get Publishers"
+  }, {
+    "permissionName" : "pubsub.subscribers.post",
+    "displayName" : "PubSub - declare subscriber",
+    "description" : "Post Subscriber Descriptor"
+  }, {
+    "permissionName" : "pubsub.subscribers.delete",
+    "displayName" : "PubSub - delete subscriber declaration",
+    "description" : "Delete Subscriber"
+  }, {
+    "permissionName" : "pubsub.subscribers.get",
+    "displayName" : "PubSub - get subscribers",
+    "description" : "Get Subscribers"
+  }, {
+    "permissionName" : "pubsub.audit.history.get",
+    "displayName" : "PubSub - get history",
+    "description" : "Get history"
+  }, {
+    "permissionName" : "pubsub.audit.message.payload.get",
+    "displayName" : "PubSub - get audit message payload",
+    "description" : "Get audit message payload"
+  }, {
+    "permissionName" : "pubsub.publish.post",
+    "displayName" : "PubSub - publish event",
+    "description" : "Publish event"
+  }, {
+    "permissionName" : "source-storage.events.post",
+    "displayName" : "Source Storage - post event",
+    "description" : "Post event"
+  }, {
+    "permissionName" : "source-records-manager.events.post",
+    "displayName" : "Source Record Manager - post event",
+    "description" : "Post event"
+  }, {
+    "permissionName" : "inventory.events.post",
+    "displayName" : "Inventory - post event",
+    "description" : "Post event to inventory"
+  }, {
+    "permissionName" : "circulation.events.post",
+    "displayName" : "Circulation - post event",
+    "description" : "Post event to circulation"
+  }, {
+    "permissionName" : "patron-blocks.events.post",
+    "displayName" : "Patron blocks - post event",
+    "description" : "Post events to patron blocks"
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-pubsub:1.2.5",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0 -XX:+HeapDumpOnOutOfMemoryError"
+    }, {
+      "name" : "DB_HOST",
+      "value" : "postgres"
+    }, {
+      "name" : "DB_PORT",
+      "value" : "5432"
+    }, {
+      "name" : "DB_USERNAME",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_PASSWORD",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_DATABASE",
+      "value" : "okapi_modules"
+    }, {
+      "name" : "DB_QUERYTIMEOUT",
+      "value" : "60000"
+    }, {
+      "name" : "DB_CHARSET",
+      "value" : "UTF-8"
+    }, {
+      "name" : "DB_MAXPOOLSIZE",
+      "value" : "5"
+    }, {
+      "name" : "KAFKA_HOST",
+      "value" : "10.0.2.15"
+    }, {
+      "name" : "KAFKA_PORT",
+      "value" : "9092"
+    }, {
+      "name" : "OKAPI_URL",
+      "value" : "http://10.0.2.15:9130"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 1073741824,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-quick-marc-1.1.1",
+  "name" : "quickMARC",
+  "requires" : [ {
+    "id" : "source-manager-parsed-records",
+    "version" : "1.0"
+  } ],
+  "provides" : [ {
+    "id" : "records-editor.records",
+    "version" : "1.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/records-editor/records",
+      "permissionsRequired" : [ "records-editor.records.item.get" ],
+      "modulePermissions" : [ "change-manager.parsedrecords.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/records-editor/records/{id}",
+      "permissionsRequired" : [ "records-editor.records.item.put" ],
+      "modulePermissions" : [ "change-manager.parsedrecords.put" ]
+    } ]
+  }, {
+    "id" : "_jsonSchemas",
+    "version" : "1.0",
+    "interfaceType" : "multiple",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/_/jsonSchemas",
+      "permissionsRequired" : [ ]
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "records-editor.records.item.get",
+    "displayName" : "records-editor - get a record",
+    "description" : "Get a record"
+  }, {
+    "permissionName" : "records-editor.records.item.put",
+    "displayName" : "records-editor - update a record",
+    "description" : "Update a record"
+  }, {
+    "permissionName" : "records-editor.all",
+    "displayName" : "All records-editor permissions",
+    "description" : "All permissions for the records-editor",
+    "subPermissions" : [ "records-editor.records.item.get", "records-editor.records.item.put" ]
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-quick-marc:1.1.1",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-rtac-1.5.0",
+  "name" : "Real Time Availability Check Module",
+  "requires" : [ {
+    "id" : "inventory",
+    "version" : "8.0 9.0 10.0"
+  }, {
+    "id" : "holdings-storage",
+    "version" : "1.2 2.0 3.0 4.0"
+  }, {
+    "id" : "circulation",
+    "version" : "3.0 4.0 5.0 6.0 7.0 8.0 9.0"
+  } ],
+  "provides" : [ {
+    "id" : "rtac",
+    "version" : "1.4",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/rtac",
+      "permissionsRequired" : [ "rtac.holdings.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/rtac/{id}",
+      "permissionsRequired" : [ "rtac.holdings.item.get" ],
+      "modulePermissions" : [ "inventory.instances.item.get", "inventory-storage.holdings.collection.get", "inventory.items.collection.get", "circulation.loans.collection.get" ]
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "rtac.holdings.collection.get",
+    "displayName" : "RTAC - get holding collection",
+    "description" : "Get holding collection"
+  }, {
+    "permissionName" : "rtac.holdings.item.get",
+    "displayName" : "RTAC - get individual holding",
+    "description" : "Get individual holding"
+  }, {
+    "permissionName" : "rtac.all",
+    "displayName" : "RTAC - all permissions",
+    "description" : "Entire set of permissions needed to use RTAC",
+    "subPermissions" : [ "rtac.holdings.collection.get", "rtac.holdings.item.get" ]
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-rtac:1.5.0",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-sender-1.3.1",
+  "name" : "Mod sender",
+  "requires" : [ {
+    "id" : "users",
+    "version" : "15.0"
+  }, {
+    "id" : "email",
+    "version" : "1.0"
+  } ],
+  "provides" : [ {
+    "id" : "message-delivery",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/message-delivery",
+      "permissionsRequired" : [ "sender.message-delivery" ],
+      "modulePermissions" : [ "email.message.post", "users.item.get" ]
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "sender.message-delivery",
+    "displayName" : "Message delivery",
+    "description" : "Send message"
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-sender:1.3.1",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 536870912,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-source-record-manager-2.3.4",
+  "name" : "Source Record Manager Module",
+  "requires" : [ {
+    "id" : "source-storage-snapshots",
+    "version" : "2.0"
+  }, {
+    "id" : "source-storage-records",
+    "version" : "2.0"
+  }, {
+    "id" : "source-storage-source-records",
+    "version" : "2.0"
+  }, {
+    "id" : "source-storage-batch",
+    "version" : "0.1"
+  }, {
+    "id" : "inventory-batch",
+    "version" : "0.3"
+  }, {
+    "id" : "users",
+    "version" : "15.0"
+  }, {
+    "id" : "identifier-types",
+    "version" : "1.2"
+  }, {
+    "id" : "electronic-access-relationships",
+    "version" : "1.0"
+  }, {
+    "id" : "classification-types",
+    "version" : "1.2"
+  }, {
+    "id" : "instance-types",
+    "version" : "2.0"
+  }, {
+    "id" : "instance-formats",
+    "version" : "2.0"
+  }, {
+    "id" : "contributor-name-types",
+    "version" : "1.2"
+  }, {
+    "id" : "contributor-types",
+    "version" : "2.0"
+  }, {
+    "id" : "instance-note-types",
+    "version" : "1.0"
+  }, {
+    "id" : "alternative-title-types",
+    "version" : "1.0"
+  }, {
+    "id" : "pubsub-event-types",
+    "version" : "0.1"
+  }, {
+    "id" : "pubsub-publishers",
+    "version" : "0.1"
+  }, {
+    "id" : "pubsub-subscribers",
+    "version" : "0.1"
+  }, {
+    "id" : "pubsub-publish",
+    "version" : "0.1"
+  }, {
+    "id" : "data-import-converter-storage",
+    "version" : "1.2"
+  }, {
+    "id" : "modes-of-issuance",
+    "version" : "1.1"
+  } ],
+  "provides" : [ {
+    "id" : "source-manager-job-executions",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/metadata-provider/jobExecutions",
+      "permissionsRequired" : [ "metadata-provider.jobexecutions.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/metadata-provider/logs/{jobExecutionId}",
+      "permissionsRequired" : [ "metadata-provider.logs.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/metadata-provider/journalRecords/{jobExecutionId}",
+      "permissionsRequired" : [ "metadata-provider.logs.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/change-manager/jobExecutions",
+      "permissionsRequired" : [ "change-manager.jobexecutions.post" ],
+      "modulePermissions" : [ "source-storage.snapshots.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/change-manager/jobExecutions/{id}",
+      "permissionsRequired" : [ "change-manager.jobexecutions.put" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/change-manager/jobExecutions/{id}",
+      "permissionsRequired" : [ "change-manager.jobexecutions.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/change-manager/jobExecutions/{id}/children",
+      "permissionsRequired" : [ "change-manager.jobexecutions.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/change-manager/jobExecutions/{id}/status",
+      "permissionsRequired" : [ "change-manager.jobexecutions.put" ],
+      "modulePermissions" : [ "source-storage.snapshots.put" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/change-manager/jobExecutions/{id}/jobProfile",
+      "permissionsRequired" : [ "change-manager.jobexecutions.put" ],
+      "modulePermissions" : [ "converter-storage.jobprofilesnapshots.post" ]
+    } ]
+  }, {
+    "id" : "source-manager-records",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/change-manager/jobExecutions/{id}/records",
+      "permissionsRequired" : [ "change-manager.records.post" ],
+      "modulePermissions" : [ "source-storage.snapshots.get", "source-storage.snapshots.put", "source-storage.records.get", "source-storage.records.post", "source-storage.records.put", "inventory.instances.batch.post", "users.collection.get", "inventory-storage.identifier-types.collection.get", "inventory-storage.classification-types.collection.get", "inventory-storage.instance-types.collection.get", "inventory-storage.electronic-access-relationships.collection.get", "inventory-storage.instance-formats.collection.get", "inventory-storage.contributor-types.collection.get", "inventory-storage.contributor-name-types.collection.get", "inventory-storage.instance-note-types.collection.get", "inventory-storage.alternative-title-types.collection.get", "inventory-storage.modes-of-issuance.collection.get", "pubsub.publish.post", "converter-storage.jobprofilesnapshots.get", "inventory-storage.items.collection.get", "inventory-storage.items.item.post", "inventory-storage.items.item.put", "inventory-storage.material-types.item.get", "inventory-storage.material-types.collection.get", "inventory-storage.loan-types.item.get", "inventory-storage.loan-types.collection.get", "inventory-storage.locations.item.get", "inventory-storage.locations.collection.get", "inventory-storage.holdings.collection.get", "inventory-storage.holdings.item.get", "inventory-storage.holdings.item.post", "inventory-storage.holdings.item.put", "inventory-storage.instances.collection.get", "inventory-storage.instances.item.get", "inventory-storage.instances.item.post", "inventory-storage.instances.item.put", "inventory-storage.preceding-succeeding-titles.item.post" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/change-manager/jobExecutions/{id}/records",
+      "permissionsRequired" : [ "change-manager.records.delete" ],
+      "modulePermissions" : [ "source-storage.snapshots.records.delete" ]
+    } ]
+  }, {
+    "id" : "source-manager-parsed-records",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/change-manager/parsedRecords",
+      "permissionsRequired" : [ "change-manager.parsedrecords.get" ],
+      "modulePermissions" : [ "source-storage.sourceRecords.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/change-manager/parsedRecords/{id}",
+      "permissionsRequired" : [ "change-manager.parsedrecords.put" ],
+      "modulePermissions" : [ "inventory-storage.identifier-types.collection.get", "inventory-storage.classification-types.collection.get", "inventory-storage.instance-types.collection.get", "inventory-storage.electronic-access-relationships.collection.get", "inventory-storage.instance-formats.collection.get", "inventory-storage.contributor-types.collection.get", "inventory-storage.contributor-name-types.collection.get", "inventory-storage.instance-note-types.collection.get", "inventory-storage.alternative-title-types.collection.get", "inventory-storage.modes-of-issuance.collection.get", "pubsub.publish.post", "inventory-storage.instances.item.get", "inventory-storage.instances.item.put" ]
+    } ]
+  }, {
+    "id" : "mapping-rules-provider",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/mapping-rules",
+      "permissionsRequired" : [ "mapping-rules.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/mapping-rules",
+      "permissionsRequired" : [ "mapping-rules.update" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/mapping-rules/restore",
+      "permissionsRequired" : [ "mapping-rules.restore" ]
+    } ]
+  }, {
+    "id" : "source-manager-event-handlers",
+    "version" : "0.1",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/change-manager/handlers/created-inventory-instance",
+      "permissionsRequired" : [ "source-records-manager.events.post" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/change-manager/handlers/processing-result",
+      "permissionsRequired" : [ "source-records-manager.events.post" ],
+      "modulePermissions" : [ "source-storage.snapshots.put" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/change-manager/handlers/qm-completed",
+      "permissionsRequired" : [ "source-records-manager.events.post" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/change-manager/handlers/qm-error",
+      "permissionsRequired" : [ "source-records-manager.events.post" ]
+    } ]
+  }, {
+    "id" : "_tenant",
+    "version" : "1.2",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/_/tenant",
+      "modulePermissions" : [ "pubsub.event-types.post", "pubsub.publishers.post", "pubsub.subscribers.post" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/_/tenant"
+    } ]
+  }, {
+    "id" : "_jsonSchemas",
+    "version" : "1.0",
+    "interfaceType" : "multiple",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/_/jsonSchemas",
+      "permissionsRequired" : [ ]
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "metadata-provider.jobexecutions.get",
+    "displayName" : "Metadata Provider - get jobExecutions",
+    "description" : "Get JobExecutions"
+  }, {
+    "permissionName" : "metadata-provider.logs.get",
+    "displayName" : "Metadata Provider - get jobExecution logs",
+    "description" : "Get JobExecutionLogDto"
+  }, {
+    "permissionName" : "change-manager.jobexecutions.post",
+    "displayName" : "Change Manager - create jobExecutions",
+    "description" : "Post JobExecution"
+  }, {
+    "permissionName" : "change-manager.jobexecutions.put",
+    "displayName" : "Change Manager - update jobExecutions",
+    "description" : "Put JobExecution"
+  }, {
+    "permissionName" : "change-manager.jobexecutions.get",
+    "displayName" : "Change Manager - get jobExecutions by id",
+    "description" : "Get JobExecution by id"
+  }, {
+    "permissionName" : "change-manager.records.post",
+    "displayName" : "Change Manager - post chunk of raw records",
+    "description" : "Post chunk of raw records"
+  }, {
+    "permissionName" : "change-manager.records.delete",
+    "displayName" : "Change Manager - delete jobExecution and all associated records from SRS",
+    "description" : "Delete JobExecution and all associated records from SRS"
+  }, {
+    "permissionName" : "change-manager.parsedrecords.get",
+    "displayName" : "Change Manager - get parsed records by instanceId",
+    "description" : "Get parsed record"
+  }, {
+    "permissionName" : "change-manager.parsedrecords.put",
+    "displayName" : "Change Manager - update parsed record by id",
+    "description" : "Update parsed record"
+  }, {
+    "permissionName" : "mapping-rules.get",
+    "displayName" : "Mapping Rules provider - get default rules by tenant id",
+    "description" : "Get mapping rules for tenant"
+  }, {
+    "permissionName" : "mapping-rules.update",
+    "displayName" : "Mapping Rules provider - update default rules by tenant id",
+    "description" : "Update mapping rules for tenant"
+  }, {
+    "permissionName" : "mapping-rules.restore",
+    "displayName" : "Mapping Rules provider - restore default rules by tenant id",
+    "description" : "Restore existing mapping rules to default for tenant"
+  }, {
+    "permissionName" : "source-records-manager.all",
+    "displayName" : "Source Record Manager - all permissions",
+    "description" : "Entire set of permissions needed to manage jobExecutions",
+    "subPermissions" : [ "metadata-provider.jobexecutions.get", "metadata-provider.logs.get", "change-manager.jobexecutions.post", "change-manager.jobexecutions.put", "change-manager.jobexecutions.get", "change-manager.records.post", "change-manager.records.delete", "change-manager.parsedrecords.get", "change-manager.parsedrecords.put", "mapping-rules.get", "mapping-rules.update", "mapping-rules.restore" ],
+    "visible" : false
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-source-record-manager:2.3.4",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    }, {
+      "name" : "DB_HOST",
+      "value" : "postgres"
+    }, {
+      "name" : "DB_PORT",
+      "value" : "5432"
+    }, {
+      "name" : "DB_USERNAME",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_PASSWORD",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_DATABASE",
+      "value" : "okapi_modules"
+    }, {
+      "name" : "DB_QUERYTIMEOUT",
+      "value" : "60000"
+    }, {
+      "name" : "DB_CHARSET",
+      "value" : "UTF-8"
+    }, {
+      "name" : "DB_MAXPOOLSIZE",
+      "value" : "5"
+    }, {
+      "name" : "test.mode",
+      "value" : "true"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 715827883,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-source-record-storage-4.0.4",
+  "name" : "Source Record Storage Module",
+  "requires" : [ {
+    "id" : "pubsub-event-types",
+    "version" : "0.1"
+  }, {
+    "id" : "pubsub-publishers",
+    "version" : "0.1"
+  }, {
+    "id" : "pubsub-subscribers",
+    "version" : "0.1"
+  }, {
+    "id" : "pubsub-publish",
+    "version" : "0.1"
+  } ],
+  "provides" : [ {
+    "id" : "source-storage-snapshots",
+    "version" : "2.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/source-storage/snapshots",
+      "permissionsRequired" : [ "source-storage.snapshots.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/source-storage/snapshots",
+      "permissionsRequired" : [ "source-storage.snapshots.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/source-storage/snapshots/{jobExecutionId}",
+      "permissionsRequired" : [ "source-storage.snapshots.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/source-storage/snapshots/{jobExecutionId}",
+      "permissionsRequired" : [ "source-storage.snapshots.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/source-storage/snapshots/{jobExecutionId}",
+      "permissionsRequired" : [ "source-storage.snapshots.delete" ]
+    } ]
+  }, {
+    "id" : "source-storage-records",
+    "version" : "2.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/source-storage/records",
+      "permissionsRequired" : [ "source-storage.records.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/source-storage/records",
+      "permissionsRequired" : [ "source-storage.records.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/source-storage/records/{id}",
+      "permissionsRequired" : [ "source-storage.records.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/source-storage/records/{id}",
+      "permissionsRequired" : [ "source-storage.records.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/source-storage/records/{id}",
+      "permissionsRequired" : [ "source-storage.records.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/source-storage/records/{id}/formatted",
+      "permissionsRequired" : [ "source-storage.records.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/source-storage/records/{id}/suppress-from-discovery",
+      "permissionsRequired" : [ "source-storage.records.update" ]
+    } ]
+  }, {
+    "id" : "source-storage-source-records",
+    "version" : "2.0",
+    "handlers" : [ {
+      "methods" : [ "GET", "POST" ],
+      "pathPattern" : "/source-storage/source-records",
+      "permissionsRequired" : [ "source-storage.sourceRecords.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/source-storage/source-records/{id}",
+      "permissionsRequired" : [ "source-storage.sourceRecords.get" ]
+    } ]
+  }, {
+    "id" : "source-storage-test-records",
+    "version" : "2.0",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/source-storage/populate-test-marc-records",
+      "permissionsRequired" : [ "source-storage.populate.records" ]
+    } ]
+  }, {
+    "id" : "source-storage-batch",
+    "version" : "0.1",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/source-storage/batch/records",
+      "permissionsRequired" : [ "source-storage.records.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/source-storage/batch/parsed-records",
+      "permissionsRequired" : [ "source-storage.records.put" ]
+    } ]
+  }, {
+    "id" : "source-storage-event-handlers",
+    "version" : "0.1",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/source-storage/handlers/inventory-instance",
+      "permissionsRequired" : [ "source-storage.events.post" ],
+      "modulePermissions" : [ "pubsub.publish.post" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/source-storage/handlers/updated-record",
+      "permissionsRequired" : [ "source-storage.events.post" ],
+      "modulePermissions" : [ "pubsub.publish.post" ]
+    } ]
+  }, {
+    "id" : "_tenant",
+    "version" : "1.2",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST", "DELETE" ],
+      "pathPattern" : "/_/tenant",
+      "modulePermissions" : [ "pubsub.event-types.post", "pubsub.publishers.post", "pubsub.subscribers.post" ]
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "source-storage.populate.records",
+    "displayName" : "Source Storage - populate storage with test records",
+    "description" : "Populate storage with test records"
+  }, {
+    "permissionName" : "source-storage.snapshots.get",
+    "displayName" : "Source Storage - get snapshot(s)",
+    "description" : "Get Snapshot(s)"
+  }, {
+    "permissionName" : "source-storage.snapshots.post",
+    "displayName" : "Source Storage - create new snapshot",
+    "description" : "Post Snapshot"
+  }, {
+    "permissionName" : "source-storage.snapshots.put",
+    "displayName" : "Source Storage - update snapshot",
+    "description" : "Put Snapshot"
+  }, {
+    "permissionName" : "source-storage.snapshots.delete",
+    "displayName" : "Source Storage - delete snapshot and records",
+    "description" : "Delete Snapshot and all related Records"
+  }, {
+    "permissionName" : "source-storage.records.get",
+    "displayName" : "Source Storage - get record(s)",
+    "description" : "Get Record(s)"
+  }, {
+    "permissionName" : "source-storage.records.post",
+    "displayName" : "Source Storage - create new record",
+    "description" : "Post Record"
+  }, {
+    "permissionName" : "source-storage.records.put",
+    "displayName" : "Source Storage - update record",
+    "description" : "Put Record"
+  }, {
+    "permissionName" : "source-storage.record.update",
+    "displayName" : "Source Storage - update record",
+    "description" : "Update Record's fields"
+  }, {
+    "permissionName" : "source-storage.records.delete",
+    "displayName" : "Source Storage - delete record",
+    "description" : "Delete Record"
+  }, {
+    "permissionName" : "source-storage.sourceRecords.get",
+    "displayName" : "Source Storage - get results",
+    "description" : "Get Results"
+  }, {
+    "permissionName" : "source-storage.all",
+    "displayName" : "Source Record Storage - all permissions",
+    "description" : "Entire set of permissions needed to manage snapshots and records",
+    "subPermissions" : [ "source-storage.populate.records", "source-storage.snapshots.get", "source-storage.snapshots.post", "source-storage.snapshots.put", "source-storage.snapshots.delete", "source-storage.records.get", "source-storage.records.post", "source-storage.records.put", "source-storage.records.delete", "source-storage.record.update", "source-storage.sourceRecords.get" ],
+    "visible" : false
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-source-record-storage:4.0.4",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    }, {
+      "name" : "DB_HOST",
+      "value" : "postgres"
+    }, {
+      "name" : "DB_PORT",
+      "value" : "5432"
+    }, {
+      "name" : "DB_USERNAME",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_PASSWORD",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_DATABASE",
+      "value" : "okapi_modules"
+    }, {
+      "name" : "DB_QUERYTIMEOUT",
+      "value" : "60000"
+    }, {
+      "name" : "DB_CHARSET",
+      "value" : "UTF-8"
+    }, {
+      "name" : "DB_MAXPOOLSIZE",
+      "value" : "5"
+    }, {
+      "name" : "test.mode",
+      "value" : "true"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 603725575,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-tags-0.6.0",
+  "name" : "Tags",
+  "requires" : [ ],
+  "provides" : [ {
+    "id" : "tags",
+    "version" : "1.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/tags",
+      "permissionsRequired" : [ "tags.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/tags",
+      "permissionsRequired" : [ "tags.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/tags/{id}",
+      "permissionsRequired" : [ "tags.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/tags/{id}",
+      "permissionsRequired" : [ "tags.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/tags/{id}",
+      "permissionsRequired" : [ "tags.item.delete" ]
+    } ]
+  }, {
+    "id" : "_tenant",
+    "version" : "1.2",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/_/tenant"
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/_/tenant"
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "tags.collection.get",
+    "displayName" : "Tags - get tags collection",
+    "description" : "Get tags collection"
+  }, {
+    "permissionName" : "tags.item.get",
+    "displayName" : "Tags - get individual tag from storage",
+    "description" : "Get individual tag"
+  }, {
+    "permissionName" : "tags.item.post",
+    "displayName" : "Tags - create tag",
+    "description" : "Create tag"
+  }, {
+    "permissionName" : "tags.item.put",
+    "displayName" : "Tags - modify tag",
+    "description" : "Modify tag"
+  }, {
+    "permissionName" : "tags.item.delete",
+    "displayName" : "Tags - delete tag",
+    "description" : "Delete tag"
+  }, {
+    "permissionName" : "tags.all",
+    "displayName" : "Tags module - all permissions",
+    "description" : "Entire set of permissions needed to use the tags module",
+    "subPermissions" : [ "tags.collection.get", "tags.item.get", "tags.item.post", "tags.item.put", "tags.item.delete" ],
+    "visible" : false
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-tags:0.6.0",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    }, {
+      "name" : "DB_HOST",
+      "value" : "postgres"
+    }, {
+      "name" : "DB_PORT",
+      "value" : "5432"
+    }, {
+      "name" : "DB_USERNAME",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_PASSWORD",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_DATABASE",
+      "value" : "okapi_modules"
+    }, {
+      "name" : "DB_QUERYTIMEOUT",
+      "value" : "60000"
+    }, {
+      "name" : "DB_CHARSET",
+      "value" : "UTF-8"
+    }, {
+      "name" : "DB_MAXPOOLSIZE",
+      "value" : "5"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-template-engine-1.9.0",
+  "name" : "Template engine module",
+  "requires" : [ {
+    "id" : "configuration",
+    "version" : "2.0"
+  }, {
+    "id" : "patron-notice-policy-storage",
+    "version" : "0.8"
+  } ],
+  "provides" : [ {
+    "id" : "template-engine",
+    "version" : "2.2",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/templates",
+      "permissionsRequired" : [ "templates.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/templates",
+      "permissionsRequired" : [ "templates.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/templates/{templateId}",
+      "permissionsRequired" : [ "templates.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/templates/{templateId}",
+      "permissionsRequired" : [ "templates.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/templates/{templateId}",
+      "permissionsRequired" : [ "templates.item.delete" ],
+      "modulePermissions" : [ "circulation-storage.patron-notice-policies.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/template-request",
+      "permissionsRequired" : [ "template-request.post" ],
+      "modulePermissions" : [ "configuration.entries.collection.get" ]
+    } ]
+  }, {
+    "id" : "_tenant",
+    "version" : "1.2",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/_/tenant"
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/_/tenant"
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "templates.collection.get",
+    "displayName" : "Templates - get Templates collection",
+    "description" : "Get Templates collection"
+  }, {
+    "permissionName" : "templates.item.get",
+    "displayName" : "Templates - get individual tag from storage",
+    "description" : "Get individual tag"
+  }, {
+    "permissionName" : "templates.item.post",
+    "displayName" : "Templates - create tag",
+    "description" : "Create tag"
+  }, {
+    "permissionName" : "templates.item.put",
+    "displayName" : "Templates - modify tag",
+    "description" : "Modify tag"
+  }, {
+    "permissionName" : "templates.item.delete",
+    "displayName" : "Templates - delete tag",
+    "description" : "Delete tag"
+  }, {
+    "permissionName" : "template-request.post",
+    "displayName" : "Template request",
+    "description" : "Request for template compilation"
+  }, {
+    "permissionName" : "templates.all",
+    "displayName" : "Templates module - all permissions",
+    "description" : "Entire set of permissions needed to use the Templates module",
+    "subPermissions" : [ "templates.collection.get", "templates.item.get", "templates.item.post", "templates.item.put", "templates.item.delete", "template-request.post" ],
+    "visible" : false
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-template-engine:1.9.0",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    }, {
+      "name" : "DB_HOST",
+      "value" : "postgres"
+    }, {
+      "name" : "DB_PORT",
+      "value" : "5432"
+    }, {
+      "name" : "DB_USERNAME",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_PASSWORD",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_DATABASE",
+      "value" : "okapi_modules"
+    }, {
+      "name" : "DB_QUERYTIMEOUT",
+      "value" : "60000"
+    }, {
+      "name" : "DB_CHARSET",
+      "value" : "UTF-8"
+    }, {
+      "name" : "DB_MAXPOOLSIZE",
+      "value" : "5"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    },
+    "dockerCMD" : [ "verify.user=true" ]
+  }
+}, {
+  "id" : "mod-user-import-3.2.1",
+  "name" : "User import",
+  "requires" : [ {
+    "id" : "permissions",
+    "version" : "5.0"
+  }, {
+    "id" : "users",
+    "version" : "14.0 15.0"
+  } ],
+  "provides" : [ {
+    "id" : "user-import",
+    "version" : "2.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/user-import",
+      "permissionsRequired" : [ "user-import.add" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/user-import",
+      "permissionsRequired" : [ "user-import.add" ],
+      "modulePermissions" : [ "addresstypes.collection.get", "perms.users.item.post", "user-settings.custom-fields.collection.get", "user-settings.custom-fields.collection.put", "usergroups.collection.get", "users.collection.get", "users.item.get", "users.item.post", "users.item.put" ]
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "user-import.add",
+    "displayName" : "Import users",
+    "description" : ""
+  }, {
+    "permissionName" : "user-import.all",
+    "displayName" : "User import",
+    "description" : "",
+    "subPermissions" : [ "user-import.add" ],
+    "visible" : true
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-user-import:3.2.1",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-users-17.1.2",
+  "name" : "users",
+  "provides" : [ {
+    "id" : "users",
+    "version" : "15.1",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/users",
+      "permissionsRequired" : [ "users.collection.get" ],
+      "permissionsDesired" : [ "users.read.basic", "users.read.restricted" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/users/{id}",
+      "permissionsRequired" : [ "users.item.get" ],
+      "permissionsDesired" : [ "users.read.basic", "users.read.restricted" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/users",
+      "permissionsRequired" : [ "users.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/users/{id}",
+      "permissionsRequired" : [ "users.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/users/{id}",
+      "permissionsRequired" : [ "users.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/groups",
+      "permissionsRequired" : [ "usergroups.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/groups/{id}*",
+      "permissionsRequired" : [ "usergroups.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/groups*",
+      "permissionsRequired" : [ "usergroups.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/groups/{id}*",
+      "permissionsRequired" : [ "usergroups.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/groups/{id}*",
+      "permissionsRequired" : [ "usergroups.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/addresstypes",
+      "permissionsRequired" : [ "addresstypes.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/addresstypes/{id}",
+      "permissionsRequired" : [ "addresstypes.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/addresstypes",
+      "permissionsRequired" : [ "addresstypes.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/addresstypes/{id}",
+      "permissionsRequired" : [ "addresstypes.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/addresstypes/{id}",
+      "permissionsRequired" : [ "addresstypes.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/proxiesfor",
+      "permissionsRequired" : [ "proxiesfor.collection.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/proxiesfor/{id}",
+      "permissionsRequired" : [ "proxiesfor.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/proxiesfor",
+      "permissionsRequired" : [ "proxiesfor.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/proxiesfor/{id}",
+      "permissionsRequired" : [ "proxiesfor.item.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/proxiesfor/{id}",
+      "permissionsRequired" : [ "proxiesfor.item.delete" ]
+    } ]
+  }, {
+    "id" : "custom-fields",
+    "version" : "2.0",
+    "interfaceType" : "multiple",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/custom-fields",
+      "permissionsRequired" : [ "user-settings.custom-fields.collection.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/custom-fields",
+      "permissionsRequired" : [ "user-settings.custom-fields.item.post" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/custom-fields/{id}",
+      "permissionsRequired" : [ "user-settings.custom-fields.item.get" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/custom-fields/{id}",
+      "permissionsRequired" : [ "user-settings.custom-fields.item.put" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/custom-fields",
+      "permissionsRequired" : [ "user-settings.custom-fields.collection.put" ]
+    }, {
+      "methods" : [ "DELETE" ],
+      "pathPattern" : "/custom-fields/{id}",
+      "permissionsRequired" : [ "user-settings.custom-fields.item.delete" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/custom-fields/{id}/stats",
+      "permissionsRequired" : [ "user-settings.custom-fields.item.stats.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/custom-fields/{id}/options/{optId}/stats",
+      "permissionsRequired" : [ "user-settings.custom-fields.item.option.stats.get" ]
+    } ]
+  }, {
+    "id" : "_tenant",
+    "version" : "1.2",
+    "interfaceType" : "system",
+    "handlers" : [ {
+      "methods" : [ "POST", "DELETE" ],
+      "pathPattern" : "/_/tenant"
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "users.collection.get",
+    "displayName" : "users collection get",
+    "description" : "Get a collection of user records"
+  }, {
+    "permissionName" : "user-settings.custom-fields.collection.put",
+    "displayName" : "Custom Fields - put collection",
+    "description" : "Put Custom Fields collection"
+  }, {
+    "permissionName" : "users.item.get",
+    "displayName" : "users item get",
+    "description" : "Read an individual record in the User module"
+  }, {
+    "permissionName" : "users.read.basic",
+    "displayName" : "users read-basic",
+    "description" : "Read non-restricted User data information"
+  }, {
+    "permissionName" : "users.read.restricted",
+    "displayName" : "users read-restricted",
+    "description" : "Read restricted User data information"
+  }, {
+    "permissionName" : "users.item.post",
+    "displayName" : "users item post",
+    "description" : "Create new records in the User module"
+  }, {
+    "permissionName" : "users.item.put",
+    "displayName" : "users item put",
+    "description" : "Edit existing records in the User module"
+  }, {
+    "permissionName" : "users.item.delete",
+    "displayName" : "users item delete",
+    "description" : "Delete records from the User module"
+  }, {
+    "permissionName" : "usergroups.collection.get",
+    "displayName" : "usergroups collection get",
+    "description" : "Get a list of usergroup records"
+  }, {
+    "permissionName" : "usergroups.item.get",
+    "displayName" : "usergroups item get",
+    "description" : "Get a single usergroup item"
+  }, {
+    "permissionName" : "usergroups.item.post",
+    "displayName" : "usergroups item post",
+    "description" : "Create new Groups for users"
+  }, {
+    "permissionName" : "usergroups.item.put",
+    "displayName" : "usergroups item put",
+    "description" : "Edit existing Groups for users"
+  }, {
+    "permissionName" : "usergroups.item.delete",
+    "displayName" : "usergroups item delete",
+    "description" : "Delete Groups for users"
+  }, {
+    "permissionName" : "addresstypes.collection.get",
+    "displayName" : "addresstypes collection get",
+    "description" : "Get a list of addresstype records"
+  }, {
+    "permissionName" : "addresstypes.item.get",
+    "displayName" : "addresstypes item get",
+    "description" : "Get a single addresstype record"
+  }, {
+    "permissionName" : "addresstypes.item.post",
+    "displayName" : "addresstypes item post",
+    "description" : "Create a new addresstype record"
+  }, {
+    "permissionName" : "addresstypes.item.put",
+    "displayName" : "addresstypes item put",
+    "description" : "Edit an addresstype record"
+  }, {
+    "permissionName" : "addresstypes.item.delete",
+    "displayName" : "addresstypes item delete",
+    "description" : "Delete an addresstype record"
+  }, {
+    "permissionName" : "proxiesfor.collection.get",
+    "displayName" : "proxiesfor collection get",
+    "description" : "Get a list of proxyfor records"
+  }, {
+    "permissionName" : "proxiesfor.item.get",
+    "displayName" : "proxiesfor item get",
+    "description" : "Get a single proxyfor record"
+  }, {
+    "permissionName" : "proxiesfor.item.post",
+    "displayName" : "proxiesfor item post",
+    "description" : "Create a new proxyfor record"
+  }, {
+    "permissionName" : "proxiesfor.item.put",
+    "displayName" : "proxiesfor item put",
+    "description" : "Edit a proxyfor record"
+  }, {
+    "permissionName" : "proxiesfor.item.delete",
+    "displayName" : "proxiesfor.item.delete",
+    "description" : "Delete a proxyfor record"
+  }, {
+    "permissionName" : "users.all",
+    "displayName" : "users all",
+    "description" : "All permissions for the mod-users module",
+    "subPermissions" : [ "users.collection.get", "users.item.get", "users.read.basic", "users.read.restricted", "users.item.post", "users.item.put", "users.item.delete", "usergroups.collection.get", "usergroups.item.get", "usergroups.item.post", "usergroups.item.put", "usergroups.item.delete", "addresstypes.collection.get", "addresstypes.item.get", "addresstypes.item.post", "addresstypes.item.put", "addresstypes.item.delete", "proxiesfor.collection.get", "proxiesfor.item.get", "proxiesfor.item.post", "proxiesfor.item.put", "proxiesfor.item.delete" ]
+  }, {
+    "permissionName" : "user-settings.custom-fields.collection.get",
+    "displayName" : "User Custom Fields - get collection",
+    "description" : "Get User Custom Fields collection"
+  }, {
+    "permissionName" : "user-settings.custom-fields.item.post",
+    "displayName" : "User Custom Fields - create field",
+    "description" : "Create User Custom Field"
+  }, {
+    "permissionName" : "user-settings.custom-fields.item.get",
+    "displayName" : "User Custom Fields - get field",
+    "description" : "Get User Custom Field"
+  }, {
+    "permissionName" : "user-settings.custom-fields.item.put",
+    "displayName" : "User Custom Fields - modify field",
+    "description" : "Modify User Custom Field"
+  }, {
+    "permissionName" : "user-settings.custom-fields.item.delete",
+    "displayName" : "User Custom Fields - delete field",
+    "description" : "Delete User Custom Field"
+  }, {
+    "permissionName" : "user-settings.custom-fields.item.stats.get",
+    "displayName" : "User Custom Fields - get item usage statistic",
+    "description" : "Get Custom Field Statistic"
+  }, {
+    "permissionName" : "user-settings.custom-fields.item.option.stats.get",
+    "displayName" : "User Custom Fields - get item option usage statistic",
+    "description" : "Get Custom Field Option Statistic"
+  }, {
+    "permissionName" : "user-settings.custom-fields.all",
+    "displayName" : "User Custom Fields module - all permissions",
+    "description" : "Entire set of permissions needed to use the user custom fields",
+    "subPermissions" : [ "user-settings.custom-fields.collection.get", "user-settings.custom-fields.collection.put", "user-settings.custom-fields.item.post", "user-settings.custom-fields.item.get", "user-settings.custom-fields.item.put", "user-settings.custom-fields.item.delete", "user-settings.custom-fields.item.stats.get", "user-settings.custom-fields.item.option.stats.get" ],
+    "visible" : false
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-users:17.1.2",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    }, {
+      "name" : "DB_HOST",
+      "value" : "postgres"
+    }, {
+      "name" : "DB_PORT",
+      "value" : "5432"
+    }, {
+      "name" : "DB_USERNAME",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_PASSWORD",
+      "value" : "folio_admin"
+    }, {
+      "name" : "DB_DATABASE",
+      "value" : "okapi_modules"
+    }, {
+      "name" : "DB_QUERYTIMEOUT",
+      "value" : "60000"
+    }, {
+      "name" : "DB_CHARSET",
+      "value" : "UTF-8"
+    }, {
+      "name" : "DB_MAXPOOLSIZE",
+      "value" : "5"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 536870912,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+}, {
+  "id" : "mod-users-bl-6.0.0",
+  "name" : "users business logic",
+  "requires" : [ {
+    "id" : "users",
+    "version" : "14.3 15.0"
+  }, {
+    "id" : "permissions",
+    "version" : "5.0"
+  }, {
+    "id" : "login",
+    "version" : "6.0 7.0"
+  }, {
+    "id" : "service-points",
+    "version" : "2.1 3.0"
+  }, {
+    "id" : "service-points-users",
+    "version" : "1.0"
+  }, {
+    "id" : "password-validator",
+    "version" : "1.0"
+  }, {
+    "id" : "authtoken",
+    "version" : "2.0"
+  }, {
+    "id" : "notify",
+    "version" : "2.0"
+  }, {
+    "id" : "configuration",
+    "version" : "2.0"
+  } ],
+  "provides" : [ {
+    "id" : "users-bl",
+    "version" : "6.0",
+    "handlers" : [ {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/bl-users",
+      "permissionsRequired" : [ "users-bl.collection.get" ],
+      "modulePermissions" : [ "users.collection.get", "inventory-storage.service-points-users.collection.get", "inventory-storage.service-points-users.item.get", "inventory-storage.service-points.collection.get", "inventory-storage.service-points.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/bl-users/_self",
+      "permissionsRequired" : [ ],
+      "modulePermissions" : [ "users.item.get", "users.collection.get", "perms.users.get", "usergroups.item.get", "inventory-storage.service-points-users.collection.get", "inventory-storage.service-points-users.item.get", "inventory-storage.service-points.collection.get", "inventory-storage.service-points.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/bl-users/login",
+      "permissionsRequired" : [ ],
+      "modulePermissions" : [ "users.item.get", "users.collection.get", "perms.users.item.get", "perms.users.get", "usergroups.item.get", "inventory-storage.service-points-users.collection.get", "inventory-storage.service-points-users.item.get", "inventory-storage.service-points.collection.get", "inventory-storage.service-points.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/bl-users/by-username/{id}",
+      "permissionsRequired" : [ "users-bl.item.get", "perms.users.get" ],
+      "modulePermissions" : [ "users.item.get", "users.collection.get", "perms.users.get", "login.item.get", "inventory-storage.service-points-users.collection.get", "inventory-storage.service-points-users.item.get", "inventory-storage.service-points.collection.get", "inventory-storage.service-points.item.get" ]
+    }, {
+      "methods" : [ "GET" ],
+      "pathPattern" : "/bl-users/by-id/{id}",
+      "permissionsRequired" : [ "users-bl.item.get", "perms.users.get" ],
+      "modulePermissions" : [ "users.item.get", "users.collection.get", "perms.users.get", "login.item.get", "inventory-storage.service-points-users.collection.get", "inventory-storage.service-points-users.item.get", "inventory-storage.service-points.collection.get", "inventory-storage.service-points.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/bl-users",
+      "permissionsRequired" : [ "users-bl.item.post" ],
+      "permissionsDesired" : [ "perms.users.item.post" ],
+      "modulePermissions" : [ "users.item.post", "perms.users.item.post", "login.item.post" ]
+    }, {
+      "methods" : [ "PUT" ],
+      "pathPattern" : "/bl-users/{id}",
+      "permissionsRequired" : [ "users-bl.item.put" ],
+      "permissionsDesired" : [ "perms.users.item.put" ],
+      "modulePermissions" : [ "users.edit", "users.item.put", "perms.users.item.put", "login.item.put" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/bl-users/forgotten/password",
+      "permissionsRequired" : [ ],
+      "permissionsDesired" : [ ],
+      "modulePermissions" : [ "users.edit", "users.item.put", "perms.users.item.put", "login.item.put", "configuration.entries.collection.get", "users.collection.get", "users.item.get", "login.password-reset-action.post", "auth.signtoken", "notify.item.post" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/bl-users/forgotten/username",
+      "permissionsRequired" : [ ],
+      "permissionsDesired" : [ ],
+      "modulePermissions" : [ "users.edit", "users.item.put", "perms.users.item.put", "login.item.put", "configuration.entries.collection.get", "users.collection.get", "notify.item.post" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/bl-users/settings/myprofile/password",
+      "permissionsRequired" : [ ],
+      "permissionsDesired" : [ ],
+      "modulePermissions" : [ "validation.validate.post", "login.item.put", "users.item.get" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/bl-users/password-reset/link",
+      "permissionsRequired" : [ "users-bl.password-reset-link.generate" ],
+      "permissionsDesired" : [ ],
+      "modulePermissions" : [ "users.item.get", "configuration.entries.collection.get", "login.password-reset-action.post", "auth.signtoken", "notify.item.post" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/bl-users/password-reset/reset",
+      "permissionsRequired" : [ "users-bl.password-reset-link.reset" ],
+      "permissionsDesired" : [ ],
+      "modulePermissions" : [ "login.password-reset-action.get", "users.item.get", "auth.signtoken", "login.password-reset.post", "validation.validate.post", "notify.item.post" ]
+    }, {
+      "methods" : [ "POST" ],
+      "pathPattern" : "/bl-users/password-reset/validate",
+      "permissionsRequired" : [ "users-bl.password-reset-link.validate" ],
+      "permissionsDesired" : [ ],
+      "modulePermissions" : [ "users.item.get", "auth.signtoken", "login.password-reset-action.get" ]
+    } ]
+  } ],
+  "permissionSets" : [ {
+    "permissionName" : "users-bl.collection.get",
+    "displayName" : "users-bl collection get",
+    "description" : "Get a list of composite user records"
+  }, {
+    "permissionName" : "users-bl.item.get",
+    "displayName" : "users-bl item get",
+    "description" : "Get a single composite user record by id"
+  }, {
+    "permissionName" : "users-bl.item.post",
+    "displayName" : "users-bl item post",
+    "description" : "Create a new composite user record"
+  }, {
+    "permissionName" : "users-bl.item.put",
+    "displayName" : "users-bl item put",
+    "description" : "Modify a composite user record"
+  }, {
+    "permissionName" : "users-bl.password-reset-link.generate",
+    "displayName" : "users-bl password reset link generate",
+    "description" : "Generate and send password reset link"
+  }, {
+    "permissionName" : "users-bl.password-reset-link.validate",
+    "displayName" : "users-bl password-reset-link validate",
+    "description" : "Validate create/reset password link and log user into system to change password"
+  }, {
+    "permissionName" : "users-bl.password-reset-link.reset",
+    "displayName" : "users-bl password-reset-link reset",
+    "description" : "Reset password by link"
+  }, {
+    "permissionName" : "users-bl.all",
+    "displayName" : "users-bl all",
+    "description" : "All user business-logic permissions",
+    "subPermissions" : [ "users-bl.collection.get", "users-bl.item.get", "users-bl.item.post", "users-bl.item.put", "users-bl.password-reset-link.generate", "users-bl.password-reset-link.validate", "users-bl.password-reset-link.reset" ],
+    "visible" : false
+  } ],
+  "launchDescriptor" : {
+    "dockerImage" : "folioorg/mod-users-bl:6.0.0",
+    "dockerPull" : true,
+    "env" : [ {
+      "name" : "JAVA_OPTIONS",
+      "value" : "-XX:MaxRAMPercentage=66.0"
+    } ],
+    "dockerArgs" : {
+      "HostConfig" : {
+        "Memory" : 357913941,
+        "PortBindings" : {
+          "8081/tcp" : [ {
+            "HostPort" : "%p"
+          } ]
+        }
+      }
+    }
+  }
+} ]


### PR DESCRIPTION
OKAPI-916... More refactoring than at first sight, because the matching.. redirects.. auth caching.. metrics was all combined in one function. The ModuleCache is "unaware" of tenants, and is managed by TenantManager so that there's one ModuleCache per tenant. The redirect functionality is ugly and not in use.. We should consider removing it.

Running through all end points for Q2 modules, the number of match invocations is down from about 500k to 5k. That's ProxyTest.testManyModules.