### PR TITLE
OKAPI-944 failed tests on mac and ec2

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/service/impl/ProcessModuleHandle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/service/impl/ProcessModuleHandle.java
@@ -149,7 +149,7 @@ public class ProcessModuleHandle extends NuAbstractProcessHandler implements Mod
     Promise<Void> promise = Promise.promise();
     // time to wait for process status.. when a port is present (always in real life)..
     // The waitReady will check if process eventually starts listening on port
-    vertx.setTimer(port == 0 ? 3000 : 1000, timerRes -> {
+    vertx.setTimer(3000, timerRes -> {
       if (process.isRunning() || exitCode == 0) {
         promise.complete();
         return;
@@ -198,7 +198,7 @@ public class ProcessModuleHandle extends NuAbstractProcessHandler implements Mod
     Promise<Void> promise = Promise.promise();
     // time to wait for process that shuts down service.. when a port is present (always in prod)
     // The waitPortClose will wait for service to shut down
-    vertx.setTimer(port == 0 ? 3000 : 1000, timerRes -> {
+    vertx.setTimer(3000, timerRes -> {
       if (pp.isRunning() || exitCode == 0) {
         promise.complete();
         return;

--- a/okapi-core/src/main/java/org/folio/okapi/service/impl/ProcessModuleHandle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/service/impl/ProcessModuleHandle.java
@@ -149,7 +149,7 @@ public class ProcessModuleHandle extends NuAbstractProcessHandler implements Mod
     Promise<Void> promise = Promise.promise();
     // time to wait for process status.. when a port is present (always in real life)..
     // The waitReady will check if process eventually starts listening on port
-    vertx.setTimer(3000, timerRes -> {
+    vertx.setTimer(port == 0 ? 3000 : 1000, timerRes -> {
       if (process.isRunning() || exitCode == 0) {
         promise.complete();
         return;
@@ -198,7 +198,7 @@ public class ProcessModuleHandle extends NuAbstractProcessHandler implements Mod
     Promise<Void> promise = Promise.promise();
     // time to wait for process that shuts down service.. when a port is present (always in prod)
     // The waitPortClose will wait for service to shut down
-    vertx.setTimer(3000, timerRes -> {
+    vertx.setTimer(port == 0 ? 3000 : 1000, timerRes -> {
       if (pp.isRunning() || exitCode == 0) {
         promise.complete();
         return;

--- a/okapi-core/src/main/java/org/folio/okapi/util/TcpPortWaiting.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/TcpPortWaiting.java
@@ -68,6 +68,9 @@ public class TcpPortWaiting {
     if (port == 0) {
       return Future.succeededFuture();
     }
+    if (process != null && !process.isRunning()) {
+      process = null;
+    }
     return tryConnect(process, 0);
   }
 }

--- a/okapi-core/src/test/java/org/folio/okapi/service/impl/DockerModuleHandleTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/service/impl/DockerModuleHandleTest.java
@@ -511,7 +511,8 @@ public class DockerModuleHandleTest implements WithAssertions {
     {
       Async async = context.async();
       dh.pullImage().onComplete(context.asyncAssertFailure(res -> {
-        context.assertTrue(res.getMessage().contains("9231: connect: connection refused"), res.getMessage());
+        context.assertTrue(res.getMessage().contains("9231")
+            && res.getMessage().contains("connection refused"), res.getMessage());
         async.complete();
       }));
       async.await();

--- a/okapi-core/src/test/java/org/folio/okapi/service/impl/DockerModuleHandleTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/service/impl/DockerModuleHandleTest.java
@@ -511,8 +511,7 @@ public class DockerModuleHandleTest implements WithAssertions {
     {
       Async async = context.async();
       dh.pullImage().onComplete(context.asyncAssertFailure(res -> {
-        context.assertTrue(res.getMessage().contains("9231")
-            && res.getMessage().contains("connection refused"), res.getMessage());
+        assertThat(res.getMessage()).contains("9231").contains("connection refused");
         async.complete();
       }));
       async.await();

--- a/okapi-core/src/test/java/org/folio/okapi/service/impl/ProcessModuleHandleTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/service/impl/ProcessModuleHandleTest.java
@@ -51,7 +51,6 @@ public class ProcessModuleHandleTest {
   };
 
   private ModuleHandle createModuleHandle(LaunchDescriptor desc, int port) {
-    desc.setWaitIterations(15);
     ProcessModuleHandle pmh = new ProcessModuleHandle(vertx, desc, "test", ports, port);
     return pmh;
   }
@@ -72,6 +71,7 @@ public class ProcessModuleHandleTest {
     LaunchDescriptor desc = new LaunchDescriptor();
     // program starts OK, but do not listen to port..
     desc.setExec("java -version %p");
+    desc.setWaitIterations(3);
     ModuleHandle mh = createModuleHandle(desc, 9231);
 
     mh.start().onComplete(context.asyncAssertFailure(cause ->

--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers-bom</artifactId>
-        <version>1.14.3</version>
+        <version>1.15.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Made two small changes to get failed tests pass. For EC2, the connection refused message does not match perfectly. For mac, it turns out the NuProcess returns the sh pid but not the Java pid. So the NuProcess object is not null and is not running, the tryConnect loop does not capture this. Extending the timer wait time to let tryConnect succeed as a work around.

After updating Docker on my Mac, I start to see lots of Ryuk connection error. Updating testcontains version fixed that. There was an issue reported for testcontainer. See https://github.com/testcontainers/testcontainers-java/pull/3159