### PR TITLE
OKAPI-839 - OKAPI portion of PoC for static permission migration

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/bean/Permission.java
+++ b/okapi-core/src/main/java/org/folio/okapi/bean/Permission.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Permission {
   private String permissionName;
+  private String[] renamedFrom;
   private String displayName;
   private String description;
   private String[] subPermissions;
@@ -22,6 +23,7 @@ public class Permission {
    */
   public Permission(Permission other) {
     this.permissionName = other.permissionName;
+    this.renamedFrom = other.renamedFrom;
     this.displayName = other.displayName;
     this.description = other.description;
     this.subPermissions = other.subPermissions;
@@ -66,6 +68,14 @@ public class Permission {
 
   public void setVisible(Boolean visible) {
     this.visible = visible;
+  }
+
+  public String[] getRenamedFrom() {
+    return renamedFrom;
+  }
+
+  public void setRenamedFrom(String[] renamedFrom) {
+    this.renamedFrom = renamedFrom;
   }
 
 }

--- a/okapi-core/src/main/java/org/folio/okapi/bean/PermissionChanges.java
+++ b/okapi-core/src/main/java/org/folio/okapi/bean/PermissionChanges.java
@@ -1,0 +1,61 @@
+package org.folio.okapi.bean;
+
+/**
+ * List of Permissions (and permission sets) belonging to a module. Used as a
+ * parameter in the system request to initialize the permission module when a
+ * module is being enabled for a tenant.
+ */
+public class PermissionChanges {
+  private String moduleId; // The module that owns these permissions.
+  private Permission[] newPermissions;
+  private Permission[] modifiedPermissions;
+  private Permission[] removedPermissions;
+
+  /**
+   * Constructor taking all fields.
+   * @param moduleId module identifier
+   * @param newPerms new permissions
+   * @param modifiedPerms modified permissions
+   * @param removedPerms removed permissions
+   */
+  public PermissionChanges(String moduleId, Permission[] newPerms, Permission[] modifiedPerms,
+      Permission[] removedPerms) {
+    this.moduleId = moduleId;
+    this.newPermissions = newPerms;
+    this.modifiedPermissions = modifiedPerms;
+    this.removedPermissions = removedPerms;
+  }
+
+  public String getModuleId() {
+    return moduleId;
+  }
+
+  public void setModuleId(String moduleId) {
+    this.moduleId = moduleId;
+  }
+
+  public Permission[] getNewPermissions() {
+    return newPermissions;
+  }
+
+  public void setNewPermissions(Permission[] newPermissions) {
+    this.newPermissions = newPermissions;
+  }
+
+  public Permission[] getModifiedPermissions() {
+    return modifiedPermissions;
+  }
+
+  public void setModifiedPermissions(Permission[] modifiedPermissions) {
+    this.modifiedPermissions = modifiedPermissions;
+  }
+
+  public Permission[] getRemovedPermissions() {
+    return removedPermissions;
+  }
+
+  public void setRemovedPermissions(Permission[] removedPermissions) {
+    this.removedPermissions = removedPermissions;
+  }
+
+}

--- a/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
@@ -679,7 +679,7 @@ public class TenantManager implements Liveness {
             updatedPerms.toArray(new Permission[updatedPerms.size()]),
             removedPerms.toArray(new Permission[removedPerms.size()]));
 
-    pc.debug("tenantPerms: " + permsModule.getId() + " and " + permPath);
+    logger.debug("tenantPerms: {} and {}", permsModule.getId(), permPath);
     if (!newPerms.isEmpty() && permInst == null) {
       return Future.failedFuture(new OkapiError(ErrorType.USER,
           "Bad _tenantPermissions interface in module " + permsModule.getId()
@@ -689,19 +689,11 @@ public class TenantManager implements Liveness {
           .callSystemInterface(tenant, permInst, Json.encodePrettily(permChanges), pc)
           .compose(cres -> {
             pc.passOkapiTraceHeaders(cres);
-            pc.debug("tenantPerms request to " + permsModule.getName() + " succeeded for module "
-                + moduleTo + " and tenant " + tenant.getId());
+            logger.debug("tenantPerms request to {} succeeded for module {} and tenant {}",
+                permsModule.getId(), moduleTo, tenant.getId());
             return Future.succeededFuture();
           });
     }
-
-    logger.debug("tenantPerms: {} and {}", permsModule.getId(), permPath);
-    return proxyService.callSystemInterface(tenant, permInst, pljson, pc).compose(cres -> {
-      pc.passOkapiTraceHeaders(cres);
-      logger.debug("tenantPerms request to {} succeeded for module {} and tenant {}",
-          permsModule.getId(), moduleTo, tenant.getId());
-      return Future.succeededFuture();
-    });
   }
 
   /**

--- a/okapi-core/src/main/raml/Permission.json
+++ b/okapi-core/src/main/raml/Permission.json
@@ -10,6 +10,13 @@
       "description": "Permission ID (usually module.service.method or similar)",
       "type": "string"
     },
+    "renamedFrom": {
+      "description": "previously used names for this permission",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "displayName": {
       "description": "Human readable name for permission",
       "type": "string"

--- a/okapi-core/src/test/java/org/folio/okapi/ModuleTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ModuleTest.java
@@ -1268,7 +1268,7 @@ public class ModuleTest {
       + "}";
     final String expPerms = "{ "
       + "\"moduleId\" : \"sample-module-1\", "
-      + "\"perms\" : [ { "
+      + "\"newPermissions\" : [ { "
       + "\"permissionName\" : \"everything\", "
       + "\"displayName\" : \"every possible permission\", "
       + "\"description\" : \"All permissions combined\", "
@@ -1286,7 +1286,7 @@ public class ModuleTest {
       + "\"description\" : \"System generated permission set\", "
       + "\"subPermissions\" : [ \"sample.tenantperm\" ], "
       + "\"visible\" : false "
-      + "} ] }";
+      + "} ], \"modifiedPermissions\": [ ], \"removedPermissions\": [ ] }";
 
     String locSampleEnable = given()
       .header("Content-Type", "application/json")
@@ -1328,7 +1328,9 @@ public class ModuleTest {
       + "}";
     final String expPerms2 = "{ "
       + "\"moduleId\" : \"sample-module2-1\", "
-      + "\"perms\" : null }";
+      + "\"newPermissions\" : [], "
+      + "\"modifiedPermissions\" : [], "
+      + "\"removedPermissions\" : [] }";
 
     String locSampleEnable2 = given()
       .header("Content-Type", "application/json")
@@ -1424,6 +1426,130 @@ public class ModuleTest {
     // Check that the tenant interface and the tenantpermission interfaces
     // were called with proper auth tokens and with ModulePermissions
 
+    //CAM -- start
+
+    // Set up the test module
+    // It provides a _tenant interface, but no _tenantPermissions
+    // Enabling it will end up invoking the _tenantPermissions in header-module
+    final String docSampleModuleUpdated = "{" + LS
+      + "  \"id\" : \"sample-module-2\"," + LS
+      + "  \"name\" : \"sample module\"," + LS
+      + "  \"provides\" : [ {" + LS
+      + "    \"id\" : \"sample\"," + LS
+      + "    \"version\" : \"2.0\"," + LS
+      + "    \"handlers\" : [ {" + LS
+      + "      \"methods\" : [ \"GET\", \"POST\" ]," + LS
+      + "      \"path\" : \"/testb\"," + LS
+      + "      \"level\" : \"30\"," + LS
+      + "      \"type\" : \"request-response\"," + LS
+      + "      \"permissionsRequired\" : [ \"sample.needed\" ]," + LS
+      + "      \"permissionsDesired\" : [ \"sample.extra\" ]," + LS
+      + "      \"modulePermissions\" : [ \"sample.modperm\" ]" + LS
+      + "    } ]" + LS
+      + "  }, {" + LS
+      + "    \"id\" : \"_tenant\"," + LS
+      + "    \"version\" : \"1.0\"," + LS
+      + "    \"interfaceType\" : \"system\"," + LS
+      + "    \"handlers\" : [ {" + LS
+      + "      \"methods\" : [ \"POST\", \"DELETE\" ]," + LS
+      + "      \"path\" : \"/_/tenant\"," + LS
+      + "      \"level\" : \"10\"," + LS
+      + "      \"type\" : \"system\"," + LS
+      + "      \"permissionsRequired\" : [ ]," + LS
+      + "      \"modulePermissions\" : [ \"sample.tenantperm\" ]" + LS
+      + "    } ]" + LS
+      + "  } ]," + LS
+      + "  \"permissionSets\" : [ {" + LS
+      + "    \"permissionName\" : \"all\"," + LS
+      + "    \"renamedFrom\" : [ \"everything\" ]," + LS
+      + "    \"displayName\" : \"all possible permissions\"," + LS
+      + "    \"description\" : \"All permissions combined\"," + LS
+      + "    \"subPermissions\" : [ \"sample.needed\", \"sample.extra\" ]," + LS
+      + "    \"visible\" : true" + LS
+      + "  } ]," + LS
+      + "  \"launchDescriptor\" : {" + LS
+      + "    \"exec\" : \"java -Dport=%p -jar " + testModJar + "\"" + LS
+      + "  }" + LS
+      + "}";
+
+    // Create and deploy the sample module
+    final String locSampleModuleUpdated = createModule(docSampleModuleUpdated);
+    final String locationSampleDeploymentUpdated = deployModule("sample-module-2");
+
+    // Enable the small module. Verify that the _tenantPermissions gets
+    // invoked.
+    final String docEnableUpdated = "[ {" + LS
+      + "  \"id\" : \"sample-module-2\"," + LS
+      + "  \"action\" : \"enable\"" + LS
+      + "} ]";
+    final String expPermsUpdated = "{ "
+        + "\"moduleId\" : \"sample-module-2\", "
+        + "\"newPermissions\" : [ { "
+        + "\"permissionName\" : \"all\", "
+        + "\"renamedFrom\" : [ \"everything\" ], "
+        + "\"displayName\" : \"all possible permissions\", "
+        + "\"description\" : \"All permissions combined\", "
+        + "\"subPermissions\" : [ \"sample.needed\", \"sample.extra\" ], "
+        + "\"visible\" : true "
+        + "}, { "
+        + "\"permissionName\" : \"SYS#sample-module-2#/testb#[GET, POST]\", "
+        + "\"displayName\" : \"System generated: SYS#sample-module-2#/testb#[GET, POST]\", "
+        + "\"description\" : \"System generated permission set\", "
+        + "\"subPermissions\" : [ \"sample.modperm\" ], "
+        + "\"visible\" : false "
+        + "}, { "
+        + "\"permissionName\" : \"SYS#sample-module-2#/_/tenant#[POST, DELETE]\", "
+        + "\"displayName\" : \"System generated: SYS#sample-module-2#/_/tenant#[POST, DELETE]\", "
+        + "\"description\" : \"System generated permission set\", "
+        + "\"subPermissions\" : [ \"sample.tenantperm\" ], "
+        + "\"visible\" : false "
+        + "} ], "
+        + "\"modifiedPermissions\": [ ], "
+        + "\"removedPermissions\": [ { "
+        + "\"permissionName\" : \"everything\", "
+        + "\"displayName\" : \"every possible permission\", "
+        + "\"description\" : \"All permissions combined\", "
+        + "\"subPermissions\" : [ \"sample.needed\", \"sample.extra\" ], "
+        + "\"visible\" : true "
+        + "}, { "
+        + "\"permissionName\" : \"SYS#sample-module-1#/testb#[GET, POST]\", "
+        + "\"displayName\" : \"System generated: SYS#sample-module-1#/testb#[GET, POST]\", "
+        + "\"description\" : \"System generated permission set\", "
+        + "\"subPermissions\" : [ \"sample.modperm\" ], "
+        + "\"visible\" : false "
+        + "}, { "
+        + "\"permissionName\" : \"SYS#sample-module-1#/_/tenant#[POST, DELETE]\", "
+        + "\"displayName\" : \"System generated: SYS#sample-module-1#/_/tenant#[POST, DELETE]\", "
+        + "\"description\" : \"System generated permission set\", "
+        + "\"subPermissions\" : [ \"sample.tenantperm\" ], "
+        + "\"visible\" : false "
+        + "} ] "
+        + "}";
+
+    given()
+      .header("Content-Type", "application/json")
+      .body(docEnableUpdated)
+      .post("/_/proxy/tenants/" + okapiTenant + "/install")
+      .then()
+      .statusCode(200)
+      .log().ifValidationFails();
+
+    String locSampleEnableUpdated = "/_/proxy/tenants/" + okapiTenant + "/modules/sample-module-2";
+
+    body = given()
+        .header("X-Okapi-Tenant", okapiTenant)
+        .get("/permResult")
+        .then()
+        .statusCode(200)
+        .log().ifValidationFails()
+        .extract().body().asString();
+
+    ar = new JsonArray(body);
+    context.assertEquals(1, ar.size());
+    context.assertEquals(new JsonObject(expPermsUpdated), ar.getJsonObject(0));
+
+    //CAM -- end
+
     // Clean up, so the next test starts with a clean slate (in reverse order)
     logger.debug("testSystemInterfaces cleaning up");
 
@@ -1432,6 +1558,11 @@ public class ModuleTest {
     given().delete(locAuthEnable).then().log().ifValidationFails().statusCode(204);
     given().delete(locAuthDeployment).then().log().ifValidationFails().statusCode(204);
     given().delete(locAuthModule).then().log().ifValidationFails().statusCode(204);
+
+    //CAM
+    given().delete(locSampleEnableUpdated).then().log().ifValidationFails().statusCode(204);
+    given().delete(locationSampleDeploymentUpdated).then().log().ifValidationFails().statusCode(204);
+    given().delete(locSampleModuleUpdated).then().log().ifValidationFails().statusCode(204);
 
     given().delete(locSampleEnable2).then().log().ifValidationFails().statusCode(204);
     given().delete(locationSampleDeployment2).then().log().ifValidationFails().statusCode(204);

--- a/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
@@ -235,7 +235,7 @@ public class ProxyTest {
           } else if (p.startsWith("/permissionscall")) {
             JsonObject permObject = new JsonObject(buf);
             if (timerTenantPermissionsStatus == 200) {
-              timerPermissions.put(permObject.getString("moduleId"), permObject.getJsonArray("perms"));
+              timerPermissions.put(permObject.getString("moduleId"), permObject.getJsonArray("newPermissions"));
             }
             ctx.response().setStatusCode(timerTenantPermissionsStatus);
             ctx.response().end("timer permissions response");


### PR DESCRIPTION
## Purpose
The PoC for [OKAPI-839](https://issues.folio.org/browse/OKAPI-839) has two parts - OKAPI and mod-permissions.  This PR is to help review the rough PoC code for the OKAPI portion.

*N.B.* I apparently got the JIRA key screwed up when creating the branch - it's OKAPI-839 not 893!  

## Approach
* Add a `renamedFrom` field to the module descriptor.
  * an array of strings (permission names) which the permission used to have.
* Upon upgrade, determine which permissions are new, updated, and deleted.
* Update the body of the request to mod-permissions _tenantPermissions endpoint to have three lists of permissions - `newPermissions`, `modifiedPermisions`, `removedPermissions`
* Update unit tests

See https://wiki.folio.org/display/FOLIJET/Migration+of+Static+Permissions+Upon+Upgrade