### PR TITLE
Dump docker response when decoding JSON fails

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/service/impl/DockerModuleHandle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/service/impl/DockerModuleHandle.java
@@ -235,6 +235,7 @@ public class DockerModuleHandle implements ModuleHandle {
         promise.complete(b);
       } catch (DecodeException e) {
         logger.warn("{}", e.getMessage(), e);
+        logger.warn("while decoding {}", body.toString());
         promise.fail(e);
       }
     });


### PR DESCRIPTION
This is a PR which simply makes the Docker Handling of Okapi dump the response body when decoding it as JSON fails.

This is to investigate https://issues.folio.org/browse/OKAPI-978