### PR TITLE
Inform mod-permissions when module is disabled OKAPI-982

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -75,6 +75,7 @@ public class ProxyService {
   // for load balancing, so security is not an issue
   private static final Random random = new Random();
   private final int waitMs;
+  private final boolean enableSystemAuth;
   private static final String REDIRECTQUERY = "redirect-query"; // See redirectProxy below
   private static final String TOKEN_CACHE_MAX_SIZE = "token_cache_max_size";
   private static final String TOKEN_CACHE_TTL_MS = "token_cache_ttl_ms";
@@ -104,6 +105,7 @@ public class ProxyService {
     this.discoveryManager = dm;
     this.okapiUrl = okapiUrl;
     this.waitMs = config.getInteger("logWaitMs", 0);
+    this.enableSystemAuth = Config.getSysConfBoolean("enable_system_auth", true, config);
     HttpClientOptions opt = new HttpClientOptions();
     opt.setMaxPoolSize(1000);
     httpClient = new FuturisedHttpClient(vertx, opt);
@@ -1125,7 +1127,7 @@ public class ProxyService {
     // If we have auth for current (super)tenant is irrelevant here!
     logger.debug("callSystemInterface: Checking if {} has auth", tenantId);
 
-    if ("true".equals(System.getProperty("skipAuthSys"))) {
+    if (!enableSystemAuth) {
       return doCallSystemInterface(headersIn, tenantId, null, inst, null, request);
     }
     return tenantManager.getEnabledModules(tenant).compose(enabledModules -> {

--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -1125,6 +1125,9 @@ public class ProxyService {
     // If we have auth for current (super)tenant is irrelevant here!
     logger.debug("callSystemInterface: Checking if {} has auth", tenantId);
 
+    if ("true".equals(System.getProperty("skipAuthSys"))) {
+      return doCallSystemInterface(headersIn, tenantId, null, inst, null, request);
+    }
     return tenantManager.getEnabledModules(tenant).compose(enabledModules -> {
       for (ModuleDescriptor md : enabledModules) {
         RoutingEntry[] filters = md.getFilters();

--- a/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
@@ -673,11 +673,9 @@ public class TenantManager implements Liveness {
       case "2.0":
         if (mdTo != null) {
           pl = new PermissionList(mdTo.getId(), mdTo.getExpandedPermissionSets());
-        } else if (mdFrom != null) {
+        } else  {
           // attempt an empty list for the module being disabled
           pl = new PermissionList(mdFrom.getId(), new Permission[0]);
-        } else {
-          return Future.succeededFuture();
         }
         break;
       default:

--- a/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
@@ -340,8 +340,7 @@ public class TenantManager implements Liveness {
   private Future<Void> invokeTenantInterface(Tenant tenant, TenantInstallOptions options,
                                              ModuleDescriptor mdFrom, ModuleDescriptor mdTo,
                                              ProxyContext pc) {
-
-    if (!options.getInvoke()) {
+    if (!options.checkInvoke(mdTo.getId())) {
       return Future.succeededFuture();
     }
     JsonObject jo = new JsonObject();
@@ -405,7 +404,7 @@ public class TenantManager implements Liveness {
    */
   private Future<Void> invokePermissions(Tenant tenant, TenantInstallOptions options,
       ModuleDescriptor mdFrom, ModuleDescriptor mdTo, ProxyContext pc) {
-    if (!options.getInvoke()) {
+    if (!options.checkInvoke(mdTo.getId())) {
       return Future.succeededFuture();
     }
     if (mdTo != null && mdTo.getSystemInterface("_tenantPermissions") != null) {
@@ -430,7 +429,7 @@ public class TenantManager implements Liveness {
    */
   private Future<Void> invokePermissionsPermMod(Tenant tenant, TenantInstallOptions options,
                                                 ModuleDescriptor mdTo, ProxyContext pc) {
-    if (mdTo == null || !options.getInvoke()
+    if (mdTo == null || !options.checkInvoke(mdTo.getId())
         || mdTo.getSystemInterface("_tenantPermissions") == null) {
       return Future.succeededFuture();
     }

--- a/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
@@ -398,7 +398,8 @@ public class TenantManager implements Liveness {
    *
    * @param tenant tenant
    * @param options install options
-   * @param mdTo module to
+   * @param mdFrom module from - is null if enabling for the first time
+   * @param mdTo module to - is null if disabling
    * @param pc proxy content
    * @return Future
    */

--- a/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
@@ -409,10 +409,7 @@ public class TenantManager implements Liveness {
       return Future.succeededFuture();
     }
     return findSystemInterface(tenant, "_tenantPermissions").compose(md -> {
-      if (md == null) {
-        return Future.succeededFuture();
-      }
-      if (!options.checkInvoke(md.getId())) {
+      if (md == null || !options.checkInvoke(md.getId())) {
         return Future.succeededFuture();
       }
       return invokePermissionsForModule(tenant, mdFrom, mdTo, md, pc);

--- a/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
@@ -283,7 +283,7 @@ public class TenantManager implements Liveness {
     if (mdFrom == null && mdTo == null) {
       return Future.succeededFuture("");
     }
-    return invokePermissions(tenant, options, mdTo, pc)
+    return invokePermissions(tenant, options, mdFrom, mdTo, pc)
         .compose(x -> invokeTenantInterface(tenant, options, mdFrom, mdTo, pc))
         .compose(x -> invokePermissionsPermMod(tenant, options, mdTo, pc))
         .compose(x -> commitModuleChange(tenant, mdFrom, mdTo))
@@ -404,16 +404,18 @@ public class TenantManager implements Liveness {
    * @return Future
    */
   private Future<Void> invokePermissions(Tenant tenant, TenantInstallOptions options,
-      ModuleDescriptor mdTo, ProxyContext pc) {
-    if (mdTo == null || !options.getInvoke()
-        || mdTo.getSystemInterface("_tenantPermissions") != null) {
+      ModuleDescriptor mdFrom, ModuleDescriptor mdTo, ProxyContext pc) {
+    if (!options.getInvoke()) {
+      return Future.succeededFuture();
+    }
+    if (mdTo != null && mdTo.getSystemInterface("_tenantPermissions") != null) {
       return Future.succeededFuture();
     }
     return findSystemInterface(tenant, "_tenantPermissions").compose(md -> {
       if (md == null) {
         return Future.succeededFuture();
       }
-      return invokePermissionsForModule(tenant, mdTo, md, pc);
+      return invokePermissionsForModule(tenant, mdFrom, mdTo, md, pc);
     });
   }
 
@@ -435,7 +437,7 @@ public class TenantManager implements Liveness {
     // enabling permissions module.
     return findSystemInterface(tenant, "_tenantPermissions")
         .compose(res -> loadPermissionsForEnabled(tenant, mdTo, pc))
-        .compose(res -> invokePermissionsForModule(tenant, mdTo, mdTo, pc));
+        .compose(res -> invokePermissionsForModule(tenant, null, mdTo, mdTo, pc));
   }
 
   /**
@@ -452,7 +454,7 @@ public class TenantManager implements Liveness {
     Future<Void> future = Future.succeededFuture();
     for (String mdid : tenant.listModules()) {
       future = future.compose(x -> moduleManager.get(mdid)
-          .compose(md -> invokePermissionsForModule(tenant, md, permsModule, pc)));
+          .compose(md -> invokePermissionsForModule(tenant, null, md, permsModule, pc)));
     }
     return future;
   }
@@ -525,7 +527,7 @@ public class TenantManager implements Liveness {
       }
       logger.info("Tenant {} moving from {} to {}", tenantId, moduleFrom, moduleTo);
       TenantInstallOptions options = new TenantInstallOptions();
-      return invokePermissions(tenant, options, md, null).compose(x ->
+      return invokePermissions(tenant, options, null, md, null).compose(x ->
           updateModuleCommit(tenant, moduleFrom, moduleTo));
     });
   }
@@ -650,31 +652,43 @@ public class TenantManager implements Liveness {
     return perms;
   }
 
-  private Future<Void> invokePermissionsForModule(Tenant tenant, ModuleDescriptor mdTo,
-      ModuleDescriptor permsModule, ProxyContext pc) {
+  private Future<Void> invokePermissionsForModule(Tenant tenant,
+                                                  ModuleDescriptor mdFrom, ModuleDescriptor mdTo,
+                                                  ModuleDescriptor permsModule, ProxyContext pc) {
 
-    logger.debug("Loading permissions for {} (using {})", mdTo.getName(), permsModule.getName());
-    String moduleTo = mdTo.getId();
     PermissionList pl;
     InterfaceDescriptor permInt = permsModule.getSystemInterface("_tenantPermissions");
     String permIntVer = permInt.getVersion();
     switch (permIntVer) {
       case "1.0":
-        pl = new PermissionList(moduleTo, stripPermissionReplaces(mdTo.getPermissionSets()));
+        if (mdTo == null) {
+          return Future.succeededFuture();
+        }
+        pl = new PermissionList(mdTo.getId(), stripPermissionReplaces(mdTo.getPermissionSets()));
         break;
       case "1.1":
-        pl = new PermissionList(moduleTo, stripPermissionReplaces(
+        if (mdTo == null) {
+          return Future.succeededFuture();
+        }
+        pl = new PermissionList(mdTo.getId(), stripPermissionReplaces(
             mdTo.getExpandedPermissionSets()));
         break;
       case "2.0":
-        pl = new PermissionList(moduleTo, mdTo.getExpandedPermissionSets());
+        if (mdTo != null) {
+          pl = new PermissionList(mdTo.getId(), mdTo.getExpandedPermissionSets());
+        } else if (mdFrom != null) {
+          // attempt an empty list for the module being disabled
+          pl = new PermissionList(mdFrom.getId(), new Permission[0]);
+        } else {
+          return Future.succeededFuture();
+        }
         break;
       default:
         return Future.failedFuture(new OkapiError(ErrorType.USER,
             "Unknown version of _tenantPermissions interface in use " + permIntVer + "."));
     }
     String pljson = Json.encodePrettily(pl);
-    logger.debug("tenantPerms Req: {}", pljson);
+    logger.info("tenantPerms Req: {}", pljson);
     String permPath = "";
     List<RoutingEntry> routingEntries = permInt.getAllRoutingEntries();
     ModuleInstance permInst = null;
@@ -699,8 +713,6 @@ public class TenantManager implements Liveness {
     }
     return proxyService.callSystemInterface(tenant, permInst, pljson, pc).compose(cres -> {
       pc.passOkapiTraceHeaders(cres);
-      logger.debug("tenantPerms request to {} succeeded for module {} and tenant {}",
-          permsModule.getId(), moduleTo, tenant.getId());
       return Future.succeededFuture();
     });
   }

--- a/okapi-core/src/main/java/org/folio/okapi/util/ModuleUtil.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/ModuleUtil.java
@@ -32,7 +32,7 @@ public class ModuleUtil {
     options.setDeploy(getParamBoolean(req, "deploy", false));
     options.setPurge(getParamBoolean(req, "purge", false));
     options.setTenantParameters(req.getParam("tenantParameters"));
-    options.setInvoke(getParamBoolean(req, "invoke", true));
+    options.setInvoke(req.getParam("invoke"));
     options.setAsync(getParamBoolean(req, "async", false));
     options.setIgnoreErrors(getParamBoolean(req, "ignoreErrors", false));
     return options;

--- a/okapi-core/src/main/java/org/folio/okapi/util/TenantInstallOptions.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/TenantInstallOptions.java
@@ -73,10 +73,6 @@ public class TenantInstallOptions {
     invoke = v;
   }
 
-  public String getInvoke() {
-    return invoke;
-  }
-
   /**
    * Check if module is to be invoked during install.
    * @param id module ID.

--- a/okapi-core/src/main/java/org/folio/okapi/util/TenantInstallOptions.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/TenantInstallOptions.java
@@ -9,7 +9,7 @@ public class TenantInstallOptions {
   private String tenantParameters;
   private boolean npmSnapshot = false;
   private boolean depCheck = true;
-  private boolean invoke = true;
+  private String invoke;
   private boolean async = false;
   private boolean ignoreErrors = false;
 
@@ -69,12 +69,27 @@ public class TenantInstallOptions {
     return depCheck;
   }
 
-  public void setInvoke(boolean v) {
+  public void setInvoke(String v) {
     invoke = v;
   }
 
-  public boolean getInvoke() {
+  public String getInvoke() {
     return invoke;
+  }
+
+  /**
+   * Check if module is to be invoked during install.
+   * @param id module ID.
+   * @return whether to invoke the module.
+   */
+  public boolean checkInvoke(String id) {
+    if (invoke == null || "true".equals(invoke)) {
+      return true;
+    }
+    if ("false".equals(invoke)) {
+      return false;
+    }
+    return id.matches(invoke);
   }
 
   public void setAsync(boolean v) {

--- a/okapi-core/src/main/raml/okapi.raml
+++ b/okapi-core/src/main/raml/okapi.raml
@@ -709,8 +709,11 @@ types:
         queryParameters:
           invoke:
             description: |
-              Whether to invoke for tenant init/permissions/purge
-            type: boolean
+              Whether to invoke for tenant init/permissions/purge. Use
+              "true" to invoke, "false" to not invoke. Any other value
+              is a regular expression that is matched against the module ID.
+              If that pattern matches, invoke is performed (same as "true)".
+            type: string
             required: false
             default: true
           purge:
@@ -764,8 +767,12 @@ types:
             This call will eventually be replaced by the 'install' service.
           queryParameters:
             invoke:
-              description: Whether to invoke for tenant init/permissions/purge
-              type: boolean
+              description: |
+                Whether to invoke for tenant init/permissions/purge. Use
+                "true" to invoke, "false" to not invoke. Any other value
+                is a regular expression that is matched against the module ID.
+                If that pattern matches, invoke is performed (same as "true)".
+              type: string
               required: false
               default: true
             purge:
@@ -808,8 +815,12 @@ types:
             This call will eventually be replaced by the 'install' service.
           queryParameters:
             invoke:
-              description: Whether to invoke for tenant init/permissions/purge
-              type: boolean
+              description: |
+                Whether to invoke for tenant init/permissions/purge. Use
+                "true" to invoke, "false" to not invoke. Any other value
+                is a regular expression that is matched against the module ID.
+                If that pattern matches, invoke is performed (same as "true)".
+              type: string
               required: false
               default: true
             purge:
@@ -913,8 +924,12 @@ types:
             required: false
             default: false
           invoke:
-            description: Whether to invoke for tenant init/permissions/purge
-            type: boolean
+            description: |
+              Whether to invoke for tenant init/permissions/purge. Use
+              "true" to invoke, "false" to not invoke. Any other value
+              is a regular expression that is matched against the module ID.
+              If that pattern matches, invoke is performed (same as "true)".
+            type: string
             required: false
             default: true
           npmSnapshot:
@@ -1048,8 +1063,12 @@ types:
             required: false
             default: false
           invoke:
-            description: Whether to invoke for tenant init/permissions/purge
-            type: boolean
+            description: |
+              Whether to invoke for tenant init/permissions/purge. Use
+              "true" to invoke, "false" to not invoke. Any other value
+              is a regular expression that is matched against the module ID.
+              If that pattern matches, invoke is performed (same as "true)".
+            type: string
             required: false
             default: true
           preRelease:

--- a/okapi-core/src/main/raml/okapi.raml
+++ b/okapi-core/src/main/raml/okapi.raml
@@ -715,7 +715,7 @@ types:
               If that pattern matches, invoke is performed (same as "true)".
             type: string
             required: false
-            default: true
+            default: "true"
           purge:
             description: Disabled modules will also be purged.
             type: boolean
@@ -774,7 +774,7 @@ types:
                 If that pattern matches, invoke is performed (same as "true)".
               type: string
               required: false
-              default: true
+              default: "true"
             purge:
               description: Disabled modules will also be purged.
               type: boolean
@@ -822,7 +822,7 @@ types:
                 If that pattern matches, invoke is performed (same as "true)".
               type: string
               required: false
-              default: true
+              default: "true"
             purge:
               description: Disabled modules will also be purged.
               type: boolean
@@ -931,7 +931,7 @@ types:
               If that pattern matches, invoke is performed (same as "true)".
             type: string
             required: false
-            default: true
+            default: "true"
           npmSnapshot:
             description: Whether to include NPM module snapshots (default:true).
             type: boolean
@@ -1070,7 +1070,7 @@ types:
               If that pattern matches, invoke is performed (same as "true)".
             type: string
             required: false
-            default: true
+            default: "true"
           preRelease:
             description: Whether pre-releases should be considered for installation.
             type: boolean

--- a/okapi-core/src/test/java/org/folio/okapi/ModuleTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ModuleTest.java
@@ -1384,8 +1384,8 @@ public class ModuleTest {
         .extract().body().asString();
 
     ar = new JsonArray(body);
-    context.assertEquals(2, ar.size());
-    context.assertEquals(new JsonObject(expPerms), ar.getJsonObject(1));
+    context.assertEquals(3, ar.size());
+    context.assertEquals(new JsonObject(expPerms), ar.getJsonObject(2));
 
     // Check that the tenant interface and the tenantpermission interfaces
     // were called with proper auth tokens and with ModulePermissions

--- a/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
@@ -488,7 +488,7 @@ public class ProxyTest {
         .header("Content-Type", "application/json")
         .body(new JsonArray().add(new JsonObject().put("id", "timer-module-1.0.0").put("action", "enable"))
             .add(new JsonObject().put("id", "request-pre-1.0.0").put("action", "enable")).encode())
-        .post("/_/proxy/tenants/" + tenant + "/install?deploy=true")
+        .post("/_/proxy/tenants/" + tenant + "/install?deploy=true&invoke=true")
         .then().statusCode(200).log().ifValidationFails();
 
     upload(context, tenant, "/echo", 0);

--- a/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
@@ -4374,7 +4374,7 @@ public class ProxyTest {
     }
 
     given()
-        .body(installJson).post("/_/proxy/tenants/testlib/install?invoke=true")
+        .body(installJson).post("/_/proxy/tenants/testlib/install?invoke=.*")
         .then().statusCode(200);
 
     long startTime = System.nanoTime();


### PR DESCRIPTION
1. Removing module sends module with empty list via _tenantPermission so that permissions module may mark those permissions as no longer in use by the module.
2. Config option: `enable_system_auth` to control whether to call auth even if it's enabled. Highly insecure, so this is something that can not be controlled at runtime.
3. install parameter `invoke` is a string rather than a `boolean`. Values `true` and `false` honored as before. Other value is regular expression for controlling which modules to invoke.