### PR TITLE
OKAPI-970: testcontainers 1.15.1 needed for latest docker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers-bom</artifactId>
-        <version>1.15.0</version>
+        <version>1.15.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Upgrade testcontainers from 1.15.0 to 1.15.1 to make it work with latest docker
Release notes: https://github.com/testcontainers/testcontainers-java/releases/tag/1.15.1

Without this upgrade unit tests that use testcontainers no longer work.