### PR TITLE
OKAPI-959 restore missing metrics code

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -192,6 +192,7 @@ public class ProxyService {
     boolean skipAuth = false;
     for (ModuleInstance mi : mods) {
       if (mi.isHandler()) {
+        pc.setHandlerModuleInstance(mi);
         RoutingEntry re = mi.getRoutingEntry();
         skipAuth = checkTokenCache(pc.getTenant(), req, re.getPathPattern(), mi);
         logger.debug("getModulesForRequest:  Added {} {} {} {} / {}",

--- a/okapi-core/src/main/java/org/folio/okapi/util/ProxyContext.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/ProxyContext.java
@@ -51,6 +51,10 @@ public class ProxyContext {
     return handlerModuleInstance;
   }
 
+  public void setHandlerModuleInstance(ModuleInstance handlerModuleInstance) {
+    this.handlerModuleInstance = handlerModuleInstance;
+  }
+
   /**
    * Constructor to be used from proxy. Does not log the request, as we do not
    * know the tenant yet.


### PR DESCRIPTION
Please see https://issues.folio.org/browse/OKAPI-959. Tested the change with InfluxDB and I can see `org_folio_okapi_http_server_processingTime` metric fields `module` and `url` are populated now.