### PR TITLE
Support both "http.port" and "port" property variables

### DIFF
--- a/dist/okapi.sh
+++ b/dist/okapi.sh
@@ -121,9 +121,19 @@ parse_okapi_conf()  {
       OKAPI_JAVA_OPTS+=" -Dhost=${host}"
    fi
 
-   # configure okapi port
-   if [ "$port" ]; then
-      OKAPI_JAVA_OPTS+=" -Dport=${port}"
+   # configure okapi http port
+   # Environment variables with periods/dots in their names are deprecated
+   # because a period is not POSIX compliant and therefore some shells, notably,
+   # the BusyBox /bin/sh included in Alpine Linux, strip them:
+   # https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html
+   # https://github.com/docker-library/docs/tree/master/openjdk#environment-variables-with-periods-in-their-names
+   # https://wiki.ubuntu.com/DashAsBinSh
+   # https://wiki.ubuntu.com/DashAsBinSh/Spec
+   # Java property variable names allow periods/dots.
+   if [ "$http_port" ]; then
+      OKAPI_JAVA_OPTS+=" -Dhttp.port=${http_port}"
+   elif [ "$port" ]; then
+      OKAPI_JAVA_OPTS+=" -Dhttp.port=${port}"
    fi
 
    # configure module port range

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -703,13 +703,13 @@ okapi-core must be last because its tests rely on the previous ones.)
 
 The result for each module and okapi-core is a combined jar file
 with all necessary components combined, including Vert.x. The listening
-port is adjusted with property `port`.
+port is adjusted with property `http.port` or `port`.
 
 For example, to run the okapi-test-auth-module module and listen on port 8600, use:
 
 ```
 cd okapi-test-auth-module
-java -Dport=8600 -jar target/okapi-test-auth-module-fat.jar
+java -Dhttp.port=8600 -jar target/okapi-test-auth-module-fat.jar
 ```
 
 In the same way, to run the okapi-core, specify its jar file. It is
@@ -719,7 +719,7 @@ single node, we use the `dev` mode.
 
 ```
 cd okapi-core
-java -Dport=8600 -jar target/okapi-core-fat.jar dev
+java -Dhttp.port=8600 -jar target/okapi-core-fat.jar dev
 ```
 
 There are other commands available. Supply `help` to get a description of
@@ -1027,7 +1027,7 @@ cat > /tmp/okapi-proxy-test-basic.1.json <<END
   ],
   "requires": [],
   "launchDescriptor": {
-    "exec": "java -Dport=%p -jar okapi-test-module/target/okapi-test-module-fat.jar"
+    "exec": "java -Dhttp.port=%p -jar okapi-test-module/target/okapi-test-module-fat.jar"
   }
 }
 END
@@ -1079,7 +1079,7 @@ Content-Length: 370
     } ]
   } ],
   "launchDescriptor" : {
-    "exec" : "java -Dport=%p -jar okapi-test-module/target/okapi-test-module-fat.jar"
+    "exec" : "java -Dhttp.port=%p -jar okapi-test-module/target/okapi-test-module-fat.jar"
   }
 }
 ```
@@ -1170,7 +1170,7 @@ Content-Length: 259
   "nodeId" : "localhost",
   "url" : "http://localhost:9131",
   "descriptor" : {
-    "exec" : "java -Dport=%p -jar okapi-test-module/target/okapi-test-module-fat.jar"
+    "exec" : "java -Dhttp.port=%p -jar okapi-test-module/target/okapi-test-module-fat.jar"
   }
 }
 ```
@@ -1452,7 +1452,7 @@ cat > /tmp/okapi-deploy-test-auth.json <<END
   "srvcId": "test-auth-3.4.1",
   "nodeId": "localhost",
   "descriptor": {
-    "exec": "java -Dport=%p -jar okapi-test-auth-module/target/okapi-test-auth-module-fat.jar"
+    "exec": "java -Dhttp.port=%p -jar okapi-test-auth-module/target/okapi-test-auth-module-fat.jar"
   }
 }
 END
