### PR TITLE
OKAPI-971: Fail unit tests if docker is not available

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,11 @@ The Okapi software has the following compile-time dependencies:
 
 * Apache Maven 3.3.x or higher
 
-In addition, the test suite must be able to bind to ports 9230-9239 to
-succeed.
+The test suite has these additional dependencies:
+
+* Docker, for details see https://www.testcontainers.org/supported_docker_environment/
+
+* Ports 9230-9239 must be free
 
 *Note: If tests fail, the API Gateway may be unable in some cases to
 shut down microservices that it has spawned, and they may need to be
@@ -28,6 +31,10 @@ To build and run:
     $ mvn exec:exec
 
 Okapi listens on port 9130.
+
+To build without running the test suite:
+
+    $ mvn install -DskipTests
 
 ## Developers
 

--- a/okapi-core/src/test/java/org/folio/okapi/service/impl/PostgresHandleTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/service/impl/PostgresHandleTest.java
@@ -15,12 +15,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.testcontainers.containers.Container.ExecResult;
-import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.MountableFile;
 
 @Timeout(5000)
 @ExtendWith(VertxExtension.class)
-@Testcontainers(disabledWithoutDocker = true)
 class PostgresHandleTest extends PgTestBase implements WithAssertions {
 
   static final String KEY_PATH = "/var/lib/postgresql/data/server.key";


### PR DESCRIPTION
FOLIO switches from embedded-postgresql to testcontainers.org that use
Docker PostgreSQL containers for tests in RMB based modules, RMB and Okapi:
FOLIO-1845

It no longer makes sense to skip tests if Docker is not available.

Tests should fail by default if we cannot run all tests so that any Docker
malfunction on the developer machine and on CI is noticed immediately. It
is misleading if such tests are skipped by default, see comments on OKAPI-970.

DockerModuleHandleTest, ModuleTest and PostgresHandleTest require Docker.

This pull request removes

    @Testcontainers(disabledWithoutDocker = true)

PostgresHandleTest. (The other two files already fail on missing Docker).
And it adjust README.

If there really is a need to run only those tests that don't require
Docker please create a new Jira for this feature. This might be
implemented by adding a `withoutDocker` maven profile to the pom.xml
that can be used in this way:

    mvn clean install -PwithoutDocker