### PR TITLE
Forward Content-Encoding header OKAPI-936

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -857,11 +857,8 @@ public class ProxyService {
           makeTraceHeader(mi, res.statusCode(), pc);
           relayToRequest(res, pc, mi);
           for (String header : FORWARD_HEADERS) {
-            String value = res.getHeader(header);
-            request.headers().remove(header);
-            if (value != null) {
-              request.headers().set(header, value);
-            }
+            MultiMap headers = request.headers();
+            request.headers().set(header, res.getHeader(header));
           }
           storeResponseInfo(pc, mi, res);
           res.pause();

--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -85,6 +85,9 @@ public class ProxyService {
       Comparator.comparing((ModuleInstance a) -> a.getRoutingEntry().getPhaseLevel());
   private final TokenCache tokenCache;
 
+  // request + response HTTP headers that are forwarded in the pipeline
+  private static final String [] FORWARD_HEADERS = new String [] { "Content-Type", "Content-Encoding"};
+
   /**
    * Construct Proxy service.
    * @param vertx Vert.x handle
@@ -823,8 +826,10 @@ public class ProxyService {
                                     List<HttpClientRequest> clientRequestList, ModuleInstance mi) {
 
     RoutingContext ctx = pc.getCtx();
+    HttpServerRequest request = ctx.request();
+    HttpServerResponse response = ctx.response();
     Future<HttpClientRequest> fut = httpClient.request(
-        new RequestOptions().setMethod(ctx.request().method()).setAbsoluteURI(makeUrl(mi, ctx)));
+        new RequestOptions().setMethod(request.method()).setAbsoluteURI(makeUrl(mi, ctx)));
     fut.onFailure(res -> proxyClientFailure(pc, mi, res));
     fut.onSuccess(clientRequest -> {
       final Timer.Sample sample = MetricsHelper.getTimerSample();
@@ -844,21 +849,24 @@ public class ProxyService {
       clientRequest.onFailure(res -> proxyClientFailure(pc, mi, res));
       clientRequest.onSuccess(res -> {
         MetricsHelper.recordHttpClientResponse(sample, pc.getTenant(), res.statusCode(),
-            ctx.request().method().name(), mi);
-        fixupXOkapiToken(mi.getModuleDescriptor(), ctx.request().headers(), res.headers());
+            request.method().name(), mi);
+        fixupXOkapiToken(mi.getModuleDescriptor(), request.headers(), res.headers());
         Iterator<ModuleInstance> newIt = getNewIterator(it, mi, res.statusCode());
         if (res.getHeader(XOkapiHeaders.STOP) == null && newIt.hasNext()) {
           makeTraceHeader(mi, res.statusCode(), pc);
           relayToRequest(res, pc, mi);
-          final String ct = res.getHeader("Content-Type");
-          if (ct != null) {
-            ctx.request().headers().set("Content-Type", ct);
+          for (String header : FORWARD_HEADERS) {
+            String value = res.getHeader(header);
+            request.headers().remove(header);
+            if (value != null) {
+              request.headers().set(header, value);
+            }
           }
           storeResponseInfo(pc, mi, res);
           res.pause();
           proxyR(newIt, pc, res, null, new LinkedList<>());
         } else {
-          relayToResponse(ctx.response(), res, pc);
+          relayToResponse(response, res, pc);
           makeTraceHeader(mi, res.statusCode(), pc);
           proxyResponseImmediate(pc, res, null, new LinkedList<>());
         }

--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -86,7 +86,8 @@ public class ProxyService {
   private final TokenCache tokenCache;
 
   // request + response HTTP headers that are forwarded in the pipeline
-  private static final String [] FORWARD_HEADERS = new String [] { "Content-Type", "Content-Encoding"};
+  private static final String [] FORWARD_HEADERS =
+      new String [] { "Content-Type", "Content-Encoding"};
 
   /**
    * Construct Proxy service.

--- a/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
@@ -4473,6 +4473,7 @@ public class ProxyTest {
         .body("Okapi").post("/echo")
         .then().statusCode(200)
         .header("Content-Type", "text/plain; charset=ISO-8859-1")
+        .header("Content-Encoding", nullValue())
         .body(equalTo("Okapi"));
 
     installReq = new JsonArray().add(new JsonObject().put("id",  "module-pre-1.0.0").put("action", "enable"));


### PR DESCRIPTION
Fix for OKAPI-936 Request logging can send compressed data to the filter. Until now only the Content-Type was forwarded from request-response pipeline.. request-only, headers should NOT forward this as the response is thrown away.