### PR TITLE
Link Docker and Ubuntu repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,28 @@ For example:
 When filing bug reports with unit test output, always use Maven
 option `-B` to avoid control characters in output.
 
+## Docker image
+
+At Docker Hub:
+
+* https://hub.docker.com/u/folioorg/okapi released versions
+* https://hub.docker.com/r/folioci/okapi snapshot versions
+
+See [Automation/Docker
+Hub](https://dev.folio.org/guides/automation/#docker-hub) for details.
+
+Docker images are the primary distribution model for FOLIO modules.
+To run the images you will need the Docker Engine or Docker Desktop
+runtime.
+
+## Ubuntu package
+
+Import the FOLIO signing key and add the [FOLIO apt
+repository](https://repository.folio.org/packages/ubuntu/):
+
+    wget --quiet -O - https://repository.folio.org/packages/debian/folio-apt-archive-key.asc | sudo apt-key add -
+    sudo add-apt-repository "deb https://repository.folio.org/packages/ubuntu/ focal/"
+
 ## Documentation
 
 * [Okapi Guide and Reference](doc/guide.md)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ option `-B` to avoid control characters in output.
 
 At Docker Hub:
 
-* https://hub.docker.com/u/folioorg/okapi released versions
+* https://hub.docker.com/r/folioorg/okapi released versions
 * https://hub.docker.com/r/folioci/okapi snapshot versions
 
 See [Automation/Docker

--- a/README.md
+++ b/README.md
@@ -59,9 +59,10 @@ runtime.
 ## Ubuntu package
 
 Import the FOLIO signing key and add the [FOLIO apt
-repository](https://repository.folio.org/packages/ubuntu/):
+repository](https://repository.folio.org/packages/ubuntu/) for
+Ubuntu 20.04 LTS (Focal Fossa):
 
-    wget --quiet -O - https://repository.folio.org/packages/debian/folio-apt-archive-key.asc | sudo apt-key add -
+    wget -q -O - https://repository.folio.org/packages/debian/folio-apt-archive-key.asc | sudo apt-key add -
     sudo add-apt-repository "deb https://repository.folio.org/packages/ubuntu/ focal/"
 
 ## Documentation


### PR DESCRIPTION
To qualify for the Open Source Project status under the
`Docker Open Source Policy` FOLIO as a publisher needs to
comply with the `Joint Marketing Programs` requirement:

"While the publisher retains the Open Source project status, the Publisher agrees to -
* Become a Docker public reference for press releases, blogs, webinars, etc
* Create joint blogs, webinars and other marketing content
* Create explicit links to their Docker Hub repos, with no ‘wrapping’ or hiding sources of their images
* Document that Docker Engine or Docker Desktop are required to run their whitelisted images
* Give Docker full attribution"

Okapi is the first pinned repository on https://github.com/folio-org

The Docker text has been copied from
https://dev.folio.org/download/artifacts/