### PR TITLE
OKAPI-875 async tenant init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ nbproject/
 .settings/
 .classpath
 .idea
+*.iml
 okapi.log
 */bin/
 x

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -48,7 +48,6 @@ managing and running microservices.
     * [Instrumentation](#instrumentation)
 * [Module Reference](#module-reference)
     * [Life cycle of a module](#life-cycle-of-a-module)
-    * [Tenant Interface](#tenant-interface)
     * [HTTP](#http)
 
 ## Introduction
@@ -3204,7 +3203,7 @@ In FOLIO two such parameters are widely recognized:
  * `loadReference` with value `true` loads reference data.
  * `loadSample` with value `true` loads sample data.
 
-### Tenant Interface
+#### Tenant Interface definitions
 
 A module supporting 1.1/1.2 of the `_tenant` interface should use this
 snippet in the module descriptor:

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -3206,20 +3206,21 @@ In FOLIO two such parameters are widely recognized:
 
 ### Tenant Interface
 
-A module supporting 1.1/1.2 of the `_tenant` interface should use this snippet
-in the module descriptor:
+A module supporting 1.1/1.2 of the `_tenant` interface should use this
+snippet in the module descriptor:
 
 ```
    "id" : "_tenant",
    "version" : "1.2",
    "interfaceType" : "system",
    "handlers" : [ {
-     "methods" : [ "POST", "DELETE" ],
-     "pathPattern" : "/_/tenant"
-    }, {
-     "methods" : [ "POST" ],
-     "pathPattern" : "/_/tenant/disable"
-    } ]
+       "methods" : [ "POST", "DELETE" ],
+       "pathPattern" : "/_/tenant"
+      }, {
+       "methods" : [ "POST" ],
+       "pathPattern" : "/_/tenant/disable"
+      }
+   ]
 ```
 The corresponding RAML definition:
 [tenant.raml](https://github.com/folio-org/raml/blob/tenant_interface_1_2/ramls/tenant.raml)
@@ -3231,12 +3232,13 @@ Snippet of version 2.0 of the `_tenant` interface:
    "version" : "2.0",
    "interfaceType" : "system",
    "handlers" : [ {
-     "methods" : [ "POST" ],
-     "pathPattern" : "/_/tenant"
-    }, {
-     "methods" : [ "GET", "DELETE" ],
-     "pathPattern" : "/_/tenant/{id}"
-    } ]
+       "methods" : [ "POST" ],
+       "pathPattern" : "/_/tenant"
+      }, {
+       "methods" : [ "GET", "DELETE" ],
+       "pathPattern" : "/_/tenant/{id}"
+      }
+   ]
 ```
 The corresponding RAML definition:
 [tenant.raml](https://github.com/folio-org/raml/blob/raml1.0/ramls/tenant.raml)

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -3001,7 +3001,7 @@ the module, and are no longer used.
 
 For the [specifics](#web-service), see under
 `.../okapi/okapi-core/src/main/raml/raml-util` the files
-`ramls/tenant.raml` and `schemas/moduleInfo.schema`.  The
+`ramls/tenant.raml` and `schemas/tenantAttributes.schema`.  The
 okapi-test-header-module has a very trivial implementation of this,
 and the moduleTest shows a module Descriptor that defines this
 interface.
@@ -3142,9 +3142,19 @@ during the operation.
 
 Add 'loadSample=true` to parameters, to load sample data as well.
 
+If the module supports version 2 of the `_tenant` interface it should return status 201 with
+a `Location` header. This signals that the tenant job has started. Use a GET request on the
+Location path returned to poll for the completion of the tenant job with the
+
+    curl -HX-Okapi-url:http://localhost:8081 -HX-Okapi-Tenant:testlib \
+      -HContent-Type:application/json "-HAccept:*/*" \
+      http://localhost:8081/path
+
+(substitute above path with the Location returned)
+
 #### Upgrading
 
-When a module gets upgraded to a new version, it happens separately
+When a module is upgraded to a new version, it happens separately
 for each tenant.  Some tenants may not wish to upgrade in the middle
 of a busy season, others may want to have everything in the latest
 version. The process starts by Okapi deploying the new version of the
@@ -3157,29 +3167,31 @@ request with path `/_/tenant` if version 1.0 or later of interface
 `_tenant` is provided. With the POST request, a JSON object is passed:
 member `module_from` being the module ID that we are upgrading 'from'
 and member `module_to` being the module ID that we are upgrading
-'to'. Note that thqe Module Descriptor of the target module
+'to'. Note that the Module Descriptor of the target module
 (module_to) is being used for the call.
-
-Upgrading large amounts of data to a newer schema can be slow. We are
-thinking about a way to make it happen asynchronously, but that is not
-even designed yet.  (TODO).
 
 We are using semantic versioning, see [Versioning and
 Dependencies](#versioning-and-dependencies)
 
 #### Disabling
 
-When a module is disabled for a tenant, Okapi makes a POST request
-with path `/_/tenant/disable` if version 1.1 and later of interface
-`_tenant` is provided. With the POST request a JSON object is passed:
-member `module_from` being the module ID that is being disabled.
+For tenant interface 1.1/1.2, when a module is disabled for a tenant, Okapi
+makes a POST request with path `/_/tenant/disable`. The request body is a
+JSON object where property `module_from` is the module ID that is being disabled.
+
+For tenant interface 2.0, when a module is disabled, Okapi
+makes a POST request with path /_/tenant/` with `module_from` being
+the module that is disabled and `module_to` omitted.
 
 #### Purge
 
-When a module is purged for a tenant, it disables the tenant for the
-module but also removes persistent content. A module may implement
-this by providing `_tenant` interface 1.0 and later with a DELETE
-method.
+Purge is like disable, but purges persistent content too for a module.
+
+For tenant interfaces 1.1 and 1.2, this is performed by a DELETE request
+to the module.
+
+For tenant interface 2.0, this is performed exactly like disable, but with
+`purge` property being `true` of the JSON content posted.
 
 #### Tenant Parameters
 
@@ -3188,7 +3200,7 @@ etc.  also load sets of reference data. This can be controlled by
 supplying tenant parameters. These are properties (key-value pairs)
 that are passed to the module when enabled or upgraded. Passing those
 are only performed when tenantParameters is specified for install and
-when the tenant interface is version 1.2.
+when the tenant interface is version 1.2 and later.
 
 In FOLIO two such parameters are widely recognized:
 
@@ -3197,7 +3209,8 @@ In FOLIO two such parameters are widely recognized:
 
 ### Tenant Interface
 
-The full `_tenant` interface version 1.1/1.2 portion:
+A module supporting 1.1/1.2 of the `_tenant` interface should use this snippet
+in the module descriptor:
 
 ```
    "id" : "_tenant",
@@ -3211,6 +3224,25 @@ The full `_tenant` interface version 1.1/1.2 portion:
      "pathPattern" : "/_/tenant/disable"
     } ]
 ```
+The corresponding RAML definition:
+[tenant.raml](https://github.com/folio-org/raml/blob/tenant_interface_1_2/ramls/tenant.raml)
+
+Snippet of version 2.0 of the `_tenant` interface:
+
+```
+   "id" : "_tenant",
+   "version" : "2.0",
+   "interfaceType" : "system",
+   "handlers" : [ {
+     "methods" : [ "POST" ],
+     "pathPattern" : "/_/tenant"
+    }, {
+     "methods" : [ "GET", "DELETE" ],
+     "pathPattern" : "/_/tenant/{id}"
+    } ]
+```
+The corresponding RAML definition:
+[tenant.raml](https://github.com/folio-org/raml/blob/raml1.0/ramls/tenant.raml)
 
 #### Closing down
 

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -3146,8 +3146,8 @@ a
 header. This signals that the tenant job has started. Use a GET request on the
 Location path returned to poll for the completion of the tenant job with the
 
-    curl -HX-Okapi-url:http://localhost:8081 -HX-Okapi-Tenant:testlib \
-      -HContent-Type:application/json "-HAccept:*/*" \
+    curl -H "X-Okapi-url: http://localhost:8081" -H "X-Okapi-Tenant: testlib" \
+      -H "Content-Type: application/json" -H "Accept: */*" \
       http://localhost:8081/_/tenant/6da99bac-457b-499f-89a4-34f4da8e9be8
 
 (substitute above path with the Location returned)

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -2972,7 +2972,7 @@ kind of housekeeping it needs.
 
 For the [specifics](#web-service), see under
 `.../okapi/okapi-core/src/main/raml/raml-util` the files
-`ramls/tenant.raml` and `schemas/moduleInfo.schema`.  The
+`ramls/tenant.raml` and `schemas/tenantAttributes.schema`.  The
 okapi-test-module has a very trivial implementation of this, and the
 moduleTest shows a module Descriptor that defines this interface.
 
@@ -2999,10 +2999,7 @@ then insert those it received in the request. That way it will clean
 up permissions that may have been introduced in some older version of
 the module, and are no longer used.
 
-For the [specifics](#web-service), see under
-`.../okapi/okapi-core/src/main/raml/raml-util` the files
-`ramls/tenant.raml` and `schemas/tenantAttributes.schema`.  The
-okapi-test-header-module has a very trivial implementation of this,
+The okapi-test-header-module has a very trivial implementation of this,
 and the moduleTest shows a module Descriptor that defines this
 interface.
 

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -3139,7 +3139,11 @@ during the operation.
 Add 'loadSample=true` to parameters, to load sample data as well.
 
 If the module supports version 2 of the `_tenant` interface it should return status 201 with
-a `Location` header. This signals that the tenant job has started. Use a GET request on the
+a
+
+    Location: /_/tenant/6da99bac-457b-499f-89a4-34f4da8e9be8
+    
+header. This signals that the tenant job has started. Use a GET request on the
 Location path returned to poll for the completion of the tenant job with the
 
     curl -HX-Okapi-url:http://localhost:8081 -HX-Okapi-Tenant:testlib \

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -3177,8 +3177,8 @@ makes a POST request with path `/_/tenant/disable`. The request body is a
 JSON object where property `module_from` is the module ID that is being disabled.
 
 For tenant interface 2.0, when a module is disabled, Okapi
-makes a POST request with path /_/tenant/` with `module_from` being
-the module that is disabled and `module_to` omitted.
+makes a POST request with path `/_/tenant/` with `module_from` property
+being the module that is disabled and `module_to` omitted.
 
 #### Purge
 

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -3148,7 +3148,7 @@ Location path returned to poll for the completion of the tenant job with the
 
     curl -HX-Okapi-url:http://localhost:8081 -HX-Okapi-Tenant:testlib \
       -HContent-Type:application/json "-HAccept:*/*" \
-      http://localhost:8081/path
+      http://localhost:8081/_/tenant/6da99bac-457b-499f-89a4-34f4da8e9be8
 
 (substitute above path with the Location returned)
 

--- a/okapi-core/src/main/java/org/folio/okapi/bean/InterfaceDescriptor.java
+++ b/okapi-core/src/main/java/org/folio/okapi/bean/InterfaceDescriptor.java
@@ -217,8 +217,8 @@ public class InterfaceDescriptor {
           prefix, version);
     }
 
-    if ("_tenant".equals(this.id) && !"1.0 1.1 1.2".contains(version)) {
-      logger.warn("{} is '{}'. Should be '1.0/1.1/1.2'", prefix, version);
+    if ("_tenant".equals(this.id) && !"1.0 1.1 1.2 2.0".contains(version)) {
+      logger.warn("{} is '{}'. Should be '1.0/1.1/1.2/2.0'", prefix, version);
     }
     if ("_tenantPermissions".equals(this.id) && !"1.0 1.1".contains(version)) {
       logger.warn("{} is '{}'. should be '1.0/1.1'", prefix, version);

--- a/okapi-core/src/main/java/org/folio/okapi/bean/ModuleInstance.java
+++ b/okapi-core/src/main/java/org/folio/okapi/bean/ModuleInstance.java
@@ -14,7 +14,7 @@ public class ModuleInstance {
   private String authToken;
   private String userId;
   private String permissions;
-  private final String path; // The relative URI from the proxy request
+  private String path; // The relative URI from the proxy request
   private final HttpMethod method;
   private final boolean handler;  // is true if handler; false otherwise (filter)
   private boolean withRetry;
@@ -42,6 +42,10 @@ public class ModuleInstance {
     this.method = method;
     this.handler = handler;
     this.withRetry = false;
+  }
+
+  public void substPath(String pattern, String value) {
+    path = path.replace(pattern, value);
   }
 
   public ModuleDescriptor getModuleDescriptor() {

--- a/okapi-core/src/main/java/org/folio/okapi/bean/ModuleInstance.java
+++ b/okapi-core/src/main/java/org/folio/okapi/bean/ModuleInstance.java
@@ -44,8 +44,12 @@ public class ModuleInstance {
     this.withRetry = false;
   }
 
-  public void substPath(String pattern, String value) {
-    path = path.replace(pattern, value);
+  /**
+   * Substitute {id} in path.
+   * @param id identifier
+   */
+  public void substPathId(String id) {
+    path = path.replace("{id}", id);
   }
 
   public ModuleDescriptor getModuleDescriptor() {

--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -1239,10 +1239,7 @@ public class ProxyService {
     if (inst.getUrl() == null) {
       future = discoveryManager.get(inst.getModuleDescriptor().getId())
           .compose(gres -> {
-            DeploymentDescriptor instance = null;
-            if (gres != null) {
-              instance = pickInstance(gres);
-            }
+            DeploymentDescriptor instance = pickInstance(gres);
             if (instance == null) {
               return Future.failedFuture(new OkapiError(ErrorType.USER, messages.getMessage("11100",
                   inst.getModuleDescriptor().getId(), inst.getPath())));

--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -1193,6 +1193,40 @@ public class ProxyService {
         });
   }
 
+  private Future<OkapiClient> doCallSystemInterface2(
+      MultiMap headersIn, String tenantId, String authToken,
+      ModuleInstance inst, String modPerms, String request) {
+
+    Map<String, String> headers = sysReqHeaders(headersIn, tenantId, authToken, inst, modPerms);
+    headers.put(XOkapiHeaders.URL_TO, inst.getUrl());
+    logger.debug("syscall begin {} {}{}", inst.getMethod(), inst.getUrl(), inst.getPath());
+    OkapiClient cli = new OkapiClient(this.httpClient, inst.getUrl(), vertx, headers);
+    String reqId = inst.getPath().replaceFirst("^[/_]*([^/]+).*", "$1");
+    cli.newReqId(reqId); // "tenant" or "tenantpermissions"
+    cli.enableInfoLog();
+    if (inst.isWithRetry()) {
+      cli.setClosedRetry(40000);
+    }
+    final Timer.Sample sample = MetricsHelper.getTimerSample();
+    Promise<OkapiClient> promise = Promise.promise();
+    cli.request(inst.getMethod(), inst.getPath(), request, cres -> {
+      logger.debug("syscall return {} {}{}", inst.getMethod(), inst.getUrl(), inst.getPath());
+      if (cres.failed()) {
+        String msg = messages.getMessage("11101", inst.getMethod(),
+            inst.getModuleDescriptor().getId(), inst.getPath(), cres.cause().getMessage());
+        logger.warn(msg, cres.cause());
+        MetricsHelper.recordHttpClientError(tenantId, inst.getMethod().name(), inst.getPath());
+        promise.fail(new OkapiError(ErrorType.USER, msg));
+        return;
+      }
+      MetricsHelper.recordHttpClientResponse(sample, tenantId, cli.getStatusCode(),
+          inst.getMethod().name(), inst);
+      // Pass response headers - needed for unit test, if nothing else
+      promise.complete(cli);
+    });
+    return promise.future();
+  }
+
   /**
    * Actually make a request to a system interface, like _tenant. Assumes we are
    * operating as the correct tenant.
@@ -1201,45 +1235,24 @@ public class ProxyService {
       MultiMap headersIn, String tenantId, String authToken,
       ModuleInstance inst, String modPerms, String request) {
 
-    return discoveryManager.get(inst.getModuleDescriptor().getId()).compose(gres -> {
-      DeploymentDescriptor instance = null;
-      if (gres != null) {
-        instance = pickInstance(gres);
-      }
-      if (instance == null) {
-        return Future.failedFuture(new OkapiError(ErrorType.USER, messages.getMessage("11100",
-            inst.getModuleDescriptor().getId(), inst.getPath())));
-      }
-      String baseurl = instance.getUrl();
-      Map<String, String> headers = sysReqHeaders(headersIn, tenantId, authToken, inst, modPerms);
-      headers.put(XOkapiHeaders.URL_TO, baseurl);
-      logger.debug("syscall begin {} {}{}", inst.getMethod(), baseurl, inst.getPath());
-      OkapiClient cli = new OkapiClient(this.httpClient, baseurl, vertx, headers);
-      String reqId = inst.getPath().replaceFirst("^[/_]*([^/]+).*", "$1");
-      cli.newReqId(reqId); // "tenant" or "tenantpermissions"
-      cli.enableInfoLog();
-      if (inst.isWithRetry()) {
-        cli.setClosedRetry(40000);
-      }
-      final Timer.Sample sample = MetricsHelper.getTimerSample();
-      Promise<OkapiClient> promise = Promise.promise();
-      cli.request(inst.getMethod(), inst.getPath(), request, cres -> {
-        logger.debug("syscall return {} {}{}", inst.getMethod(), baseurl, inst.getPath());
-        if (cres.failed()) {
-          String msg = messages.getMessage("11101", inst.getMethod(),
-              inst.getModuleDescriptor().getId(), inst.getPath(), cres.cause().getMessage());
-          logger.warn(msg, cres.cause());
-          MetricsHelper.recordHttpClientError(tenantId, inst.getMethod().name(), inst.getPath());
-          promise.fail(new OkapiError(ErrorType.USER, msg));
-          return;
-        }
-        MetricsHelper.recordHttpClientResponse(sample, tenantId, cli.getStatusCode(),
-            inst.getMethod().name(), inst);
-        // Pass response headers - needed for unit test, if nothing else
-        promise.complete(cli);
-      });
-      return promise.future();
-    });
+    Future<Void> future = Future.succeededFuture();
+    if (inst.getUrl() == null) {
+      future = discoveryManager.get(inst.getModuleDescriptor().getId())
+          .compose(gres -> {
+            DeploymentDescriptor instance = null;
+            if (gres != null) {
+              instance = pickInstance(gres);
+            }
+            if (instance == null) {
+              return Future.failedFuture(new OkapiError(ErrorType.USER, messages.getMessage("11100",
+                  inst.getModuleDescriptor().getId(), inst.getPath())));
+            }
+            inst.setUrl(instance.getUrl());
+            return Future.succeededFuture();
+          });
+    }
+    return future.compose(x -> doCallSystemInterface2(
+        headersIn, tenantId, authToken, inst, modPerms, request));
   }
 
   /**

--- a/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
@@ -317,14 +317,15 @@ public class TenantManager implements Liveness {
                 (mdTo != null ? mdTo.getId() : mdFrom.getId()));
             return Future.succeededFuture();
           }
-          String req = HttpMethod.DELETE.equals(instance.get(0).getMethod()) ?
-              "" : jo.encodePrettily();
-          return proxyService.callSystemInterface(tenant, instance.get(0), req, pc).compose(cres -> {
-            pc.passOkapiTraceHeaders(cres);
-            // TODO:
-            String location = cres.getRespHeaders().get("Location");
-            return Future.succeededFuture();
-          });
+          String req = HttpMethod.DELETE.equals(instance.get(0).getMethod())
+              ? "" : jo.encodePrettily();
+          return proxyService.callSystemInterface(tenant, instance.get(0), req, pc)
+              .compose(cres -> {
+                pc.passOkapiTraceHeaders(cres);
+                // TODO:
+                String location = cres.getRespHeaders().get("Location");
+                return Future.succeededFuture();
+              });
         });
   }
 
@@ -751,7 +752,8 @@ public class TenantManager implements Liveness {
       List<RoutingEntry> res = pi.getAllRoutingEntries();
       for (RoutingEntry re : res) {
         if (re.match(null, method)) {
-          return new ModuleInstance(md, re, re.getStaticPath(), HttpMethod.valueOf(method), true).withRetry();
+          return new ModuleInstance(md, re, re.getStaticPath(), HttpMethod.valueOf(method), true)
+              .withRetry();
         }
       }
     }

--- a/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
@@ -724,7 +724,7 @@ public class TenantManager implements Liveness {
             putTenantParameters(jo, tenantParameters);
             instance = getTenantInstanceForInterfacev2(pi, mdFrom, mdTo, "POST");
             if (instance == null) {
-              return Future.succeededFuture(null);
+              return Future.succeededFuture(instances);
             }
             instances.add(instance);
             instance = getTenantInstanceForInterfacev2(pi, mdFrom, mdTo, "GET");

--- a/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
@@ -48,7 +48,7 @@ import org.folio.okapi.util.TenantInstallOptions;
 @java.lang.SuppressWarnings({"squid:S1192"}) // String literals should not be duplicated
 public class TenantManager implements Liveness {
 
-  private final Logger logger = OkapiLogger.get();
+  private static final Logger logger = OkapiLogger.get();
   private ModuleManager moduleManager;
   private ProxyService proxyService = null;
   private DiscoveryManager discoveryManager;
@@ -58,7 +58,7 @@ public class TenantManager implements Liveness {
   private LockedTypedMap2<InstallJob> jobs = new LockedTypedMap2<>(InstallJob.class);
   private static final String EVENT_NAME = "timer";
   private Set<String> timers = new HashSet<>();
-  private Messages messages = Messages.getInstance();
+  private static Messages messages = Messages.getInstance();
   private Vertx vertx;
   private Map<String, ModuleCache> enabledModulesCache = new HashMap<>();
   // tenants with new permission module (_tenantPermissions version 1.1 or later)
@@ -316,7 +316,7 @@ public class TenantManager implements Liveness {
                 (mdTo != null ? mdTo.getId() : mdFrom.getId()));
             return Future.succeededFuture();
           }
-          final String req = purge ? "" : jo.encodePrettily();
+          String req = HttpMethod.DELETE.equals(instance.getMethod()) ? "" : jo.encodePrettily();
           return proxyService.callSystemInterface(tenant, instance, req, pc).compose(cres -> {
             pc.passOkapiTraceHeaders(cres);
             // We can ignore the result, the call went well.
@@ -642,7 +642,7 @@ public class TenantManager implements Liveness {
    * @param purge true if purging (DELETE)
    * @return future (result==null if no tenant interface!)
    */
-  private Future<ModuleInstance> getTenantInstanceForModule(
+  static Future<ModuleInstance> getTenantInstanceForModule(
       ModuleDescriptor mdFrom,
       ModuleDescriptor mdTo, JsonObject jo, String tenantParameters, boolean purge) {
 
@@ -691,7 +691,7 @@ public class TenantManager implements Liveness {
     return Future.succeededFuture(null);
   }
 
-  private void putTenantParameters(JsonObject jo, String tenantParameters) {
+  private static void putTenantParameters(JsonObject jo, String tenantParameters) {
     if (tenantParameters != null) {
       JsonArray ja = new JsonArray();
       for (String p : tenantParameters.split(",")) {
@@ -709,7 +709,7 @@ public class TenantManager implements Liveness {
     }
   }
 
-  private ModuleInstance getTenantInstanceForInterface(
+  private static ModuleInstance getTenantInstanceForInterface(
       InterfaceDescriptor pi, ModuleDescriptor mdFrom,
       ModuleDescriptor mdTo, String method) {
 

--- a/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
@@ -287,8 +287,8 @@ public class TenantManager implements Liveness {
     );
   }
 
-  private void waitTenantInit(Tenant tenant, ModuleInstance getInstance, ModuleInstance deleteInstance,
-                              ProxyContext pc,
+  private void waitTenantInit(Tenant tenant, ModuleInstance getInstance,
+                              ModuleInstance deleteInstance, ProxyContext pc,
                               Promise<Void> promise, int waitMs) {
     proxyService.callSystemInterface(tenant, getInstance, "", pc)
         .onFailure(x -> promise.fail(x))
@@ -356,16 +356,16 @@ public class TenantManager implements Liveness {
                   return Future.failedFuture(messages.getMessage("10407",
                       postInstance.getMethod().name(), postInstance.getPath()));
                 }
-                ModuleInstance getInstance = instances.get(1);
-                ModuleInstance deleteInstance = instances.get(2);
                 JsonObject obj = new JsonObject(cres.getResponsebody());
                 String id = obj.getString("id");
                 if (id == null) {
                   return Future.failedFuture(messages.getMessage("10408",
                       postInstance.getMethod().name(), postInstance.getPath()));
                 }
+                ModuleInstance getInstance = instances.get(1);
                 getInstance.setUrl(postInstance.getUrl()); // same URL for POST & GET
                 getInstance.substPath("{id}", id);
+                ModuleInstance deleteInstance = instances.get(2);
                 deleteInstance.setUrl(postInstance.getUrl()); // same URL for POST & DELETE
                 deleteInstance.substPath("{id}", id);
                 Promise<Void> promise = Promise.promise();

--- a/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
@@ -380,10 +380,10 @@ public class TenantManager implements Liveness {
                 }
                 ModuleInstance getInstance = instances.get(1);
                 getInstance.setUrl(postInstance.getUrl()); // same URL for POST & GET
-                getInstance.substPath("{id}", id);
+                getInstance.substPathId(id);
                 ModuleInstance deleteInstance = instances.get(2);
                 deleteInstance.setUrl(postInstance.getUrl()); // same URL for POST & DELETE
-                deleteInstance.substPath("{id}", id);
+                deleteInstance.substPathId(id);
                 Promise<Void> promise = Promise.promise();
                 waitTenantInit(tenant, getInstance, deleteInstance, pc, promise, TENANT_INIT_DELAY);
                 return promise.future();

--- a/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
@@ -369,12 +369,8 @@ public class TenantManager implements Liveness {
                   return Future.succeededFuture(); // sync v1 / v2
                 }
                 if (instances.size() != 3) {
-                  logger.warn("Module does not provide _tenant interface 2.0, "
-                      + "but yet seems to be.");
-                  instances.add(new ModuleInstance(md, null,
-                      "/_/tenant/{id}", HttpMethod.GET, true));
-                  instances.add(new ModuleInstance(md, null,
-                      "/_/tenant/{id}", HttpMethod.DELETE, true));
+                  return Future.failedFuture(messages.getMessage(
+                      "10409", postInstance.getMethod(), postInstance.getPath()));
                 }
                 JsonObject obj = new JsonObject(cres.getResponsebody());
                 String id = obj.getString("id");

--- a/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
@@ -294,16 +294,18 @@ public class TenantManager implements Liveness {
         .onFailure(x -> promise.fail(x))
         .onSuccess(cli -> {
           JsonObject obj = new JsonObject(cli.getResponsebody());
-          String error = obj.getString("error");
-          if (error != null) {
-            promise.fail(error);
-            return;
-          }
           Boolean complete = obj.getBoolean("complete");
           if (Boolean.TRUE.equals(complete)) {
             proxyService.callSystemInterface(tenant, deleteInstance, "", pc)
                 .onFailure(x -> promise.fail(x))
-                .onSuccess(x -> promise.complete());
+                .onSuccess(x -> {
+                  String error = obj.getString("error");
+                  if (error != null) {
+                    promise.fail(error);
+                    return;
+                  }
+                  promise.complete();
+                });
             return;
           }
           vertx.setTimer(waitMs, x ->

--- a/okapi-core/src/main/resources/infra-messages/Messages_en.properties
+++ b/okapi-core/src/main/resources/infra-messages/Messages_en.properties
@@ -38,7 +38,7 @@
 10404=Not implemented: action = {0}
 10405=Missing action for id {0}
 10406=Cannot delete non-completed job {0}
-10407=No Location returned for {0} {1}
+10407=Missing DELETE method for tenant interface version 2
 10408=Missing id property in JSON response for {0} {1}
 
 

--- a/okapi-core/src/main/resources/infra-messages/Messages_en.properties
+++ b/okapi-core/src/main/resources/infra-messages/Messages_en.properties
@@ -38,6 +38,9 @@
 10404=Not implemented: action = {0}
 10405=Missing action for id {0}
 10406=Cannot delete non-completed job {0}
+10407=No Location returned for {0} {1}
+10408=Missing id property in JSON response for {0} {1}
+
 
 #OkapiClient
 10500=OkapiClient: No OkapiUrl specified

--- a/okapi-core/src/main/resources/infra-messages/Messages_en.properties
+++ b/okapi-core/src/main/resources/infra-messages/Messages_en.properties
@@ -40,7 +40,7 @@
 10406=Cannot delete non-completed job {0}
 10407=Missing DELETE method for tenant interface version 2
 10408=Missing id property in JSON response for {0} {1}
-
+10409=Unexpected Location header in response for {0} {1}
 
 #OkapiClient
 10500=OkapiClient: No OkapiUrl specified

--- a/okapi-core/src/test/java/org/folio/okapi/InstallTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/InstallTest.java
@@ -1136,8 +1136,7 @@ public class InstallTest {
         + "  \"modules\" : [ {" + LS
         + "    \"id\" : \"async-init-1.0.0\"," + LS
         + "    \"action\" : \"enable\"," + LS
-        + "    \"message\" : \"Unsupported interface _tenant: 2.0\"," + LS
-        + "    \"stage\" : \"invoke\"" + LS
+        + "    \"stage\" : \"done\"" + LS
         + "  } ]" + LS
         + "}", job.encodePrettily());
 

--- a/okapi-core/src/test/java/org/folio/okapi/InstallTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/InstallTest.java
@@ -1184,7 +1184,8 @@ public class InstallTest {
         + "  \"modules\" : [ {" + LS
         + "    \"id\" : \"" + module + "\"," + LS
         + "    \"action\" : \"enable\"," + LS
-        + "    \"stage\" : \"done\"" + LS
+        + "    \"message\" : \"Unexpected Location header in response for POST /_/tenant\"," + LS
+        + "    \"stage\" : \"invoke\"" + LS
         + "  } ]" + LS
         + "}", job.encodePrettily());
 

--- a/okapi-core/src/test/java/org/folio/okapi/InstallTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/InstallTest.java
@@ -1084,7 +1084,21 @@ public class InstallTest {
         + "  \"provides\" : [ {" + LS
         + "    \"id\" : \"_tenant\"," + LS
         + "    \"version\" : \"2.0\"," + LS
-        + "    \"interfaceType\" : \"system\"" + LS
+        + "    \"interfaceType\" : \"system\"," + LS
+
+
+        + "    \"handlers\" : [ {" + LS
+        + "      \"methods\" : [ \"POST\" ]," + LS
+        + "      \"pathPattern\" : \"/_/tenant\"," + LS
+        + "      \"permissionsRequired\" : [ ]" + LS
+        + "    }, {" + LS
+        + "      \"methods\" : [ \"GET\" ]," + LS
+        + "      \"pathPattern\" : \"/_/tenant/{id}\"," + LS
+        + "      \"permissionsRequired\" : [ ]" + LS
+        + "    } ]" + LS
+
+
+
         + "  } ]," + LS
         + "  \"requires\" : [ ]" + LS
         + "}";

--- a/okapi-core/src/test/java/org/folio/okapi/InstallTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/InstallTest.java
@@ -1107,9 +1107,7 @@ public class InstallTest {
     Assert.assertTrue(
         "raml: " + c.getLastReport().toString(),
         c.getLastReport().isEmpty());
-    String locationInstallJob = r.getHeader("Location");
-
-    String path = locationInstallJob.substring(locationInstallJob.indexOf("/_/"));
+    String path = r.getHeader("Location");
 
     return pollCompleteStrip(context, path);
   }

--- a/okapi-core/src/test/java/org/folio/okapi/InstallTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/InstallTest.java
@@ -1071,9 +1071,9 @@ public class InstallTest {
     timerServer.close();
   }
 
-  void createAsyncInitModule(TestContext context) {
+  void createAsyncInitModule(TestContext context, String module) {
     final String docModule = "{" + LS
-        + "  \"id\" : \"async-init-1.0.0\"," + LS
+        + "  \"id\" : \"" + module + "\"," + LS
         + "  \"name\" : \"async tenant init module\"," + LS
         + "  \"provides\" : [ {" + LS
         + "    \"id\" : \"_tenant\"," + LS
@@ -1098,10 +1098,10 @@ public class InstallTest {
         .body(docModule).post("/_/proxy/modules").then().statusCode(201);
   }
 
-  void deployAsyncInitModule(TestContext context, int port) {
+  void deployAsyncInitModule(TestContext context, String module, int port) {
     final String nodeDoc1 = "{" + LS
         + "  \"instId\" : \"localhost-" + Integer.toString(port) + "\"," + LS
-        + "  \"srvcId\" : \"async-init-1.0.0\"," + LS
+        + "  \"srvcId\" : \"" + module + "\"," + LS
         + "  \"url\" : \"http://localhost:" + Integer.toString(port) + "\"" + LS
         + "}";
 
@@ -1121,7 +1121,7 @@ public class InstallTest {
         .post("/_/proxy/tenants/" + tenant + "/install?async=true")
         .then().statusCode(201)
         .body(equalTo("[ {" + LS
-            + "  \"id\" : \"async-init-1.0.0\"," + LS
+            + "  \"id\" : \""+ module + "\"," + LS
             + "  \"action\" : \"enable\"" + LS
             + "} ]"))
         .extract().response();
@@ -1138,20 +1138,21 @@ public class InstallTest {
   @Test
   public void installTenantInitVersion2OK(TestContext context) {
     final String okapiTenant = "roskilde";
+    final String module = "async-init-1.0.0";
 
     createTenant(context, okapiTenant);
-    createAsyncInitModule(context);
-    ModuleTenantInitAsync tModule = new ModuleTenantInitAsync(vertx, "async-init-1.0.0", portTimer);
+    createAsyncInitModule(context, module);
+    ModuleTenantInitAsync tModule = new ModuleTenantInitAsync(vertx, module, portTimer);
 
     tModule.start().onComplete(context.asyncAssertSuccess());
 
-    deployAsyncInitModule(context, portTimer);
+    deployAsyncInitModule(context, module, portTimer);
 
-    JsonObject job = enableAndWait(context, okapiTenant, "async-init-1.0.0");
+    JsonObject job = enableAndWait(context, okapiTenant, module);
     context.assertEquals("{" + LS
         + "  \"complete\" : true," + LS
         + "  \"modules\" : [ {" + LS
-        + "    \"id\" : \"async-init-1.0.0\"," + LS
+        + "    \"id\" : \"" + module + "\"," + LS
         + "    \"action\" : \"enable\"," + LS
         + "    \"stage\" : \"done\"" + LS
         + "  } ]" + LS
@@ -1163,21 +1164,22 @@ public class InstallTest {
   @Test
   public void installTenantInitVersion2NoLocation(TestContext context) {
     final String okapiTenant = "roskilde";
+    String module = "async-init-1.0.0";
 
     createTenant(context, okapiTenant);
-    createAsyncInitModule(context);
-    ModuleTenantInitAsync tModule = new ModuleTenantInitAsync(vertx, "async-init-1.0.0", portTimer);
+    createAsyncInitModule(context, module);
+    ModuleTenantInitAsync tModule = new ModuleTenantInitAsync(vertx, module, portTimer);
 
     tModule.setOmitLocationInResponse(true);
     tModule.start().onComplete(context.asyncAssertSuccess());
 
-    deployAsyncInitModule(context, portTimer);
+    deployAsyncInitModule(context, module, portTimer);
 
-    JsonObject job = enableAndWait(context, okapiTenant, "async-init-1.0.0");
+    JsonObject job = enableAndWait(context, okapiTenant, module);
     context.assertEquals("{" + LS
         + "  \"complete\" : true," + LS
         + "  \"modules\" : [ {" + LS
-        + "    \"id\" : \"async-init-1.0.0\"," + LS
+        + "    \"id\" : \"" + module + "\"," + LS
         + "    \"action\" : \"enable\"," + LS
         + "    \"message\" : \"No Location returned for POST /_/tenant\"," + LS
         + "    \"stage\" : \"invoke\"" + LS
@@ -1190,21 +1192,22 @@ public class InstallTest {
   @Test
   public void installTenantInitVersion2NoId(TestContext context) {
     final String okapiTenant = "roskilde";
+    final String module ="async-init-1.0.0";
 
     createTenant(context, okapiTenant);
-    createAsyncInitModule(context);
-    ModuleTenantInitAsync tModule = new ModuleTenantInitAsync(vertx, "async-init-1.0.0", portTimer);
+    createAsyncInitModule(context, module);
+    ModuleTenantInitAsync tModule = new ModuleTenantInitAsync(vertx, module, portTimer);
 
     tModule.setOmitIdInResponse(true);
     tModule.start().onComplete(context.asyncAssertSuccess());
 
-    deployAsyncInitModule(context, portTimer);
+    deployAsyncInitModule(context, module, portTimer);
 
-    JsonObject job = enableAndWait(context, okapiTenant, "async-init-1.0.0");
+    JsonObject job = enableAndWait(context, okapiTenant, module);
     context.assertEquals("{" + LS
         + "  \"complete\" : true," + LS
         + "  \"modules\" : [ {" + LS
-        + "    \"id\" : \"async-init-1.0.0\"," + LS
+        + "    \"id\" : \"" + module + "\"," + LS
         + "    \"action\" : \"enable\"," + LS
         + "    \"message\" : \"Missing id property in JSON response for POST /_/tenant\"," + LS
         + "    \"stage\" : \"invoke\"" + LS
@@ -1217,17 +1220,18 @@ public class InstallTest {
   @Test
   public void installTenantInitVersion2BadJson(TestContext context) {
     final String okapiTenant = "roskilde";
+    final String module = "async-init-1.0.0";
 
     createTenant(context, okapiTenant);
-    createAsyncInitModule(context);
-    ModuleTenantInitAsync tModule = new ModuleTenantInitAsync(vertx, "async-init-1.0.0", portTimer);
+    createAsyncInitModule(context, module);
+    ModuleTenantInitAsync tModule = new ModuleTenantInitAsync(vertx, module, portTimer);
 
     tModule.setBadJsonResponse(true);
     tModule.start().onComplete(context.asyncAssertSuccess());
 
-    deployAsyncInitModule(context, portTimer);
+    deployAsyncInitModule(context, module, portTimer);
 
-    JsonObject job = enableAndWait(context, okapiTenant, "async-init-1.0.0");
+    JsonObject job = enableAndWait(context, okapiTenant, module);
     context.assertTrue(job.getJsonArray("modules").getJsonObject(0).
         getString("message").startsWith("Failed to decode:Unexpected close marker"));
 
@@ -1237,17 +1241,18 @@ public class InstallTest {
   @Test
   public void installTenantInitVersion2Status400(TestContext context) {
     final String okapiTenant = "roskilde";
+    final String module = "async-init-1.0.0";
 
     createTenant(context, okapiTenant);
-    createAsyncInitModule(context);
-    ModuleTenantInitAsync tModule = new ModuleTenantInitAsync(vertx, "async-init-1.0.0", portTimer);
+    createAsyncInitModule(context, module);
+    ModuleTenantInitAsync tModule = new ModuleTenantInitAsync(vertx, module, portTimer);
 
     tModule.setGetStatusResponse(400);
     tModule.start().onComplete(context.asyncAssertSuccess());
 
-    deployAsyncInitModule(context, portTimer);
+    deployAsyncInitModule(context, module, portTimer);
 
-    JsonObject job = enableAndWait(context, okapiTenant, "async-init-1.0.0");
+    JsonObject job = enableAndWait(context, okapiTenant, module);
     context.assertTrue(job.getJsonArray("modules").getJsonObject(0).
         getString("message").contains("failed with 400:"), job.encodePrettily());
 
@@ -1257,17 +1262,18 @@ public class InstallTest {
   @Test
   public void installTenantInitVersion2JobError(TestContext context) {
     final String okapiTenant = "roskilde";
+    final String module = "async-init-1.0.0";
 
     createTenant(context, okapiTenant);
-    createAsyncInitModule(context);
-    ModuleTenantInitAsync tModule = new ModuleTenantInitAsync(vertx, "async-init-1.0.0", portTimer);
+    createAsyncInitModule(context, module);
+    ModuleTenantInitAsync tModule = new ModuleTenantInitAsync(vertx, module, portTimer);
 
     tModule.setErrorMessage("foo bar error");
     tModule.start().onComplete(context.asyncAssertSuccess());
 
-    deployAsyncInitModule(context, portTimer);
+    deployAsyncInitModule(context, module, portTimer);
 
-    JsonObject job = enableAndWait(context, okapiTenant, "async-init-1.0.0");
+    JsonObject job = enableAndWait(context, okapiTenant, module);
     context.assertTrue(job.getJsonArray("modules").getJsonObject(0).
         getString("message").contains("foo bar error"), job.encodePrettily());
 

--- a/okapi-core/src/test/java/org/folio/okapi/InstallTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/InstallTest.java
@@ -1084,7 +1084,7 @@ public class InstallTest {
         + "      \"pathPattern\" : \"/_/tenant\"," + LS
         + "      \"permissionsRequired\" : [ ]" + LS
         + "    }, {" + LS
-        + "      \"methods\" : [ \"GET\" ]," + LS
+        + "      \"methods\" : [ \"GET\", \"DELETE\" ]," + LS
         + "      \"pathPattern\" : \"/_/tenant/{id}\"," + LS
         + "      \"permissionsRequired\" : [ ]" + LS
         + "    } ]" + LS

--- a/okapi-core/src/test/java/org/folio/okapi/InstallTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/InstallTest.java
@@ -1234,4 +1234,44 @@ public class InstallTest {
     tModule.stop().onComplete(context.asyncAssertSuccess());
   }
 
+  @Test
+  public void installTenantInitVersion2Status400(TestContext context) {
+    final String okapiTenant = "roskilde";
+
+    createTenant(context, okapiTenant);
+    createAsyncInitModule(context);
+    ModuleTenantInitAsync tModule = new ModuleTenantInitAsync(vertx, "async-init-1.0.0", portTimer);
+
+    tModule.setGetStatusResponse(400);
+    tModule.start().onComplete(context.asyncAssertSuccess());
+
+    deployAsyncInitModule(context, portTimer);
+
+    JsonObject job = enableAndWait(context, okapiTenant, "async-init-1.0.0");
+    context.assertTrue(job.getJsonArray("modules").getJsonObject(0).
+        getString("message").contains("failed with 400:"), job.encodePrettily());
+
+    tModule.stop().onComplete(context.asyncAssertSuccess());
+  }
+
+  @Test
+  public void installTenantInitVersion2JobError(TestContext context) {
+    final String okapiTenant = "roskilde";
+
+    createTenant(context, okapiTenant);
+    createAsyncInitModule(context);
+    ModuleTenantInitAsync tModule = new ModuleTenantInitAsync(vertx, "async-init-1.0.0", portTimer);
+
+    tModule.setErrorMessage("foo bar error");
+    tModule.start().onComplete(context.asyncAssertSuccess());
+
+    deployAsyncInitModule(context, portTimer);
+
+    JsonObject job = enableAndWait(context, okapiTenant, "async-init-1.0.0");
+    context.assertTrue(job.getJsonArray("modules").getJsonObject(0).
+        getString("message").contains("foo bar error"), job.encodePrettily());
+
+    tModule.stop().onComplete(context.asyncAssertSuccess());
+  }
+
 }

--- a/okapi-core/src/test/java/org/folio/okapi/InstallTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/InstallTest.java
@@ -1247,14 +1247,20 @@ public class InstallTest {
     createAsyncInitModule(context, module);
     ModuleTenantInitAsync tModule = new ModuleTenantInitAsync(vertx, module, portModule);
 
-    tModule.setErrorMessage("foo bar error");
+    tModule.setErrorMessage("foo bar error", null);
     tModule.start().onComplete(context.asyncAssertSuccess());
 
     deployAsyncInitModule(context, module, portModule);
 
     JsonObject job = enableAndWait(context, okapiTenant, module);
-    context.assertTrue(job.getJsonArray("modules").getJsonObject(0).
-        getString("message").contains("foo bar error"), job.encodePrettily());
+    context.assertEquals("foo bar error", job.getJsonArray("modules")
+        .getJsonObject(0).getString("message"));
+
+    tModule.setErrorMessage("foo bar error", new JsonArray().add("msg1").add("msg2"));
+
+    job = enableAndWait(context, okapiTenant, module);
+    context.assertEquals("foo bar error\nmsg1\nmsg2", job.getJsonArray("modules")
+        .getJsonObject(0).getString("message"));
 
     tModule.stop().onComplete(context.asyncAssertSuccess());
   }

--- a/okapi-core/src/test/java/org/folio/okapi/managers/TenantManagerTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/managers/TenantManagerTest.java
@@ -274,7 +274,41 @@ public class TenantManagerTest extends TestBase {
   }
 
   @Test
-  public void testTenantInterfaces(TestContext context) {
+  public void testTenantInterfacesNoSystem(TestContext context) {
+    ModuleDescriptor md = new ModuleDescriptor();
+    JsonObject obj = new JsonObject();
+    md.setId("module-1.0.0");
+    TenantManager.getTenantInstanceForModule(null, md, obj, null, false)
+        .onComplete(context.asyncAssertSuccess(instances -> context.assertTrue(instances.isEmpty())));
+
+    InterfaceDescriptor interfaceDescriptor = new InterfaceDescriptor();
+    interfaceDescriptor.setId("_tenant");
+    interfaceDescriptor.setVersion("1.0");
+    InterfaceDescriptor[] provides = new InterfaceDescriptor[1];
+    provides[0] = interfaceDescriptor;
+    md.setProvides(provides);
+
+    TenantManager.getTenantInstanceForModule(null, md, obj, null, false)
+        .onComplete(context.asyncAssertSuccess(instances -> context.assertEquals(1, instances.size())));
+
+    TenantManager.getTenantInstanceForModule(null, md, obj, null, true)
+        .onComplete(context.asyncAssertSuccess(instances -> context.assertTrue(instances.isEmpty())));
+
+    interfaceDescriptor.setVersion("1.1");
+    TenantManager.getTenantInstanceForModule(null, md, obj, null, false)
+        .onComplete(context.asyncAssertSuccess(instances -> context.assertTrue(instances.isEmpty())));
+
+    interfaceDescriptor.setVersion("1.2");
+    TenantManager.getTenantInstanceForModule(null, md, obj, null, false)
+        .onComplete(context.asyncAssertSuccess(instances -> context.assertTrue(instances.isEmpty())));
+
+    interfaceDescriptor.setVersion("2.0");
+    TenantManager.getTenantInstanceForModule(null, md, obj, null, false)
+        .onComplete(context.asyncAssertSuccess(instances -> context.assertTrue(instances.isEmpty())));
+  }
+
+  @Test
+  public void testTenantInterfacesv1(TestContext context) {
     ModuleDescriptor md = new ModuleDescriptor();
     JsonObject obj = new JsonObject();
     md.setId("module-1.0.0");
@@ -285,7 +319,7 @@ public class TenantManagerTest extends TestBase {
     interfaceDescriptor.setId("_tenant");
     interfaceDescriptor.setVersion("1.0");
     interfaceDescriptor.setInterfaceType("system");
-    InterfaceDescriptor [] provides = new InterfaceDescriptor[1];
+    InterfaceDescriptor[] provides = new InterfaceDescriptor[1];
     provides[0] = interfaceDescriptor;
     md.setProvides(provides);
 
@@ -317,17 +351,17 @@ public class TenantManagerTest extends TestBase {
     List<RoutingEntry> handlers = new LinkedList<>();
     RoutingEntry tmp = new RoutingEntry();
     tmp.setPathPattern("/_/tenantpath");
-    tmp.setMethods(new String [] { "GET", "POST"});
+    tmp.setMethods(new String[]{"GET", "POST"});
     handlers.add(tmp);
 
     tmp = new RoutingEntry();
     tmp.setPathPattern("/_/tenant/disable");
-    tmp.setMethods(new String [] { "POST"});
+    tmp.setMethods(new String[]{"POST"});
     handlers.add(tmp);
 
     tmp = new RoutingEntry();
     tmp.setPathPattern("/_/tenantpurge");
-    tmp.setMethods(new String [] { "DELETE"});
+    tmp.setMethods(new String[]{"DELETE"});
     handlers.add(tmp);
 
     interfaceDescriptor.setHandlers(handlers.toArray(new RoutingEntry[0]));
@@ -349,7 +383,7 @@ public class TenantManagerTest extends TestBase {
         }));
     TenantManager.getTenantInstanceForModule(md, null, obj, null, true)
         .onComplete(context.asyncAssertSuccess(instances -> {
-          context.assertFalse(instances.isEmpty());
+          context.assertEquals(1, instances.size());
           ModuleInstance instance = instances.get(0);
           context.assertEquals(HttpMethod.DELETE, instance.getMethod());
           context.assertEquals("/_/tenantpurge", instance.getPath());
@@ -358,7 +392,7 @@ public class TenantManagerTest extends TestBase {
     interfaceDescriptor.setVersion("1.2");
     TenantManager.getTenantInstanceForModule(null, md, obj, null, false)
         .onComplete(context.asyncAssertSuccess(instances -> {
-          context.assertFalse(instances.isEmpty());
+          context.assertEquals(1, instances.size());
           ModuleInstance instance = instances.get(0);
           context.assertEquals(HttpMethod.POST, instance.getMethod());
           context.assertEquals("/_/tenantpath", instance.getPath());
@@ -367,37 +401,84 @@ public class TenantManagerTest extends TestBase {
     interfaceDescriptor.setVersion("2.0");
     TenantManager.getTenantInstanceForModule(null, md, obj, null, false)
         .onComplete(context.asyncAssertSuccess(instances -> {
-          context.assertEquals(2, instances.size());
+          context.assertEquals(1, instances.size());
+          ModuleInstance instance = instances.get(0);
+          context.assertEquals(HttpMethod.POST, instance.getMethod());
+          context.assertEquals("/_/tenantpath", instance.getPath());
+        }));
+
+  }
+
+  @Test
+  public void testTenantInterfacesv2(TestContext context) {
+    ModuleDescriptor md = new ModuleDescriptor();
+    JsonObject obj = new JsonObject();
+    md.setId("module-1.0.0");
+    TenantManager.getTenantInstanceForModule(null, md, obj, null, false)
+        .onComplete(context.asyncAssertSuccess(instances -> context.assertTrue(instances.isEmpty())));
+
+    InterfaceDescriptor interfaceDescriptor = new InterfaceDescriptor();
+    interfaceDescriptor.setId("_tenant");
+    interfaceDescriptor.setVersion("2.0");
+    interfaceDescriptor.setInterfaceType("system");
+    InterfaceDescriptor[] provides = new InterfaceDescriptor[1];
+    provides[0] = interfaceDescriptor;
+    md.setProvides(provides);
+
+    List<RoutingEntry> handlers = new LinkedList<>();
+    RoutingEntry tmp = new RoutingEntry();
+    tmp.setPathPattern("/_/tenantpath");
+    tmp.setMethods(new String [] { "POST"});
+    handlers.add(tmp);
+
+    tmp = new RoutingEntry();
+    tmp.setPathPattern("/_/tenantpath/{id}");
+    tmp.setMethods(new String [] { "DELETE", "GET"});
+    handlers.add(tmp);
+
+    interfaceDescriptor.setHandlers(handlers.toArray(new RoutingEntry[0]));
+
+    TenantManager.getTenantInstanceForModule(null, md, obj, null, false)
+        .onComplete(context.asyncAssertSuccess(instances -> {
+          context.assertEquals(3, instances.size());
           ModuleInstance instance = instances.get(0);
           context.assertEquals(HttpMethod.POST, instance.getMethod());
           context.assertEquals("/_/tenantpath", instance.getPath());
           instance = instances.get(1);
           context.assertEquals(HttpMethod.GET, instance.getMethod());
-          context.assertEquals("/_/tenantpath", instance.getPath());
+          context.assertEquals("/_/tenantpath/{id}", instance.getPath());
+          instance = instances.get(2);
+          context.assertEquals(HttpMethod.DELETE, instance.getMethod());
+          context.assertEquals("/_/tenantpath/{id}", instance.getPath());
           context.assertFalse(obj.getBoolean("purge"));
         }));
     TenantManager.getTenantInstanceForModule(md, null, obj, null, false)
         .onComplete(context.asyncAssertSuccess(instances -> {
-          context.assertEquals(2, instances.size());
+          context.assertEquals(3, instances.size());
           ModuleInstance instance = instances.get(0);
           context.assertEquals(HttpMethod.POST, instance.getMethod());
           context.assertEquals("/_/tenantpath", instance.getPath());
           instance = instances.get(1);
           context.assertEquals(HttpMethod.GET, instance.getMethod());
-          context.assertEquals("/_/tenantpath", instance.getPath());
+          context.assertEquals("/_/tenantpath/{id}", instance.getPath());
+          instance = instances.get(2);
+          context.assertEquals(HttpMethod.DELETE, instance.getMethod());
+          context.assertEquals("/_/tenantpath/{id}", instance.getPath());
           context.assertFalse(obj.getBoolean("purge"));
         }));
     TenantManager.getTenantInstanceForModule(md, null, obj, null, true)
         .onComplete(context.asyncAssertSuccess(instances -> {
-          context.assertEquals(2, instances.size());
+          context.assertEquals(3, instances.size());
           ModuleInstance instance = instances.get(0);
           context.assertEquals(HttpMethod.POST, instance.getMethod());
           context.assertEquals("/_/tenantpath", instance.getPath());
           instance = instances.get(1);
           context.assertEquals(HttpMethod.GET, instance.getMethod());
-          context.assertEquals("/_/tenantpath", instance.getPath());
+          context.assertEquals("/_/tenantpath/{id}", instance.getPath());
+          instance = instances.get(2);
+          context.assertEquals(HttpMethod.DELETE, instance.getMethod());
+          context.assertEquals("/_/tenantpath/{id}", instance.getPath());
           context.assertTrue(obj.getBoolean("purge"));
         }));
-
   }
 }

--- a/okapi-core/src/test/java/org/folio/okapi/managers/TenantManagerTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/managers/TenantManagerTest.java
@@ -278,7 +278,7 @@ public class TenantManagerTest extends TestBase {
     ModuleDescriptor md = new ModuleDescriptor();
     JsonObject obj = new JsonObject();
     md.setId("module-1.0.0");
-    TenantManager.getTenantInstanceForModule(null, md, obj, null, false)
+    TenantManager.getTenantInstanceForModule(md,null, md, obj, null, false)
         .onComplete(context.asyncAssertSuccess(instances -> context.assertTrue(instances.isEmpty())));
 
     InterfaceDescriptor interfaceDescriptor = new InterfaceDescriptor();
@@ -288,22 +288,22 @@ public class TenantManagerTest extends TestBase {
     provides[0] = interfaceDescriptor;
     md.setProvides(provides);
 
-    TenantManager.getTenantInstanceForModule(null, md, obj, null, false)
+    TenantManager.getTenantInstanceForModule(md,null, md, obj, null, false)
         .onComplete(context.asyncAssertSuccess(instances -> context.assertEquals(1, instances.size())));
 
-    TenantManager.getTenantInstanceForModule(null, md, obj, null, true)
+    TenantManager.getTenantInstanceForModule(md,null, md, obj, null, true)
         .onComplete(context.asyncAssertSuccess(instances -> context.assertTrue(instances.isEmpty())));
 
     interfaceDescriptor.setVersion("1.1");
-    TenantManager.getTenantInstanceForModule(null, md, obj, null, false)
+    TenantManager.getTenantInstanceForModule(md,null, md, obj, null, false)
         .onComplete(context.asyncAssertSuccess(instances -> context.assertTrue(instances.isEmpty())));
 
     interfaceDescriptor.setVersion("1.2");
-    TenantManager.getTenantInstanceForModule(null, md, obj, null, false)
+    TenantManager.getTenantInstanceForModule(md, null, md, obj, null, false)
         .onComplete(context.asyncAssertSuccess(instances -> context.assertTrue(instances.isEmpty())));
 
     interfaceDescriptor.setVersion("2.0");
-    TenantManager.getTenantInstanceForModule(null, md, obj, null, false)
+    TenantManager.getTenantInstanceForModule(md,null, md, obj, null, false)
         .onComplete(context.asyncAssertSuccess(instances -> context.assertTrue(instances.isEmpty())));
   }
 
@@ -312,7 +312,7 @@ public class TenantManagerTest extends TestBase {
     ModuleDescriptor md = new ModuleDescriptor();
     JsonObject obj = new JsonObject();
     md.setId("module-1.0.0");
-    TenantManager.getTenantInstanceForModule(null, md, obj, null, false)
+    TenantManager.getTenantInstanceForModule(md,null, md, obj, null, false)
         .onComplete(context.asyncAssertSuccess(instances -> context.assertTrue(instances.isEmpty())));
 
     InterfaceDescriptor interfaceDescriptor = new InterfaceDescriptor();
@@ -323,7 +323,7 @@ public class TenantManagerTest extends TestBase {
     provides[0] = interfaceDescriptor;
     md.setProvides(provides);
 
-    TenantManager.getTenantInstanceForModule(null, md, obj, null, false)
+    TenantManager.getTenantInstanceForModule(md,null, md, obj, null, false)
         .onComplete(context.asyncAssertSuccess(instances -> {
           context.assertFalse(instances.isEmpty());
           ModuleInstance instance = instances.get(0);
@@ -332,20 +332,20 @@ public class TenantManagerTest extends TestBase {
         }));
 
     interfaceDescriptor.setVersion("1.1");
-    TenantManager.getTenantInstanceForModule(null, md, obj, null, false)
+    TenantManager.getTenantInstanceForModule(md,null, md, obj, null, false)
         .onComplete(context.asyncAssertSuccess(instances -> context.assertTrue(instances.isEmpty())));
 
     interfaceDescriptor.setVersion("1.2");
-    TenantManager.getTenantInstanceForModule(null, md, obj, null, false)
+    TenantManager.getTenantInstanceForModule(md,null, md, obj, null, false)
         .onComplete(context.asyncAssertSuccess(instances -> context.assertTrue(instances.isEmpty())));
 
     interfaceDescriptor.setVersion("1.3");
-    TenantManager.getTenantInstanceForModule(null, md, obj, null, false)
+    TenantManager.getTenantInstanceForModule(md,null, md, obj, null, false)
         .onComplete(context.asyncAssertFailure(cause -> context.assertEquals("Unsupported interface _tenant: 1.3",
             cause.getMessage())));
 
     interfaceDescriptor.setVersion("2.0");
-    TenantManager.getTenantInstanceForModule(null, md, obj, null, false)
+    TenantManager.getTenantInstanceForModule(md,null, md, obj, null, false)
         .onComplete(context.asyncAssertSuccess(instances -> context.assertTrue(instances.isEmpty())));
 
     List<RoutingEntry> handlers = new LinkedList<>();
@@ -367,21 +367,21 @@ public class TenantManagerTest extends TestBase {
     interfaceDescriptor.setHandlers(handlers.toArray(new RoutingEntry[0]));
 
     interfaceDescriptor.setVersion("1.1");
-    TenantManager.getTenantInstanceForModule(null, md, obj, null, false)
+    TenantManager.getTenantInstanceForModule(md,null, md, obj, null, false)
         .onComplete(context.asyncAssertSuccess(instances -> {
           context.assertFalse(instances.isEmpty());
           ModuleInstance instance = instances.get(0);
           context.assertEquals(HttpMethod.POST, instance.getMethod());
           context.assertEquals("/_/tenantpath", instance.getPath());
         }));
-    TenantManager.getTenantInstanceForModule(md, null, obj, null, false)
+    TenantManager.getTenantInstanceForModule(md, md, null, obj, null, false)
         .onComplete(context.asyncAssertSuccess(instances -> {
           context.assertFalse(instances.isEmpty());
           ModuleInstance instance = instances.get(0);
           context.assertEquals(HttpMethod.POST, instance.getMethod());
           context.assertEquals("/_/tenant/disable", instance.getPath());
         }));
-    TenantManager.getTenantInstanceForModule(md, null, obj, null, true)
+    TenantManager.getTenantInstanceForModule(md, md, null, obj, null, true)
         .onComplete(context.asyncAssertSuccess(instances -> {
           context.assertEquals(1, instances.size());
           ModuleInstance instance = instances.get(0);
@@ -390,7 +390,7 @@ public class TenantManagerTest extends TestBase {
         }));
 
     interfaceDescriptor.setVersion("1.2");
-    TenantManager.getTenantInstanceForModule(null, md, obj, null, false)
+    TenantManager.getTenantInstanceForModule(md,null, md, obj, null, false)
         .onComplete(context.asyncAssertSuccess(instances -> {
           context.assertEquals(1, instances.size());
           ModuleInstance instance = instances.get(0);
@@ -399,7 +399,7 @@ public class TenantManagerTest extends TestBase {
         }));
 
     interfaceDescriptor.setVersion("2.0");
-    TenantManager.getTenantInstanceForModule(null, md, obj, null, false)
+    TenantManager.getTenantInstanceForModule(md,null, md, obj, null, false)
         .onComplete(context.asyncAssertSuccess(instances -> {
           context.assertEquals(1, instances.size());
           ModuleInstance instance = instances.get(0);
@@ -414,7 +414,7 @@ public class TenantManagerTest extends TestBase {
     ModuleDescriptor md = new ModuleDescriptor();
     JsonObject obj = new JsonObject();
     md.setId("module-1.0.0");
-    TenantManager.getTenantInstanceForModule(null, md, obj, null, false)
+    TenantManager.getTenantInstanceForModule(md,null, md, obj, null, false)
         .onComplete(context.asyncAssertSuccess(instances -> context.assertTrue(instances.isEmpty())));
 
     InterfaceDescriptor interfaceDescriptor = new InterfaceDescriptor();
@@ -438,7 +438,7 @@ public class TenantManagerTest extends TestBase {
 
     interfaceDescriptor.setHandlers(handlers.toArray(new RoutingEntry[0]));
 
-    TenantManager.getTenantInstanceForModule(null, md, obj, null, false)
+    TenantManager.getTenantInstanceForModule(md,null, md, obj, null, false)
         .onComplete(context.asyncAssertSuccess(instances -> {
           context.assertEquals(3, instances.size());
           ModuleInstance instance = instances.get(0);
@@ -452,7 +452,7 @@ public class TenantManagerTest extends TestBase {
           context.assertEquals("/_/tenantpath/{id}", instance.getPath());
           context.assertFalse(obj.getBoolean("purge"));
         }));
-    TenantManager.getTenantInstanceForModule(md, null, obj, null, false)
+    TenantManager.getTenantInstanceForModule(md, md, null, obj, null, false)
         .onComplete(context.asyncAssertSuccess(instances -> {
           context.assertEquals(3, instances.size());
           ModuleInstance instance = instances.get(0);
@@ -466,7 +466,7 @@ public class TenantManagerTest extends TestBase {
           context.assertEquals("/_/tenantpath/{id}", instance.getPath());
           context.assertFalse(obj.getBoolean("purge"));
         }));
-    TenantManager.getTenantInstanceForModule(md, null, obj, null, true)
+    TenantManager.getTenantInstanceForModule(md, md, null, obj, null, true)
         .onComplete(context.asyncAssertSuccess(instances -> {
           context.assertEquals(3, instances.size());
           ModuleInstance instance = instances.get(0);

--- a/okapi-core/src/test/java/org/folio/okapi/managers/TenantManagerTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/managers/TenantManagerTest.java
@@ -1,12 +1,22 @@
 package org.folio.okapi.managers;
 
+import com.github.dockerjava.api.model.Link;
 import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+import java.util.LinkedList;
 import java.util.List;
 
 import org.apache.logging.log4j.Logger;
+import org.folio.okapi.bean.InterfaceDescriptor;
+import org.folio.okapi.bean.ModuleDescriptor;
+import org.folio.okapi.bean.ModuleInstance;
+import org.folio.okapi.bean.RoutingEntry;
 import org.folio.okapi.bean.Tenant;
 import org.folio.okapi.bean.TenantDescriptor;
 import org.folio.okapi.common.ErrorType;
@@ -261,5 +271,133 @@ public class TenantManagerTest extends TestBase {
       tenantManager.handleTimer("tenantId", "moduleId", 0);
       Assert.assertEquals(0, tenantManager.getTimers().size());
     }));
+  }
+
+  @Test
+  public void testTenantInterfaces(TestContext context) {
+    ModuleDescriptor md = new ModuleDescriptor();
+    JsonObject obj = new JsonObject();
+    md.setId("module-1.0.0");
+    TenantManager.getTenantInstanceForModule(null, md, obj, null, false)
+        .onComplete(context.asyncAssertSuccess(instances -> context.assertTrue(instances.isEmpty())));
+
+    InterfaceDescriptor interfaceDescriptor = new InterfaceDescriptor();
+    interfaceDescriptor.setId("_tenant");
+    interfaceDescriptor.setVersion("1.0");
+    interfaceDescriptor.setInterfaceType("system");
+    InterfaceDescriptor [] provides = new InterfaceDescriptor[1];
+    provides[0] = interfaceDescriptor;
+    md.setProvides(provides);
+
+    TenantManager.getTenantInstanceForModule(null, md, obj, null, false)
+        .onComplete(context.asyncAssertSuccess(instances -> {
+          context.assertFalse(instances.isEmpty());
+          ModuleInstance instance = instances.get(0);
+          context.assertEquals(HttpMethod.POST, instance.getMethod());
+          context.assertEquals("/_/tenant", instance.getPath());
+        }));
+
+    interfaceDescriptor.setVersion("1.1");
+    TenantManager.getTenantInstanceForModule(null, md, obj, null, false)
+        .onComplete(context.asyncAssertSuccess(instances -> context.assertTrue(instances.isEmpty())));
+
+    interfaceDescriptor.setVersion("1.2");
+    TenantManager.getTenantInstanceForModule(null, md, obj, null, false)
+        .onComplete(context.asyncAssertSuccess(instances -> context.assertTrue(instances.isEmpty())));
+
+    interfaceDescriptor.setVersion("1.3");
+    TenantManager.getTenantInstanceForModule(null, md, obj, null, false)
+        .onComplete(context.asyncAssertFailure(cause -> context.assertEquals("Unsupported interface _tenant: 1.3",
+            cause.getMessage())));
+
+    interfaceDescriptor.setVersion("2.0");
+    TenantManager.getTenantInstanceForModule(null, md, obj, null, false)
+        .onComplete(context.asyncAssertSuccess(instances -> context.assertTrue(instances.isEmpty())));
+
+    List<RoutingEntry> handlers = new LinkedList<>();
+    RoutingEntry tmp = new RoutingEntry();
+    tmp.setPathPattern("/_/tenantpath");
+    tmp.setMethods(new String [] { "GET", "POST"});
+    handlers.add(tmp);
+
+    tmp = new RoutingEntry();
+    tmp.setPathPattern("/_/tenant/disable");
+    tmp.setMethods(new String [] { "POST"});
+    handlers.add(tmp);
+
+    tmp = new RoutingEntry();
+    tmp.setPathPattern("/_/tenantpurge");
+    tmp.setMethods(new String [] { "DELETE"});
+    handlers.add(tmp);
+
+    interfaceDescriptor.setHandlers(handlers.toArray(new RoutingEntry[0]));
+
+    interfaceDescriptor.setVersion("1.1");
+    TenantManager.getTenantInstanceForModule(null, md, obj, null, false)
+        .onComplete(context.asyncAssertSuccess(instances -> {
+          context.assertFalse(instances.isEmpty());
+          ModuleInstance instance = instances.get(0);
+          context.assertEquals(HttpMethod.POST, instance.getMethod());
+          context.assertEquals("/_/tenantpath", instance.getPath());
+        }));
+    TenantManager.getTenantInstanceForModule(md, null, obj, null, false)
+        .onComplete(context.asyncAssertSuccess(instances -> {
+          context.assertFalse(instances.isEmpty());
+          ModuleInstance instance = instances.get(0);
+          context.assertEquals(HttpMethod.POST, instance.getMethod());
+          context.assertEquals("/_/tenant/disable", instance.getPath());
+        }));
+    TenantManager.getTenantInstanceForModule(md, null, obj, null, true)
+        .onComplete(context.asyncAssertSuccess(instances -> {
+          context.assertFalse(instances.isEmpty());
+          ModuleInstance instance = instances.get(0);
+          context.assertEquals(HttpMethod.DELETE, instance.getMethod());
+          context.assertEquals("/_/tenantpurge", instance.getPath());
+        }));
+
+    interfaceDescriptor.setVersion("1.2");
+    TenantManager.getTenantInstanceForModule(null, md, obj, null, false)
+        .onComplete(context.asyncAssertSuccess(instances -> {
+          context.assertFalse(instances.isEmpty());
+          ModuleInstance instance = instances.get(0);
+          context.assertEquals(HttpMethod.POST, instance.getMethod());
+          context.assertEquals("/_/tenantpath", instance.getPath());
+        }));
+
+    interfaceDescriptor.setVersion("2.0");
+    TenantManager.getTenantInstanceForModule(null, md, obj, null, false)
+        .onComplete(context.asyncAssertSuccess(instances -> {
+          context.assertEquals(2, instances.size());
+          ModuleInstance instance = instances.get(0);
+          context.assertEquals(HttpMethod.POST, instance.getMethod());
+          context.assertEquals("/_/tenantpath", instance.getPath());
+          instance = instances.get(1);
+          context.assertEquals(HttpMethod.GET, instance.getMethod());
+          context.assertEquals("/_/tenantpath", instance.getPath());
+          context.assertFalse(obj.getBoolean("purge"));
+        }));
+    TenantManager.getTenantInstanceForModule(md, null, obj, null, false)
+        .onComplete(context.asyncAssertSuccess(instances -> {
+          context.assertEquals(2, instances.size());
+          ModuleInstance instance = instances.get(0);
+          context.assertEquals(HttpMethod.POST, instance.getMethod());
+          context.assertEquals("/_/tenantpath", instance.getPath());
+          instance = instances.get(1);
+          context.assertEquals(HttpMethod.GET, instance.getMethod());
+          context.assertEquals("/_/tenantpath", instance.getPath());
+          context.assertFalse(obj.getBoolean("purge"));
+        }));
+    TenantManager.getTenantInstanceForModule(md, null, obj, null, true)
+        .onComplete(context.asyncAssertSuccess(instances -> {
+          context.assertEquals(2, instances.size());
+          ModuleInstance instance = instances.get(0);
+          context.assertEquals(HttpMethod.POST, instance.getMethod());
+          context.assertEquals("/_/tenantpath", instance.getPath());
+          instance = instances.get(1);
+          context.assertEquals(HttpMethod.GET, instance.getMethod());
+          context.assertEquals("/_/tenantpath", instance.getPath());
+          context.assertTrue(obj.getBoolean("purge"));
+        }));
+
   }
 }

--- a/okapi-core/src/test/java/org/folio/okapi/testutil/ModuleTenantInitAsync.java
+++ b/okapi-core/src/test/java/org/folio/okapi/testutil/ModuleTenantInitAsync.java
@@ -1,0 +1,84 @@
+package org.folio.okapi.testutil;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.BodyHandler;
+import org.apache.logging.log4j.Logger;
+import org.folio.okapi.common.OkapiLogger;
+import org.folio.okapi.service.ModuleHandle;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class ModuleTenantInitAsync implements ModuleHandle {
+  private static final Logger logger = OkapiLogger.get();
+
+  private Vertx vertx;
+  private String id;
+  private int port;
+  private HttpServer server;
+  private Map<String,JsonObject> jobs = new HashMap<>();
+
+  ModuleTenantInitAsync(Vertx vertx, String id, int port) {
+    this.vertx = vertx;
+    this.id = id;
+    this.port = port;
+  }
+
+  public void tenantHandler(RoutingContext ctx) {
+    HttpMethod method = ctx.request().method();
+    String path = ctx.request().path();
+    if (HttpMethod.POST.equals(method) && path.equals("/_/tenant")) {
+      JsonObject obj = ctx.getBodyAsJson();
+      obj.put("complete", Boolean.FALSE);
+      String id = UUID.randomUUID().toString();
+      obj.put("id", id);
+      jobs.put(id, obj);
+      ctx.response().setStatusCode(201);
+      ctx.response().putHeader("Content-Type", "application/json");
+      ctx.response().putHeader("Location", "/_/tenant/" + id);
+      ctx.end(obj.encodePrettily());
+    } else if (HttpMethod.GET.equals(method) && path.startsWith("/_/tenant/")) {
+      String id = path.substring(path.lastIndexOf('/') + 1);
+      JsonObject obj = jobs.get(id);
+      if (obj == null) {
+        ctx.response().setStatusCode(404);
+        ctx.response().putHeader("Content-Type", "text/plain");
+        ctx.response().end("Not found " + id);
+        return;
+      }
+      obj.put("complete", Boolean.TRUE);
+      ctx.response().setStatusCode(200);
+      ctx.response().putHeader("Content-Type", "application/json");
+      ctx.response().putHeader("Location", "/_/tenant/" + id);
+      ctx.end(obj.encodePrettily());
+    } else {
+      ctx.response().setStatusCode(404);
+      ctx.response().putHeader("Content-Type", "text/plain");
+      ctx.response().end("Not found");
+    }
+  }
+  @Override
+  public Future<Void> start() {
+    Router router = Router.router(vertx);
+
+    router.post("/_/tenant").handler(BodyHandler.create());
+    router.post("/_/tenant").handler(this::tenantHandler);
+
+    return vertx.createHttpServer()
+        .requestHandler(router)
+        .listen(port)
+        .compose(x -> { server = x; return Future.succeededFuture(); });
+  }
+
+  @Override
+  public Future<Void> stop() {
+    return server == null ? Future.succeededFuture() : server.close();
+  }
+}

--- a/okapi-core/src/test/java/org/folio/okapi/testutil/ModuleTenantInitAsync.java
+++ b/okapi-core/src/test/java/org/folio/okapi/testutil/ModuleTenantInitAsync.java
@@ -4,6 +4,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServer;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
@@ -28,6 +29,7 @@ public class ModuleTenantInitAsync implements ModuleHandle {
   private boolean badJsonResponse = false;
   private int getStatusCode = 200;
   private String errorMessage;
+  private JsonArray additionalMessages;
   private Map<String,JsonObject> jobs = new HashMap<>();
 
   public ModuleTenantInitAsync(Vertx vertx, String id, int port) {
@@ -52,8 +54,9 @@ public class ModuleTenantInitAsync implements ModuleHandle {
     this.getStatusCode = statusCode;
   }
 
-  public void setErrorMessage(String errorMessage) {
+  public void setErrorMessage(String errorMessage, JsonArray additionalMessages) {
     this.errorMessage = errorMessage;
+    this.additionalMessages = additionalMessages;
   }
 
   public void tenantPost(RoutingContext ctx) {
@@ -97,6 +100,9 @@ public class ModuleTenantInitAsync implements ModuleHandle {
     obj.put("complete", count <= 0);
     if (errorMessage != null) {
       obj.put("error", errorMessage);
+    }
+    if (additionalMessages != null) {
+      obj.put("messages", additionalMessages);
     }
     ctx.response().setStatusCode(getStatusCode);
     ctx.response().putHeader("Content-Type", "application/json");

--- a/okapi-core/src/test/java/org/folio/okapi/testutil/ModuleTenantInitAsync.java
+++ b/okapi-core/src/test/java/org/folio/okapi/testutil/ModuleTenantInitAsync.java
@@ -25,7 +25,7 @@ public class ModuleTenantInitAsync implements ModuleHandle {
   private HttpServer server;
   private Map<String,JsonObject> jobs = new HashMap<>();
 
-  ModuleTenantInitAsync(Vertx vertx, String id, int port) {
+  public ModuleTenantInitAsync(Vertx vertx, String id, int port) {
     this.vertx = vertx;
     this.id = id;
     this.port = port;

--- a/okapi-core/src/test/java/org/folio/okapi/testutil/ModuleTenantInitAsync.java
+++ b/okapi-core/src/test/java/org/folio/okapi/testutil/ModuleTenantInitAsync.java
@@ -26,6 +26,8 @@ public class ModuleTenantInitAsync implements ModuleHandle {
   private boolean omitIdInResponse = false;
   private boolean omitLocationInResponse = false;
   private boolean badJsonResponse = false;
+  private int getStatusCode = 200;
+  private String errorMessage;
   private Map<String,JsonObject> jobs = new HashMap<>();
 
   public ModuleTenantInitAsync(Vertx vertx, String id, int port) {
@@ -44,6 +46,14 @@ public class ModuleTenantInitAsync implements ModuleHandle {
 
   public void setBadJsonResponse(boolean badJsonResponse) {
     this.badJsonResponse = badJsonResponse;
+  }
+
+  public void setGetStatusResponse(int statusCode) {
+    this.getStatusCode = statusCode;
+  }
+
+  public void setErrorMessage(String errorMessage) {
+    this.errorMessage = errorMessage;
   }
 
   public void tenantPost(RoutingContext ctx) {
@@ -85,7 +95,10 @@ public class ModuleTenantInitAsync implements ModuleHandle {
     int count = obj.getInteger("count");
     obj.put("count", --count);
     obj.put("complete", count <= 0);
-    ctx.response().setStatusCode(200);
+    if (errorMessage != null) {
+      obj.put("error", errorMessage);
+    }
+    ctx.response().setStatusCode(getStatusCode);
     ctx.response().putHeader("Content-Type", "application/json");
     ctx.response().putHeader("Location", "/_/tenant/" + id);
     ctx.end(obj.encodePrettily());


### PR DESCRIPTION
PR for version 2.0 of _tenant interface. It will use the paths for POST, GET, DELETE as provided. Version 1 series are still supported and there should be no changes in behavior. So this is a pure extension as far as Okapi is concerned.

Should a Location be returned at runtime and yet the module descriptor only says 1.1 / 1.2 , Okapi issues an error. That is maintainer forgets https://github.com/folio-org/raml-module-builder/pull/815 .