@@ -1475,7 +1475,7 @@ Content-Length: 268
   "nodeId" : "localhost",
   "url" : "http://localhost:9132",
   "descriptor" : {
-    "exec" : "java -Dport=%p -jar okapi-test-auth-module/target/okapi-test-auth-module-fat.jar"
+    "exec" : "java -Dhttp.port=%p -jar okapi-test-auth-module/target/okapi-test-auth-module-fat.jar"
   }
 }
 ```
@@ -1643,7 +1643,7 @@ cat > /tmp/okapi-proxy-test-basic.2.json <<END
     }
   ],
   "launchDescriptor": {
-    "exec": "java -Dport=%p -jar okapi-test-module/target/okapi-test-module-fat.jar",
+    "exec": "java -Dhttp.port=%p -jar okapi-test-module/target/okapi-test-module-fat.jar",
     "env": [
       {
         "name": "helloGreeting",
@@ -1879,7 +1879,7 @@ there is no need to repeat all the `curl` commands.
     }
   ],
   "launchDescriptor": {
-    "exec": "java -Dport=%p -jar okapi-test-module/target/okapi-test-module-fat.jar",
+    "exec": "java -Dhttp.port=%p -jar okapi-test-module/target/okapi-test-module-fat.jar",
     "env": [
       {
         "name": "helloGreeting",
@@ -2001,7 +2001,7 @@ cat > /tmp/okapi-proxy-foo.json <<END
   ],
   "requires": [],
   "launchDescriptor": {
-    "exec": "java -Dport=%p -jar okapi-test-module/target/okapi-test-module-fat.jar"
+    "exec": "java -Dhttp.port=%p -jar okapi-test-module/target/okapi-test-module-fat.jar"
   }
 }
 END
@@ -2056,7 +2056,7 @@ cat > /tmp/okapi-proxy-bar.json <<END
   ],
   "requires": [],
   "launchDescriptor": {
-    "exec": "java -Dport=%p -jar okapi-test-module/target/okapi-test-module-fat.jar"
+    "exec": "java -Dhttp.port=%p -jar okapi-test-module/target/okapi-test-module-fat.jar"
   }
 }
 END
@@ -2224,7 +2224,7 @@ same port. By default Okapi allocates 20 ports for the modules, so
 let's start the next Okapi on port 9150:
 
 ```
