### PR TITLE
Update Okapi systemd service configuration

### DIFF
--- a/debian/okapi.service
+++ b/debian/okapi.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=FOLIO Okapi service
 Wants=postgresql.service docker.service
-After=network-online.target postgresql.service docker.service
+After=network-online.target postgresql.service docker.service multi-user.target
 
 
 [Service]
@@ -37,4 +37,3 @@ LimitNOFILE=65536
 
 [Install]
 WantedBy=multi-user.target
-


### PR DESCRIPTION
OKAPI-966. This change is required because of a change to the docker-ce Debian package.