### PR TITLE
OKAPI-947 Update documentation, renamedFrom -> replaces, and bump _tenantpermissions version

### DIFF
--- a/doc/guide.md
+++ b/doc/guide.md
@@ -1962,7 +1962,8 @@ Assuming `test-basic.get.list` and `test-basic-view.list` were defined in previo
 1. Update any `childOf`/`subPermission` relationships.  `test-basic.collection.get` would be added to any permission's `childOf` or `subPermissions` fields which contain `test-basic.get.list` or `test-basic.view.list`
 
 See the following for additional details of how this is handled by the permissions module.
-* [Migration of Static Permissions Upon Upgrade](https://wiki.folio.org/display/DD/Migration+of+Static+Permissions+Upon+Upgrade "Migration of Static Permissions Upon Upgrade") * [Permissions API Definition](https://github.com/folio-org/mod-permissions/blob/master/ramls/permissions.raml)
+* [Migration of Static Permissions Upon Upgrade](https://wiki.folio.org/display/DD/Migration+of+Static+Permissions+Upon+Upgrade "Migration of Static Permissions Upon Upgrade")
+* [Permissions API Definition](https://github.com/folio-org/mod-permissions/blob/master/ramls/permissions.raml)
 * [TenantPermission API Definition](https://github.com/folio-org/mod-permissions/blob/master/ramls/tenantPermissions.raml)
 
 ### Optional interfaces

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -1943,7 +1943,7 @@ As desribed earlier, permissions and permissionSets can be defined in the Module
 
 When mod-permissions is enabled for a tenant, OKAPI will invoke the `_tenantPermissions` API for all modules currently enabled for that tenant.  This is needed to inform the permissions module of any permissions defined in module descriptors enabled for the tenant prior to mod-permissions.
 
-Note that OKAPI is only responsible for providing the permissions and the corresponding moduleId to the `_tenantPermissions` API.  Determination of the appropriate actions to be taken is the responsibility of the permissions module.   Most of this will happen without explicit or special provisioning in the ModuleDescriptor.  Adding, removing or updating the permissions in the `permissionsSet` proprety is sufficient.  One exception to that is renaming of permissions.   If you wish to rename an existing permission, use the `renamedFrom` property on the permission object, e.g. 
+Note that OKAPI is only responsible for providing the permissions and the corresponding moduleId to the `_tenantPermissions` API.  Determination of the appropriate actions to be taken is the responsibility of the permissions module.   Most of this will happen without explicit or special provisioning in the ModuleDescriptor.  Adding, removing or updating the permissions in the `permissionsSet` property is sufficient.  One exception to that is renaming of permissions.   If you wish to rename an existing permission, use the `renamedFrom` property on the permission object, e.g. 
 ```
 ...
   "permissionSets": [
@@ -1951,17 +1951,19 @@ Note that OKAPI is only responsible for providing the permissions and the corres
       "permissionName": "test-basic.collection.get",
       "displayName": "test-basic list records",
       "description": "Get a list of records",
-      "renamedFrom": [ "test-basic.get.list", "test-basic.view.list" ]
+	    "renamedFrom": [ "test-basic.get.list", "test-basic.view.list" ]
     }, 
 ...
 ```
-Assuming `test-basic.get.list` and `test-basic-view.list` were defined in an versions of the ModuleDescriptor, this would result in:
+Assuming `test-basic.get.list` and `test-basic-view.list` were defined in previous versions of the ModuleDescriptor, this would result in:
 1. `test-basic.get.list` and `test-basic.view.list` being deprecated.
 1. A new permission `test-basic.collection.get` being created.
 1. Update any permission assignments so that any users that were granted  `test-basic.get.list` or `test-basic.view.list` are automatically granted `test-basic.collection.get`
 1. Update any `childOf`/`subPermission` relationships.  `test-basic.collection.get` would be added to any permission's `childOf` or `subPermissions` fields which contain `test-basic.get.list` or `test-basic.view.list`
 
-See [Migration of Static Permissions Upon Upgrade](https://wiki.folio.org/display/DD/Migration+of+Static+Permissions+Upon+Upgrade "Migration of Static Permissions Upon Upgrade") and the [Permissions API Definition](https://github.com/folio-org/mod-permissions/blob/master/ramls/permissions.raml) for additional details of how this is handled by the permissions module.
+See the following for additional details of how this is handled by the permissions module.
+* [Migration of Static Permissions Upon Upgrade](https://wiki.folio.org/display/DD/Migration+of+Static+Permissions+Upon+Upgrade "Migration of Static Permissions Upon Upgrade") * [Permissions API Definition](https://github.com/folio-org/mod-permissions/blob/master/ramls/permissions.raml)
+* [TenantPermission API Definition](https://github.com/folio-org/mod-permissions/blob/master/ramls/tenantPermissions.raml)
 
 ### Optional interfaces
 

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -1937,6 +1937,31 @@ descriptor. For the fully up-to-date definition, you should always
 refer to the RAML and JSON schemas in the [Reference](#web-service)
 section.
 
+### Permissions and the `_tenantPermissions` Interface
+As desribed earlier, permissions and permissionSets can be defined in the ModuleDescriptor, but how does mod-permissions learn about them?  The answer is via another system interface: `_tenantPermissions`.  This interface, implemented by mod-permissions, is invoked by OKAPI when a module is enabled for a tenant.  The permissions defined in that module's ModuleDescriptor are furnished, allowing the permissions module to perform the necessary CRUD operations against permission storage.
+
+When mod-permissions is enabled for a tenant, OKAPI will invoke the `_tenantPermissions` API for all modules currently enabled for that tenant.  This is needed to inform the permissions module of any permissions defined in module descriptors enabled for the tenant prior to mod-permissions.
+
+Note that OKAPI is only responsible for providing the permissions and the corresponding moduleId to the `_tenantPermissions` API.  Determination of the appropriate actions to be taken is the responsibility of the permissions module.   Most of this will happen without explicit or special provisioning in the ModuleDescriptor.  Adding, removing or updating the permissions in the `permissionsSet` proprety is sufficient.  One exception to that is renaming of permissions.   If you wish to rename an existing permission, use the `renamedFrom` property on the permission object, e.g. 
+```
+...
+  "permissionSets": [
+    {
+      "permissionName": "test-basic.collection.get",
+      "displayName": "test-basic list records",
+      "description": "Get a list of records",
+	  "renamedFrom": [ "test-basic.get.list", "test-basic.view.list" ]
+    }, 
+...
+```
+Assuming `test-basic.get.list` and `test-basic-view.list` were defined in an versions of the ModuleDescriptor, this would result in:
+1. `test-basic.get.list` and `test-basic.view.list` being deprecated.
+1. A new permission `test-basic.collection.get` being created.
+1. Update any permission assignments so that any users that were granted  `test-basic.get.list` or `test-basic.view.list` are automatically granted `test-basic.collection.get`
+1. Update any `childOf`/`subPermission` relationships.  `test-basic.collection.get` would be added to any permission's `childOf` or `subPermissions` fields which contain `test-basic.get.list` or `test-basic.view.list`
+
+See [Migration of Static Permissions Upon Upgrade](https://wiki.folio.org/display/DD/Migration+of+Static+Permissions+Upon+Upgrade "Migration of Static Permissions Upon Upgrade") and the [Permissions API Definition](https://github.com/folio-org/mod-permissions/blob/master/ramls/permissions.raml) for additional details of how this is handled by the permissions module.
+
 ### Optional interfaces
 
 An optional interface is used to specify that a module may use

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -1961,7 +1961,7 @@ Assuming `test-basic.get.list` and `test-basic-view.list` were defined in previo
 1. Update any permission assignments so that any users that were granted  `test-basic.get.list` or `test-basic.view.list` are automatically granted `test-basic.collection.get`
 1. Update any `childOf`/`subPermission` relationships.  `test-basic.collection.get` would be added to any permission's `childOf` or `subPermissions` fields which contain `test-basic.get.list` or `test-basic.view.list`
 
-See the following for additional details of how this is handled by the permissions module.
+See the following for additional details of how this is handled by the permissions module:
 * [Migration of Static Permissions Upon Upgrade](https://wiki.folio.org/display/DD/Migration+of+Static+Permissions+Upon+Upgrade "Migration of Static Permissions Upon Upgrade")
 * [Permissions API Definition](https://github.com/folio-org/mod-permissions/blob/master/ramls/permissions.raml)
 * [TenantPermission API Definition](https://github.com/folio-org/mod-permissions/blob/master/ramls/tenantPermissions.raml)

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -1943,7 +1943,7 @@ As desribed earlier, permissions and permissionSets can be defined in the Module
 
 When mod-permissions is enabled for a tenant, OKAPI will invoke the `_tenantPermissions` API for all modules currently enabled for that tenant.  This is needed to inform the permissions module of any permissions defined in module descriptors enabled for the tenant prior to mod-permissions.
 
-Note that OKAPI is only responsible for providing the permissions and the corresponding moduleId to the `_tenantPermissions` API.  Determination of the appropriate actions to be taken is the responsibility of the permissions module.   Most of this will happen without explicit or special provisioning in the ModuleDescriptor.  Adding, removing or updating the permissions in the `permissionsSet` property is sufficient.  One exception to that is renaming of permissions.   If you wish to rename an existing permission, use the `renamedFrom` property on the permission object, e.g. 
+Note that OKAPI is only responsible for providing the permissions and the corresponding moduleId to the `_tenantPermissions` API.  Determination of the appropriate actions to be taken is the responsibility of the permissions module.   Most of this will happen without explicit or special provisioning in the ModuleDescriptor.  Adding, removing or updating the permissions in the `permissionsSet` property is sufficient.  One exception to that is renaming or replaceing one or more permissions with another.   This is accomplished via the `replaces` property on the permission object, e.g. 
 ```
 ...
   "permissionSets": [
@@ -1951,7 +1951,7 @@ Note that OKAPI is only responsible for providing the permissions and the corres
       "permissionName": "test-basic.collection.get",
       "displayName": "test-basic list records",
       "description": "Get a list of records",
-      "renamedFrom": [ "test-basic.get.list", "test-basic.view.list" ]
+      "replaces": [ "test-basic.get.list", "test-basic.view.list" ]
     }, 
 ...
 ```

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -1951,7 +1951,7 @@ Note that OKAPI is only responsible for providing the permissions and the corres
       "permissionName": "test-basic.collection.get",
       "displayName": "test-basic list records",
       "description": "Get a list of records",
-	  "renamedFrom": [ "test-basic.get.list", "test-basic.view.list" ]
+      "renamedFrom": [ "test-basic.get.list", "test-basic.view.list" ]
     }, 
 ...
 ```

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -24,6 +24,7 @@ managing and running microservices.
     * [Example 2: Adding the Auth module](#example-2-adding-the-auth-module)
     * [Example 3: Upgrading, versions, environment, and the `_tenant` interface](#example-3-upgrading-versions-environment-and-the-_tenant-interface)
     * [Example 4: Complete ModuleDescriptor](#example-4-complete-moduledescriptor)
+    * [Permissions and the `_tenantPermissions` Interface](#permissions-and-the-_tenantpermissions-interface)
     * [Optional interfaces](#optional-interfaces)
     * [Multiple interfaces](#multiple-interfaces)
     * [Cleaning up](#cleaning-up)

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -1951,7 +1951,7 @@ Note that OKAPI is only responsible for providing the permissions and the corres
       "permissionName": "test-basic.collection.get",
       "displayName": "test-basic list records",
       "description": "Get a list of records",
-	    "renamedFrom": [ "test-basic.get.list", "test-basic.view.list" ]
+      "renamedFrom": [ "test-basic.get.list", "test-basic.view.list" ]
     }, 
 ...
 ```

--- a/okapi-core/src/main/java/org/folio/okapi/bean/Permission.java
+++ b/okapi-core/src/main/java/org/folio/okapi/bean/Permission.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Permission {
   private String permissionName;
-  private String[] renamedFrom;
+  private String[] replaces;
   private String displayName;
   private String description;
   private String[] subPermissions;
@@ -51,11 +51,11 @@ public class Permission {
     this.visible = visible;
   }
 
-  public String[] getRenamedFrom() {
-    return renamedFrom;
+  public String[] getReplaces() {
+    return replaces;
   }
 
-  public void setRenamedFrom(String[] renamedFrom) {
-    this.renamedFrom = renamedFrom;
+  public void setReplaces(String[] replaces) {
+    this.replaces = replaces;
   }
 }

--- a/okapi-core/src/main/raml/Permission.json
+++ b/okapi-core/src/main/raml/Permission.json
@@ -10,7 +10,7 @@
       "description": "Permission ID (usually module.service.method or similar)",
       "type": "string"
     },
-    "renamedFrom": {
+    "replaces": {
       "description": "previously used names for this permission",
       "type": "array",
       "items": {

--- a/okapi-core/src/test/java/org/folio/okapi/ModuleTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ModuleTest.java
@@ -1449,7 +1449,7 @@ public class ModuleTest {
       + "  } ]," + LS
       + "  \"permissionSets\" : [ {" + LS
       + "    \"permissionName\" : \"all\"," + LS
-      + "    \"renamedFrom\" : [ \"everything\" ]," + LS
+      + "    \"replaces\" : [ \"everything\" ]," + LS
       + "    \"displayName\" : \"all possible permissions\"," + LS
       + "    \"description\" : \"All permissions combined\"," + LS
       + "    \"subPermissions\" : [ \"sample.needed\", \"sample.extra\" ]," + LS
@@ -1474,7 +1474,7 @@ public class ModuleTest {
         + "\"moduleId\" : \"sample-module-2\", "
         + "\"perms\" : [ { "
         + "\"permissionName\" : \"all\", "
-        + "\"renamedFrom\" : [ \"everything\" ], "
+        + "\"replaces\" : [ \"everything\" ], "
         + "\"displayName\" : \"all possible permissions\", "
         + "\"description\" : \"All permissions combined\", "
         + "\"subPermissions\" : [ \"sample.needed\", \"sample.extra\" ], "

--- a/okapi-core/src/test/java/org/folio/okapi/ModuleTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ModuleTest.java
@@ -1175,7 +1175,7 @@ public class ModuleTest {
     // this.
 
     // Create, deploy, and enable the header module
-    final String locHdrModule = createHeaderModule("1.1");
+    final String locHdrModule = createHeaderModule("2.0");
     locationHeaderDeployment = deployModule("header-1");
     final String docEnableHdr = "{" + LS
       + "  \"id\" : \"header-1\"" + LS
@@ -2903,5 +2903,58 @@ public class ModuleTest {
     c.given().delete("/_/proxy/modules/foo-1.0.0")
         .then().statusCode(404).body(containsString("delete: module foo-1.0.0 does not exist"));
     assertEmptyReport(c);
+  }
+
+  /**
+   * Test that unknown versions of _tenantPermissions are rejected.
+   *
+   * @param context
+   */
+  @Test
+  public void testTenantPermissionsUnknownVersion(TestContext context) {
+    checkDbIsEmpty("testTenantPermissionsUnknownVersion starting", context);
+
+    // Set up a tenant to test with
+    final String locTenant = createTenant();
+
+    // Enable the Okapi internal module for our tenant.
+    // This is not unlike what happens to the superTenant, who has the internal
+    // module enabled from the boot up, before anyone can provide the
+    // _tenantPermissions interface. Its permissions should normally be (re)loaded
+    // when our Hdr module gets enabled, but we're expecting the call to enable
+    // mod-permissions to fail due to an unknown version of _tenantPermissions
+    final String locInternal = enableModule("okapi-0.0.0");
+
+    // Set up a module that does the _tenantPermissions interface that will
+    // get called when sample gets enabled. We (ab)use the header module for
+    // this.
+
+    // Create, deploy, and enable the header module w/ unknown _tenantPermissions version
+    final String locHdrModule = createHeaderModule("9.0");
+    locationHeaderDeployment = deployModule("header-1");
+    final String docEnableHdr = "{" + LS
+      + "  \"id\" : \"header-1\"" + LS
+      + "}";
+
+    // Enable the header module. Check that we get an appropriate error response.
+    String body = given()
+      .header("Content-Type", "application/json")
+      .body(docEnableHdr)
+      .post("/_/proxy/tenants/" + okapiTenant + "/modules")
+      .then()
+      .statusCode(400)
+      .log().ifValidationFails()
+      .extract().asString();
+    context.assertEquals("Unknown version of _tenantPermissions interface in use 9.0.", body);
+
+    // Clean up, so the next test starts with a clean slate (in reverse order)
+    logger.debug("testTenantPermissionsUnknownVersion cleaning up");
+
+    given().delete(locationHeaderDeployment).then().log().ifValidationFails().statusCode(204);
+    locationHeaderDeployment = null;
+    given().delete(locHdrModule).then().log().ifValidationFails().statusCode(204);
+    given().delete(locInternal).then().log().ifValidationFails().statusCode(204);
+    given().delete(locTenant).then().log().ifValidationFails().statusCode(204);
+    checkDbIsEmpty("testSystemInterfaces done", context);
   }
 }


### PR DESCRIPTION
## Overview

* Update documentation for [OKAPI-947](https://issues.folio.org/browse/OKAPI-947).  
* Change the `renamedFrom` property to be called `replaces` in the Permission schema.
* Bump `_tenantPermissions` to `2.0` since `permissionSets.permission.replaces` isn't supported by mod-permissions (until MODPERMS-115 is complete).

See also:
* [MODPERMS-115](https://issues.folio.org/browse/MODPERMS-115)
* https://wiki.folio.org/display/DD/Migration+of+Static+Permissions+Upon+Upgrade