### PR TITLE
Publish reload-modules also when disabling module OKAPI-967

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
@@ -479,13 +479,10 @@ public class TenantManager implements Liveness {
     String moduleFrom = mdFrom != null ? mdFrom.getId() : null;
     String moduleTo = mdTo != null ? mdTo.getId() : null;
 
-    Promise<Void> promise = Promise.promise();
     return updateModuleCommit(tenant, moduleFrom, moduleTo)
         .compose(x -> {
-          if (moduleTo != null) {
-            EventBus eb = vertx.eventBus();
-            eb.publish(EVENT_NAME, tenant.getId());
-          }
+          EventBus eb = vertx.eventBus();
+          eb.publish(EVENT_NAME, tenant.getId());
           return Future.succeededFuture();
         });
   }


### PR DESCRIPTION
Fix this brain-damage - due to previous behavior when we were caching modules as a whole (for all tenants).. In that case we could ignore when a module was disabled.. In the current design.. of course all changes to modules enabled for a tenant needs to be published to all okapi instances.