-java -Dport=9150 -jar okapi-core/target/okapi-core-fat.jar cluster
+java -Dhttp.port=9150 -jar okapi-core/target/okapi-core-fat.jar cluster
 ```
 Again Okapi prints some startup messages, but note that also the first Okapi
 prints some stuff. Those two are connecting, and talking to each other.
@@ -2743,7 +2743,7 @@ properties.
 When the `-D` option is used, it should be in the beginning of the
 command-line, before the `-jar`.
 
-* `port`: The port on which Okapi listens. Defaults to 9130
+* `http.port` or `port`: The port on which Okapi listens. Defaults to 9130.
 * `port_start` and `port_end`: The range of ports for modules. Default to
 `port`+1 to `port`+10, normally 9131 to 9141
 * `host`: Hostname to be used in the URLs returned by the deployment service.

--- a/okapi-common/src/main/java/org/folio/okapi/common/Config.java
+++ b/okapi-common/src/main/java/org/folio/okapi/common/Config.java
@@ -27,6 +27,30 @@ public class Config {
   }
 
   /**
+   * Returns string config info from properties and JSON config.
+   * Check in this order and return the first that is defined and,
+   * for properties, is not empty:
+   * key1 property, key2 property, key1 in JsonObject, key2 in JsonObject,
+   * {@code def} fallback value.
+   * @param key1 property key (JSON key)
+   * @param key2 property key (JSON key)
+   * @param def default value (may be null)
+   * @param conf JSON object configuration
+   * @return property value (possibly null)
+   */
+  public static String getSysConf(String key1, String key2, String def, JsonObject conf) {
+    String v = System.getProperty(key1);
+    if (v != null && ! v.isEmpty()) {
+      return v;
+    }
+    v = System.getProperty(key2);
+    if (v != null && ! v.isEmpty()) {
+      return v;
+    }
+    return conf.getString(key1, conf.getString(key2, def));
+  }
+
+  /**
    * Returns boolean config info from properties and JSON config.
    * Check boolean property first in system; if not found OR empty,
    * inspect JSON configuration
@@ -43,4 +67,5 @@ public class Config {
     }
     return Boolean.parseBoolean(v);
   }
+
 }

--- a/okapi-common/src/test/java/org/folio/okapi/common/ConfigTest.java
+++ b/okapi-common/src/test/java/org/folio/okapi/common/ConfigTest.java
@@ -1,7 +1,8 @@
 package org.folio.okapi.common;
+
 import io.vertx.core.json.JsonObject;
-import org.junit.Test;
 import org.junit.Assert;
+import org.junit.Test;
 
 public class ConfigTest {
   @Test
@@ -20,6 +21,42 @@ public class ConfigTest {
 
     System.setProperty(varName, "");
     Assert.assertEquals("124", Config.getSysConf(varName, "123", conf));
+  }
+
+  private void assert2(String prop1, String prop2, String json1, String json2, String expected) {
+    final String key1 = "foo-bar92304231";
+    final String key2 = "foo-bar92304232";
+    JsonObject conf = new JsonObject();
+    if (json1 != null) {
+      conf.put(key1, json1);
+    }
+    if (json2 != null) {
+      conf.put(key2, json2);
+    }
+    if (prop1 == null) {
+      System.clearProperty(key1);
+    } else {
+      System.setProperty(key1, prop1);
+    }
+    if (prop2 == null) {
+      System.clearProperty(key2);
+    } else {
+      System.setProperty(key2, prop2);
+    }
+    Assert.assertEquals(expected, Config.getSysConf(key1, key2, "de", conf));
+  }
+
+  @Test
+  public void testConfig2Keys() {
+    assert2(null, null, null, null, "de");
+    assert2("",   "",   null, null, "de");
+    assert2(null, null, null, "j2", "j2");
+    assert2(null, null, "j1", "j2", "j1");
+    assert2(null, "p2", "j1", "j2", "p2");
+    assert2("",   "p2", "j1", "j2", "p2");
+    assert2("p1", "p2", "j1", "j2", "p1");
+    assert2("p1", null, null, null, "p1");
+    assert2("p1", "",   "",   "",   "p1");
   }
 
   @Test
@@ -60,5 +97,5 @@ public class ConfigTest {
     Assert.assertEquals(null, Config.getSysConfBoolean(varName, null, conf));
 
   }
-  
+
 }

--- a/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
@@ -83,7 +83,8 @@ public class MainVerticle extends AbstractVerticle {
     super.init(vertx, context);
 
     JsonObject config = context.config();
-    port = Integer.parseInt(Config.getSysConf("port", "9130", config));
+    String portString = System.getProperty("http.port", "9130");
+    port = Integer.parseInt(Config.getSysConf("port", portString, config));
     String okapiVersion2 = Config.getSysConf("okapiVersion", null, config);
     if (okapiVersion2 != null) {
       okapiVersion = okapiVersion2;

--- a/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
@@ -83,8 +83,7 @@ public class MainVerticle extends AbstractVerticle {
     super.init(vertx, context);
 
     JsonObject config = context.config();
-    String portString = System.getProperty("http.port", "9130");
-    port = Integer.parseInt(Config.getSysConf("port", portString, config));
+    port = Integer.parseInt(Config.getSysConf("http.port", "port", "9130", config));
     String okapiVersion2 = Config.getSysConf("okapiVersion", null, config);
     if (okapiVersion2 != null) {
       okapiVersion = okapiVersion2;

--- a/okapi-test-auth-module/src/main/java/org/folio/okapi/auth/MainVerticle.java
+++ b/okapi-test-auth-module/src/main/java/org/folio/okapi/auth/MainVerticle.java
@@ -29,7 +29,8 @@ public class MainVerticle extends AbstractVerticle {
     Router router = Router.router(vertx);
     Auth auth = new Auth();
 
-    final int port = Integer.parseInt(System.getProperty("port", "9020"));
+    final int port = Integer.parseInt(
+        System.getProperty("http.port", System.getProperty("port", "9020")));
 
     logger.info("Starting auth {} on port {}",
         ManagementFactory.getRuntimeMXBean().getName(), port);

--- a/okapi-test-header-module/src/main/java/org/folio/okapi/header/MainVerticle.java
+++ b/okapi-test-header-module/src/main/java/org/folio/okapi/header/MainVerticle.java
@@ -73,7 +73,8 @@ public class MainVerticle extends AbstractVerticle {
   public void start(Promise<Void> promise) throws IOException {
     Router router = Router.router(vertx);
 
-    final int port = Integer.parseInt(System.getProperty("port", "8080"));
+    final int port = Integer.parseInt(
+        System.getProperty("http.port", System.getProperty("port", "8080")));
     logger.info("Starting okapi-test-header-module {} on port {}",
         ManagementFactory.getRuntimeMXBean().getName(), port);
 

--- a/okapi-test-module/src/main/java/org/folio/okapi/sample/MainVerticle.java
+++ b/okapi-test-module/src/main/java/org/folio/okapi/sample/MainVerticle.java
@@ -223,7 +223,8 @@ public class MainVerticle extends AbstractVerticle {
     if (helloGreeting == null) {
       helloGreeting = "Hello";
     }
-    final int port = Integer.parseInt(System.getProperty("port", "8080"));
+    final int port = Integer.parseInt(
+        System.getProperty("http.port", System.getProperty("port", "8080")));
     String name = ManagementFactory.getRuntimeMXBean().getName();
 
     ModuleVersionReporter m = new ModuleVersionReporter("org.folio.okapi/okapi-test-module");


### PR DESCRIPTION
"http.port" is the command-line option name that all RMB based
modules support:
https://github.com/folio-org/raml-module-builder#command-line-options

For consistency Okapi should also support this.

The guide.md should show "http.port" because most modules
are RMB based and support only this form.