### PR TITLE
OKAPI-947 - Updates for static permissions migration

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/bean/Permission.java
+++ b/okapi-core/src/main/java/org/folio/okapi/bean/Permission.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Permission {
   private String permissionName;
+  private String[] renamedFrom;
   private String displayName;
   private String description;
   private String[] subPermissions;
@@ -50,4 +51,11 @@ public class Permission {
     this.visible = visible;
   }
 
+  public String[] getRenamedFrom() {
+    return renamedFrom;
+  }
+
+  public void setRenamedFrom(String[] renamedFrom) {
+    this.renamedFrom = renamedFrom;
+  }
 }

--- a/okapi-core/src/main/java/org/folio/okapi/bean/PermissionList.java
+++ b/okapi-core/src/main/java/org/folio/okapi/bean/PermissionList.java
@@ -1,55 +1,5 @@
 package org.folio.okapi.bean;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-
-/**
- * List of Permissions (and permission sets) belonging to a module. Used as a
- * parameter in the system request to initialize the permission module when a
- * module is being enabled for a tenant.
- */
-public class PermissionList {
-  private final String moduleToId; // The module that owns these permissions.
-  private final Permission[] permsTo;
-
-  @JsonInclude(JsonInclude.Include.NON_NULL)
-  private final String moduleFromId;
-  @JsonInclude(JsonInclude.Include.NON_NULL)
-  private final Permission[] permsFrom;
-
-  public PermissionList(String moduleToId, Permission[] permsTo) {
-    this(moduleToId, null, permsTo, null);
-  }
-
-  /**
-   * Constructor taking all four args.
-   *
-   * @param moduleToId the module/version we're moving to
-   * @param moduleFromId the current module/version
-   * @param permsTo the permissions we're moving to
-   * @param permsFrom the current permissions
-   */
-  public PermissionList(String moduleToId, String moduleFromId, Permission[] permsTo,
-      Permission[] permsFrom) {
-    this.moduleToId = moduleToId;
-    this.moduleFromId = moduleFromId;
-    this.permsTo = permsTo;
-    this.permsFrom = permsFrom;
-  }
-
-  public String getModuleToId() {
-    return moduleToId;
-  }
-
-  public Permission[] getPermsTo() {
-    return permsTo;
-  }
-
-  public String getModuleFromId() {
-    return moduleFromId;
-  }
-
-  public Permission[] getPermsFrom() {
-    return permsFrom;
-  }
+public interface PermissionList {
 
 }

--- a/okapi-core/src/main/java/org/folio/okapi/bean/PermissionList.java
+++ b/okapi-core/src/main/java/org/folio/okapi/bean/PermissionList.java
@@ -1,25 +1,55 @@
 package org.folio.okapi.bean;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 /**
  * List of Permissions (and permission sets) belonging to a module. Used as a
  * parameter in the system request to initialize the permission module when a
  * module is being enabled for a tenant.
  */
 public class PermissionList {
-  private String moduleId; // The module that owns these permissions.
-  private Permission[] perms;
+  private final String moduleToId; // The module that owns these permissions.
+  private final Permission[] permsTo;
 
-  public PermissionList(String moduleId, Permission[] perms) {
-    this.moduleId = moduleId;
-    this.perms = perms;
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private final String moduleFromId;
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private final Permission[] permsFrom;
+
+  public PermissionList(String moduleToId, Permission[] permsTo) {
+    this(moduleToId, null, permsTo, null);
   }
 
-  public String getModuleId() {
-    return moduleId;
+  /**
+   * Constructor taking all four args.
+   *
+   * @param moduleToId the module/version we're moving to
+   * @param moduleFromId the current module/version
+   * @param permsTo the permissions we're moving to
+   * @param permsFrom the current permissions
+   */
+  public PermissionList(String moduleToId, String moduleFromId, Permission[] permsTo,
+      Permission[] permsFrom) {
+    this.moduleToId = moduleToId;
+    this.moduleFromId = moduleFromId;
+    this.permsTo = permsTo;
+    this.permsFrom = permsFrom;
   }
 
-  public Permission[] getPerms() {
-    return perms;
+  public String getModuleToId() {
+    return moduleToId;
+  }
+
+  public Permission[] getPermsTo() {
+    return permsTo;
+  }
+
+  public String getModuleFromId() {
+    return moduleFromId;
+  }
+
+  public Permission[] getPermsFrom() {
+    return permsFrom;
   }
 
 }

--- a/okapi-core/src/main/java/org/folio/okapi/bean/PermissionListV1.java
+++ b/okapi-core/src/main/java/org/folio/okapi/bean/PermissionListV1.java
@@ -1,0 +1,25 @@
+package org.folio.okapi.bean;
+
+/**
+ * List of Permissions (and permission sets) belonging to a module. Used as a
+ * parameter in the system request to initialize the permission module when a
+ * module is being enabled for a tenant.
+ */
+public class PermissionListV1 implements PermissionList {
+  private final String moduleId; // The module that owns these permissions.
+  private final Permission[] perms;
+
+  public PermissionListV1(String moduleId, Permission[] perms) {
+    this.moduleId = moduleId;
+    this.perms = perms;
+  }
+
+  public String getModuleId() {
+    return moduleId;
+  }
+
+  public Permission[] getPerms() {
+    return perms;
+  }
+
+}

--- a/okapi-core/src/main/java/org/folio/okapi/bean/PermissionListV2.java
+++ b/okapi-core/src/main/java/org/folio/okapi/bean/PermissionListV2.java
@@ -1,0 +1,55 @@
+package org.folio.okapi.bean;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * List of Permissions (and permission sets) belonging to a module. Used as a
+ * parameter in the system request to initialize the permission module when a
+ * module is being enabled for a tenant.
+ */
+public class PermissionListV2 implements PermissionList {
+  private final String moduleToId; // The module that owns these permissions.
+  private final Permission[] permsTo;
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private final String moduleFromId;
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private final Permission[] permsFrom;
+
+  public PermissionListV2(String moduleToId, Permission[] permsTo) {
+    this(moduleToId, null, permsTo, null);
+  }
+
+  /**
+   * Constructor taking all four args.
+   *
+   * @param moduleToId the module/version we're moving to
+   * @param moduleFromId the current module/version
+   * @param permsTo the permissions we're moving to
+   * @param permsFrom the current permissions
+   */
+  public PermissionListV2(String moduleToId, String moduleFromId, Permission[] permsTo,
+      Permission[] permsFrom) {
+    this.moduleToId = moduleToId;
+    this.moduleFromId = moduleFromId;
+    this.permsTo = permsTo;
+    this.permsFrom = permsFrom;
+  }
+
+  public String getModuleToId() {
+    return moduleToId;
+  }
+
+  public Permission[] getPermsTo() {
+    return permsTo;
+  }
+
+  public String getModuleFromId() {
+    return moduleFromId;
+  }
+
+  public Permission[] getPermsFrom() {
+    return permsFrom;
+  }
+
+}

--- a/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
@@ -659,13 +659,16 @@ public class TenantManager implements Liveness {
       pl = new PermissionListV1(moduleTo, mdTo.getPermissionSets());
     } else if (permIntVer.equals("1.1")) {
       pl = new PermissionListV1(moduleTo, mdTo.getExpandedPermissionSets());
-    } else {
+    } else if (permIntVer.equals("2.0")) {
       if (mdFrom != null) {
         pl = new PermissionListV2(moduleTo, mdFrom.getId(), mdTo.getExpandedPermissionSets(),
             mdFrom.getExpandedPermissionSets());
       } else {
         pl = new PermissionListV2(moduleTo, mdTo.getExpandedPermissionSets());
       }
+    } else {
+      return Future.failedFuture(new OkapiError(ErrorType.ANY,
+          "Unknown version of _tenantPermissions interface in use " + permIntVer + "."));
     }
     String pljson = Json.encodePrettily(pl);
     logger.debug("tenantPerms Req: {}", pljson);

--- a/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
@@ -667,7 +667,7 @@ public class TenantManager implements Liveness {
         pl = new PermissionListV2(moduleTo, mdTo.getExpandedPermissionSets());
       }
     } else {
-      return Future.failedFuture(new OkapiError(ErrorType.ANY,
+      return Future.failedFuture(new OkapiError(ErrorType.USER,
           "Unknown version of _tenantPermissions interface in use " + permIntVer + "."));
     }
     String pljson = Json.encodePrettily(pl);

--- a/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
@@ -24,6 +24,8 @@ import org.folio.okapi.bean.InterfaceDescriptor;
 import org.folio.okapi.bean.ModuleDescriptor;
 import org.folio.okapi.bean.ModuleInstance;
 import org.folio.okapi.bean.PermissionList;
+import org.folio.okapi.bean.PermissionListV1;
+import org.folio.okapi.bean.PermissionListV2;
 import org.folio.okapi.bean.RoutingEntry;
 import org.folio.okapi.bean.Tenant;
 import org.folio.okapi.bean.TenantDescriptor;
@@ -652,13 +654,18 @@ public class TenantManager implements Liveness {
     String moduleTo = mdTo.getId();
     PermissionList pl = null;
     InterfaceDescriptor permInt = permsModule.getSystemInterface("_tenantPermissions");
-    if (permInt.getVersion().equals("1.0")) {
-      pl = new PermissionList(moduleTo, mdTo.getPermissionSets());
-    } else if (mdFrom != null) {
-      pl = new PermissionList(moduleTo, mdFrom.getId(), mdTo.getExpandedPermissionSets(),
-          mdFrom.getExpandedPermissionSets());
+    String permIntVer = permInt.getVersion();
+    if (permIntVer.equals("1.0")) {
+      pl = new PermissionListV1(moduleTo, mdTo.getPermissionSets());
+    } else if (permIntVer.equals("1.1")) {
+      pl = new PermissionListV1(moduleTo, mdTo.getExpandedPermissionSets());
     } else {
-      pl = new PermissionList(moduleTo, mdTo.getExpandedPermissionSets());
+      if (mdFrom != null) {
+        pl = new PermissionListV2(moduleTo, mdFrom.getId(), mdTo.getExpandedPermissionSets(),
+            mdFrom.getExpandedPermissionSets());
+      } else {
+        pl = new PermissionListV2(moduleTo, mdTo.getExpandedPermissionSets());
+      }
     }
     String pljson = Json.encodePrettily(pl);
     logger.debug("tenantPerms Req: {}", pljson);

--- a/okapi-core/src/main/raml/Permission.json
+++ b/okapi-core/src/main/raml/Permission.json
@@ -10,6 +10,13 @@
       "description": "Permission ID (usually module.service.method or similar)",
       "type": "string"
     },
+    "renamedFrom": {
+      "description": "previously used names for this permission",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "displayName": {
       "description": "Human readable name for permission",
       "type": "string"

--- a/okapi-core/src/test/java/org/folio/okapi/InstallTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/InstallTest.java
@@ -517,7 +517,7 @@ public class InstallTest {
           } else if (p.startsWith("/permissionscall")) {
             JsonObject permObject = new JsonObject(buf);
             if (timerTenantPermissionsStatus == 200) {
-              timerPermissions.put(permObject.getString("moduleId"), permObject.getJsonArray("perms"));
+              timerPermissions.put(permObject.getString("moduleToId"), permObject.getJsonArray("permsTo"));
             }
             ctx.response().setStatusCode(timerTenantPermissionsStatus);
             ctx.response().end("timer permissions response");

--- a/okapi-core/src/test/java/org/folio/okapi/ModuleTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ModuleTest.java
@@ -3358,7 +3358,7 @@ public class ModuleTest {
       .body(docEnableHdr)
       .post("/_/proxy/tenants/" + okapiTenant + "/modules")
       .then()
-      .statusCode(500)
+      .statusCode(400)
       .log().ifValidationFails()
       .extract().asString();
     context.assertEquals("Unknown version of _tenantPermissions interface in use 9.0.", body);

--- a/okapi-core/src/test/java/org/folio/okapi/ModuleTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ModuleTest.java
@@ -1108,14 +1108,14 @@ public class ModuleTest {
     checkDbIsEmpty("testOneModule done", context);
   }
 
-  private String createHeaderModule() {
+  private String createHeaderModule(String tenantPermsVer) {
     final String testHdrJar = "../okapi-test-header-module/target/okapi-test-header-module-fat.jar";
     final String docHdrModule = "{" + LS
         + "  \"id\" : \"header-1\"," + LS
         + "  \"name\" : \"header-module\"," + LS
         + "  \"provides\" : [ {" + LS
         + "    \"id\" : \"_tenantPermissions\"," + LS
-        + "    \"version\" : \"1.1\"," + LS
+        + "    \"version\" : \"" + tenantPermsVer + "\"," + LS
         + "    \"interfaceType\" : \"system\"," + LS
         + "    \"handlers\" : [ {" + LS
         + "      \"methods\" : [ \"POST\" ]," + LS
@@ -1170,7 +1170,7 @@ public class ModuleTest {
     // this.
 
     // Create, deploy, and enable the header module
-    final String locHdrModule = createHeaderModule();
+    final String locHdrModule = createHeaderModule("2.0");
     locationHeaderDeployment = deployModule("header-1");
     final String docEnableHdr = "{" + LS
       + "  \"id\" : \"header-1\"" + LS
@@ -2759,7 +2759,7 @@ public class ModuleTest {
         .then().statusCode(foundStatus)
         .log().ifValidationFails();
 
-    final String locHdrModule = createHeaderModule();
+    final String locHdrModule = createHeaderModule("2.0");
 
     given()
         .header("Content-Type", "application/json")
@@ -2918,5 +2918,401 @@ public class ModuleTest {
     c.given().delete("/_/proxy/modules/foo-1.0.0")
         .then().statusCode(404).body(containsString("delete: module foo-1.0.0 does not exist"));
     assertEmptyReport(c);
+  }
+
+  /**
+   * Test backwards compatibility of the _tenantPermissions interface v1.1
+   *
+   * @param context
+   */
+  @Test
+  public void testTenantPermissionsCompatibility(TestContext context) {
+    checkDbIsEmpty("testTenantPermissionsCompatibility starting", context);
+
+    RestAssuredClient c;
+    Response r;
+
+    // Set up a tenant to test with
+    final String locTenant = createTenant();
+
+    // Enable the Okapi internal module for our tenant.
+    // This is not unlike what happens to the superTenant, who has the internal
+    // module enabled from the boot up, before anyone can provide the
+    // _tenantPermissions interface. Its permissions should be (re)loaded
+    // when our Hdr module gets enabled.
+    final String locInternal = enableModule("okapi-0.0.0");
+
+    // Set up a module that does the _tenantPermissions interface that will
+    // get called when sample gets enabled. We (ab)use the header module for
+    // this.
+
+    // Create, deploy, and enable the header module
+    final String locHdrModule = createHeaderModule("1.1");
+    locationHeaderDeployment = deployModule("header-1");
+    final String docEnableHdr = "{" + LS
+      + "  \"id\" : \"header-1\"" + LS
+      + "}";
+
+    // Enable the header module. Check that tenantPermissions gets called
+    // both for header module, and the already-enabled okapi internal module.
+    Headers headers = given()
+      .header("Content-Type", "application/json")
+      .body(docEnableHdr)
+      .post("/_/proxy/tenants/" + okapiTenant + "/modules")
+      .then()
+      .statusCode(201)
+      .log().ifValidationFails()
+      .extract().headers();
+    final String locHdrEnable = headers.getValue("Location");
+    // one trace from Okapi, two from the header module since it's called twice
+    context.assertEquals(3, headers.getValues("X-Okapi-Trace").size());
+
+    given()
+        .header("X-Okapi-Tenant", okapiTenant)
+        .get("/permResult")
+        .then()
+        .statusCode(200)
+        .log().ifValidationFails()
+        .body("$", hasSize(2))
+        .body("[0].moduleId", is("okapi-0.0.0"))
+        .body("[1].moduleId", is("header-1"));
+
+    // Set up the test module
+    // It provides a _tenant interface, but no _tenantPermissions
+    // Enabling it will end up invoking the _tenantPermissions in header-module
+    final String testModJar = "../okapi-test-module/target/okapi-test-module-fat.jar";
+    final String docSampleModule = "{" + LS
+      + "  \"id\" : \"sample-module-1\"," + LS
+      + "  \"name\" : \"sample module\"," + LS
+      + "  \"provides\" : [ {" + LS
+      + "    \"id\" : \"sample\"," + LS
+      + "    \"version\" : \"1.0\"," + LS
+      + "    \"handlers\" : [ {" + LS
+      + "      \"methods\" : [ \"GET\", \"POST\" ]," + LS
+      + "      \"path\" : \"/testb\"," + LS
+      + "      \"level\" : \"30\"," + LS
+      + "      \"type\" : \"request-response\"," + LS
+      + "      \"permissionsRequired\" : [ \"sample.needed\" ]," + LS
+      + "      \"permissionsDesired\" : [ \"sample.extra\" ]," + LS
+      + "      \"modulePermissions\" : [ \"sample.modperm\" ]" + LS
+      + "    } ]" + LS
+      + "  }, {" + LS
+      + "    \"id\" : \"_tenant\"," + LS
+      + "    \"version\" : \"1.0\"," + LS
+      + "    \"interfaceType\" : \"system\"," + LS
+      + "    \"handlers\" : [ {" + LS
+      + "      \"methods\" : [ \"POST\", \"DELETE\" ]," + LS
+      + "      \"path\" : \"/_/tenant\"," + LS
+      + "      \"level\" : \"10\"," + LS
+      + "      \"type\" : \"system\"," + LS
+      + "      \"permissionsRequired\" : [ ]," + LS
+      + "      \"modulePermissions\" : [ \"sample.tenantperm\" ]" + LS
+      + "    } ]" + LS
+      + "  } ]," + LS
+      + "  \"permissionSets\" : [ {" + LS
+      + "    \"permissionName\" : \"everything\"," + LS
+      + "    \"displayName\" : \"every possible permission\"," + LS
+      + "    \"description\" : \"All permissions combined\"," + LS
+      + "    \"subPermissions\" : [ \"sample.needed\", \"sample.extra\" ]," + LS
+      + "    \"visible\" : true" + LS
+      + "  } ]," + LS
+      + "  \"launchDescriptor\" : {" + LS
+      + "    \"exec\" : \"java -Dport=%p -jar " + testModJar + "\"" + LS
+      + "  }" + LS
+      + "}";
+
+    // Create and deploy the sample module
+    final String locSampleModule = createModule(docSampleModule);
+    locationSampleDeployment = deployModule("sample-module-1");
+
+    // Enable the sample module. Verify that the _tenantPermissions gets
+    // invoked.
+    final String docEnable = "{" + LS
+      + "  \"id\" : \"sample-module-1\"" + LS
+      + "}";
+    final String expPerms = "{ "
+      + "\"moduleId\" : \"sample-module-1\", "
+      + "\"perms\" : [ { "
+      + "\"permissionName\" : \"everything\", "
+      + "\"displayName\" : \"every possible permission\", "
+      + "\"description\" : \"All permissions combined\", "
+      + "\"subPermissions\" : [ \"sample.needed\", \"sample.extra\" ], "
+      + "\"visible\" : true "
+      + "}, { "
+      + "\"permissionName\" : \"SYS#sample-module-1#/testb#[GET, POST]\", "
+      + "\"displayName\" : \"System generated: SYS#sample-module-1#/testb#[GET, POST]\", "
+      + "\"description\" : \"System generated permission set\", "
+      + "\"subPermissions\" : [ \"sample.modperm\" ], "
+      + "\"visible\" : false "
+      + "}, { "
+      + "\"permissionName\" : \"SYS#sample-module-1#/_/tenant#[POST, DELETE]\", "
+      + "\"displayName\" : \"System generated: SYS#sample-module-1#/_/tenant#[POST, DELETE]\", "
+      + "\"description\" : \"System generated permission set\", "
+      + "\"subPermissions\" : [ \"sample.tenantperm\" ], "
+      + "\"visible\" : false "
+      + "} ] }";
+
+    String locSampleEnable = given()
+      .header("Content-Type", "application/json")
+      .body(docEnable)
+      .post("/_/proxy/tenants/" + okapiTenant + "/modules")
+      .then()
+      .statusCode(201)
+      .log().ifValidationFails()
+      .extract().header("Location");
+
+    String body = given()
+        .header("X-Okapi-Tenant", okapiTenant)
+        .get("/permResult")
+        .then()
+        .statusCode(200)
+        .log().ifValidationFails()
+        .extract().body().asString();
+
+    JsonArray ar = new JsonArray(body);
+    context.assertEquals(1, ar.size());
+    context.assertEquals(new JsonObject(expPerms), ar.getJsonObject(0));
+
+    // Try with a minimal MD, to see we don't have null pointers hanging around
+    final String docSampleModule2 = "{" + LS
+      + "  \"id\" : \"sample-module2-1\"," + LS
+      + "  \"name\" : \"sample module2\"," + LS
+      + "  \"launchDescriptor\" : {" + LS
+      + "    \"exec\" : \"java -Dport=%p -jar " + testModJar + "\"" + LS
+      + "  }" + LS
+      + "}";
+    // Create the sample module
+    final String locSampleModule2 = createModule(docSampleModule2);
+    final String locationSampleDeployment2 = deployModule("sample-module2-1");
+
+    // Enable the small module. Verify that the _tenantPermissions gets
+    // invoked.
+    final String docEnable2 = "{" + LS
+      + "  \"id\" : \"sample-module2-1\"" + LS
+      + "}";
+    final String expPerms2 = "{ "
+      + "\"moduleId\" : \"sample-module2-1\", "
+      + "\"perms\" : null }";
+
+    String locSampleEnable2 = given()
+      .header("Content-Type", "application/json")
+      .body(docEnable2)
+      .post("/_/proxy/tenants/" + okapiTenant + "/modules")
+      .then()
+      .statusCode(201)
+      .log().ifValidationFails()
+      .extract().header("Location");
+
+    body = given()
+        .header("X-Okapi-Tenant", okapiTenant)
+        .get("/permResult")
+        .then()
+        .statusCode(200)
+        .log().ifValidationFails()
+        .extract().body().asString();
+
+    ar = new JsonArray(body);
+    context.assertEquals(1, ar.size());
+    context.assertEquals(new JsonObject(expPerms2), ar.getJsonObject(0));
+
+    // Tests to see that we get a new auth token for the system calls
+    // Disable sample, so we can re-enable it after we have established auth
+    given().delete(locSampleEnable).then().log().ifValidationFails().statusCode(204);
+    locSampleEnable = null;
+
+    // Declare and enable test-auth
+    final String testAuthJar = "../okapi-test-auth-module/target/okapi-test-auth-module-fat.jar";
+    final String docAuthModule = "{" + LS
+      + "  \"id\" : \"auth-1\"," + LS
+      + "  \"name\" : \"auth\"," + LS
+      + "  \"provides\" : [ {" + LS
+      + "    \"id\" : \"auth\"," + LS
+      + "    \"version\" : \"1.2\"," + LS
+      + "    \"handlers\" : [ {" + LS
+      + "      \"methods\" : [ \"POST\" ]," + LS
+      + "      \"path\" : \"/authn/login\"," + LS
+      + "      \"level\" : \"20\"," + LS
+      + "      \"type\" : \"request-response\"," + LS
+      + "      \"permissionsRequired\" : [ ]" + LS
+      + "    } ]" + LS
+      + "  } ]," + LS
+      + "  \"filters\" : [ {" + LS
+      + "    \"methods\" : [ \"*\" ]," + LS
+      + "    \"path\" : \"/\"," + LS
+      + "    \"phase\" : \"auth\"," + LS
+      + "    \"type\" : \"headers\"," + LS
+      + "    \"permissionsRequired\" : [ ]," + LS
+      + "    \"permissionsDesired\" : [ \"auth.extra\" ]" + LS
+      + "  } ]," + LS
+      + "  \"requires\" : [ ]," + LS
+      + "  \"launchDescriptor\" : {" + LS
+      + "    \"exec\" : \"java -Dport=%p -jar " + testAuthJar + "\"" + LS
+      + "  }" + LS
+      + "}";
+    final String docEnableAuth = "{" + LS
+      + "  \"id\" : \"auth-1\"" + LS
+      + "}";
+    final String locAuthModule = createModule(docAuthModule);
+    final String locAuthDeployment = deployModule("auth-1");
+    final String locAuthEnable = given()
+      .header("Content-Type", "application/json")
+      .body(docEnableAuth)
+      .post("/_/proxy/tenants/" + okapiTenant + "/modules")
+      .then()
+      .statusCode(201)
+      .log().ifValidationFails()
+      .extract().header("Location");
+
+    // Re-enable sample.
+    locSampleEnable = given()
+      .header("Content-Type", "application/json")
+      .body(docEnable)
+      .post("/_/proxy/tenants/" + okapiTenant + "/modules")
+      .then()
+      .statusCode(201)
+      .log().ifValidationFails()
+      .extract().header("Location");
+
+    body = given()
+        .header("X-Okapi-Tenant", okapiTenant)
+        .get("/permResult")
+        .then()
+        .statusCode(200)
+        .log().ifValidationFails()
+        .extract().body().asString();
+
+    ar = new JsonArray(body);
+    context.assertEquals(2, ar.size());
+    context.assertEquals(new JsonObject(expPerms), ar.getJsonObject(1));
+
+    // Check that the tenant interface and the tenantpermission interfaces
+    // were called with proper auth tokens and with ModulePermissions
+
+    // Set up the test module
+    // It provides a _tenant interface, but no _tenantPermissions
+    // Enabling it will end up invoking the _tenantPermissions in header-module
+    final String docSampleModuleUpdated = "{" + LS
+      + "  \"id\" : \"sample-module-2\"," + LS
+      + "  \"name\" : \"sample module\"," + LS
+      + "  \"provides\" : [ {" + LS
+      + "    \"id\" : \"sample\"," + LS
+      + "    \"version\" : \"2.0\"," + LS
+      + "    \"handlers\" : [ {" + LS
+      + "      \"methods\" : [ \"GET\", \"POST\" ]," + LS
+      + "      \"path\" : \"/testb\"," + LS
+      + "      \"level\" : \"30\"," + LS
+      + "      \"type\" : \"request-response\"," + LS
+      + "      \"permissionsRequired\" : [ \"sample.needed\" ]," + LS
+      + "      \"permissionsDesired\" : [ \"sample.extra\" ]," + LS
+      + "      \"modulePermissions\" : [ \"sample.modperm\" ]" + LS
+      + "    } ]" + LS
+      + "  }, {" + LS
+      + "    \"id\" : \"_tenant\"," + LS
+      + "    \"version\" : \"1.0\"," + LS
+      + "    \"interfaceType\" : \"system\"," + LS
+      + "    \"handlers\" : [ {" + LS
+      + "      \"methods\" : [ \"POST\", \"DELETE\" ]," + LS
+      + "      \"path\" : \"/_/tenant\"," + LS
+      + "      \"level\" : \"10\"," + LS
+      + "      \"type\" : \"system\"," + LS
+      + "      \"permissionsRequired\" : [ ]," + LS
+      + "      \"modulePermissions\" : [ \"sample.tenantperm\" ]" + LS
+      + "    } ]" + LS
+      + "  } ]," + LS
+      + "  \"permissionSets\" : [ {" + LS
+      + "    \"permissionName\" : \"all\"," + LS
+      + "    \"displayName\" : \"all possible permissions\"," + LS
+      + "    \"description\" : \"All permissions combined\"," + LS
+      + "    \"subPermissions\" : [ \"sample.needed\", \"sample.extra\" ]," + LS
+      + "    \"visible\" : true" + LS
+      + "  } ]," + LS
+      + "  \"launchDescriptor\" : {" + LS
+      + "    \"exec\" : \"java -Dport=%p -jar " + testModJar + "\"" + LS
+      + "  }" + LS
+      + "}";
+
+    // Create and deploy the sample module
+    final String locSampleModuleUpdated = createModule(docSampleModuleUpdated);
+    final String locationSampleDeploymentUpdated = deployModule("sample-module-2");
+
+    // Enable the small module. Verify that the _tenantPermissions gets
+    // invoked.
+    final String docEnableUpdated = "[ {" + LS
+      + "  \"id\" : \"sample-module-2\"," + LS
+      + "  \"action\" : \"enable\"" + LS
+      + "} ]";
+    final String expPermsUpdated = "{ "
+        + "\"moduleId\" : \"sample-module-2\", "
+        + "\"perms\" : [ { "
+        + "\"permissionName\" : \"all\", "
+        + "\"displayName\" : \"all possible permissions\", "
+        + "\"description\" : \"All permissions combined\", "
+        + "\"subPermissions\" : [ \"sample.needed\", \"sample.extra\" ], "
+        + "\"visible\" : true "
+        + "}, { "
+        + "\"permissionName\" : \"SYS#sample-module-2#/testb#[GET, POST]\", "
+        + "\"displayName\" : \"System generated: SYS#sample-module-2#/testb#[GET, POST]\", "
+        + "\"description\" : \"System generated permission set\", "
+        + "\"subPermissions\" : [ \"sample.modperm\" ], "
+        + "\"visible\" : false "
+        + "}, { "
+        + "\"permissionName\" : \"SYS#sample-module-2#/_/tenant#[POST, DELETE]\", "
+        + "\"displayName\" : \"System generated: SYS#sample-module-2#/_/tenant#[POST, DELETE]\", "
+        + "\"description\" : \"System generated permission set\", "
+        + "\"subPermissions\" : [ \"sample.tenantperm\" ], "
+        + "\"visible\" : false "
+        + "} ] }";
+
+    given()
+      .header("Content-Type", "application/json")
+      .body(docEnableUpdated)
+      .post("/_/proxy/tenants/" + okapiTenant + "/install")
+      .then()
+      .statusCode(200)
+      .log().ifValidationFails();
+
+    String locSampleEnableUpdated = "/_/proxy/tenants/" + okapiTenant + "/modules/sample-module-2";
+
+    body = given()
+        .header("X-Okapi-Tenant", okapiTenant)
+        .get("/permResult")
+        .then()
+        .statusCode(200)
+        .log().ifValidationFails()
+        .extract().body().asString();
+
+    ar = new JsonArray(body);
+    context.assertEquals(1, ar.size());
+    context.assertEquals(new JsonObject(expPermsUpdated), ar.getJsonObject(0));
+
+    // Clean up, so the next test starts with a clean slate (in reverse order)
+    logger.debug("testSystemInterfaces cleaning up");
+
+    given().delete(locSampleEnable).then().log().ifValidationFails().statusCode(204);
+
+    given().delete(locAuthEnable).then().log().ifValidationFails().statusCode(204);
+    given().delete(locAuthDeployment).then().log().ifValidationFails().statusCode(204);
+    c = api.createRestAssured3();
+    c.given().delete(locAuthModule).then().log().ifValidationFails().statusCode(204);
+    assertEmptyReport(c);
+
+    given().delete(locSampleEnableUpdated).then().log().ifValidationFails().statusCode(204);
+    given().delete(locationSampleDeploymentUpdated).then().log().ifValidationFails().statusCode(204);
+    given().delete(locSampleModuleUpdated).then().log().ifValidationFails().statusCode(204);
+
+    given().delete(locSampleEnable2).then().log().ifValidationFails().statusCode(204);
+    given().delete(locationSampleDeployment2).then().log().ifValidationFails().statusCode(204);
+    given().delete(locSampleModule2).then().log().ifValidationFails().statusCode(204);
+    //given().delete(locSampleEnable).then().log().ifValidationFails().statusCode(204);
+    given().delete(locationSampleDeployment).then().log().ifValidationFails().statusCode(204);
+    given().delete(locSampleModule).then().log().ifValidationFails().statusCode(204);
+    locationSampleDeployment = null;
+    given().delete(locHdrEnable).then().log().ifValidationFails().statusCode(204);
+    given().delete(locationHeaderDeployment).then().log().ifValidationFails().statusCode(204);
+    locationHeaderDeployment = null;
+    given().delete(locHdrModule).then().log().ifValidationFails().statusCode(204);
+    given().delete(locInternal).then().log().ifValidationFails().statusCode(204);
+    given().delete(locTenant).then().log().ifValidationFails().statusCode(204);
+    checkDbIsEmpty("testSystemInterfaces done", context);
   }
 }

--- a/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
@@ -253,7 +253,7 @@ public class ProxyTest {
           } else if (p.startsWith("/permissionscall")) {
             JsonObject permObject = new JsonObject(buf);
             if (timerTenantPermissionsStatus == 200) {
-              timerPermissions.put(permObject.getString("moduleId"), permObject.getJsonArray("perms"));
+              timerPermissions.put(permObject.getString("moduleToId"), permObject.getJsonArray("permsTo"));
             }
             response.setStatusCode(timerTenantPermissionsStatus);
             response.end("timer permissions response");

--- a/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
@@ -253,7 +253,12 @@ public class ProxyTest {
           } else if (p.startsWith("/permissionscall")) {
             JsonObject permObject = new JsonObject(buf);
             if (timerTenantPermissionsStatus == 200) {
-              timerPermissions.put(permObject.getString("moduleToId"), permObject.getJsonArray("permsTo"));
+              String moduleToId = permObject.getString("moduleToId");
+              if (moduleToId != null) {
+                timerPermissions.put(moduleToId, permObject.getJsonArray("permsTo"));
+              } else {
+                timerPermissions.put(permObject.getString("moduleId"), permObject.getJsonArray("perms"));
+              }
             }
             response.setStatusCode(timerTenantPermissionsStatus);
             response.end("timer permissions response");
@@ -3842,8 +3847,8 @@ public class ProxyTest {
 
     setupBasicTenant(tenant);
 
-    // test _tenantpermissions 1.0 vs 1.1
-    for (String tenantPermissionsVersion : Arrays.asList("1.0", "1.1")) {
+    // test _tenantpermissions 1.0 vs 1.1 vs 2.0
+    for (String tenantPermissionsVersion : Arrays.asList("1.0", "1.1", "2.0")) {
       timerPermissions.clear();
       setupBasicModule(tenant, moduleId, tenantPermissionsVersion, true, true);
       setupBasicAuth(tenant, authModuleId);


### PR DESCRIPTION
## Purpose
Implement changes to facilitate static permission migration.  For details, see https://wiki.folio.org/display/DD/Migration+of+Static+Permissions+Upon+Upgrade?src=contextnavpagetreemode

Also see:  https://issues.folio.org/browse/OKAPI-947

## Approach
* Add a `renamedFrom` field to the module descriptor permission schema indicating a permission's previously used name(s)
* Adjust the payload for the _tenantPermissions call to include:
  * `moduleIdFrom` - the name/version of the module currently in use/being upgraded from (if applicable)
  * `permsFrom` - the list of permissions defined by the version of the module currently in use (if applicable)
  * `permsTo` - renamed from `perms` for clarity. 
  * `moduleIdTo` - renamed from `moduleId` for clarity.
* When upgrading mod-permissions, call the _tenantPermissions API for each module enabled for the tenant, resulting in the permissions being refreshed.  This is already done when first enabling mod-permissions install, but is now also done when upgrading it.
