### PR TITLE
Fix NPE in LockedStringMap.clear

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/util/LockedStringMap.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/LockedStringMap.java
@@ -50,7 +50,14 @@ public class LockedStringMap {
     return list.size();
   }
 
+  /**
+   * Clear map.
+   * @return async result.
+   */
   public Future<Void> clear() {
+    if (list == null) {
+      return Future.succeededFuture();
+    }
     return list.clear();
   }
 


### PR DESCRIPTION
Called from DiscoveryManager.shutdown. Not really seen because
the problem is shutting down anyway.