### PR TITLE
Update de.flapdoodle.embed.{mongo,process}

### DIFF
--- a/okapi-core/pom.xml
+++ b/okapi-core/pom.xml
@@ -145,13 +145,13 @@
     <dependency>
       <groupId>de.flapdoodle.embed</groupId>
       <artifactId>de.flapdoodle.embed.mongo</artifactId>
-      <version>2.1.2</version>
+      <version>2.2.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>de.flapdoodle.embed</groupId>
       <artifactId>de.flapdoodle.embed.process</artifactId>
-      <version>2.0.5</version>
+      <version>2.1.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/okapi-core/src/test/java/org/folio/okapi/ModuleTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ModuleTest.java
@@ -148,7 +148,7 @@ public class ModuleTest {
       if (mongoD == null) {
         MongodStarter starter = MongodStarter.getDefaultInstance();
         mongoExe = starter.prepare(new MongodConfigBuilder()
-          .version(Version.V3_6_0)
+          .version(Version.V3_6_5)
           .net(new Net("localhost", MONGO_PORT, Network.localhostIsIPv6()))
           .build());
         mongoD = mongoExe.start();


### PR DESCRIPTION
Update de.flapdoodle.embed.mongo to 2.2.0.
Update de.flapdoodle.embed.process to 2.1.2.
Update Mongo from 3.6.0 to 3.6.5.

This might fix stability with Mongo unit tests OKAPI-932.