### PR TITLE
Use HTTP check for module readiness in deployment OKAPI-984

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
@@ -510,6 +510,7 @@ public class TenantManager implements Liveness {
           enver = emod;
         }
       }
+      logger.info("Checking okapi module for tenant {} md={}", tenantId, moduleTo);
       String moduleFrom = enver;
       if (moduleFrom == null) {
         logger.info("Tenant {} does not have okapi module enabled already", tenantId);

--- a/okapi-core/src/main/java/org/folio/okapi/util/TcpPortWaiting.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/TcpPortWaiting.java
@@ -34,6 +34,7 @@ public class TcpPortWaiting {
   }
 
   private Future<Void> tryConnect(NuProcess process, int count) {
+    // don't use NetClient because container ports are immediately ready, instead check for HTTP response
     WebClientOptions options = new WebClientOptions().setConnectTimeout(MILLISECONDS);
     WebClient c = WebClient.create(vertx, options);
     logger.info("tryConnect() host {} port {} count {}", host, port, count);


### PR DESCRIPTION
Use WebClient on module host+port to see if module is alive, rather
than just TCP socket agsinst host and port. The latter is unreliable
in cases of Containers where exposed port is ready "immediately". This
in turn fixes Okapi startup with mod-permissions being called for
the purpose of upgrading the okapi module for a tenant.