### PR TITLE
Fix Docker deployment fails - part two OKAPI-988

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/managers/DeploymentManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/DeploymentManager.java
@@ -169,7 +169,7 @@ public class DeploymentManager {
       String moduleUrl = "http://" + host + ":" + usePort;
       String moduleHost = host;
       if (descriptor.getDockerImage() != null) {
-        moduleHost = Config.getSysConf("containerHost", "localhost", config);
+        moduleHost = Config.getSysConf("containerHost", host, config);
       }
       ModuleHandle mh = ModuleHandleFactory.create(vertx, descriptor,
           md1.getSrvcId(), ports, moduleHost, usePort, config);

--- a/okapi-core/src/main/java/org/folio/okapi/service/impl/ProcessModuleHandle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/service/impl/ProcessModuleHandle.java
@@ -59,7 +59,7 @@ public class ProcessModuleHandle extends NuAbstractProcessHandler implements Mod
     this.port = port;
     this.ports = ports;
     this.process = null;
-    this.tcpPortWaiting = new TcpPortWaiting(vertx, "localhost", port);
+    this.tcpPortWaiting = new TcpPortWaiting(vertx, id, "localhost", port);
     if (desc.getWaitIterations() != null) {
       tcpPortWaiting.setMaxIterations(desc.getWaitIterations());
     }

--- a/okapi-core/src/main/java/org/folio/okapi/util/TcpPortWaiting.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/TcpPortWaiting.java
@@ -2,7 +2,6 @@ package org.folio.okapi.util;
 
 import com.zaxxer.nuprocess.NuProcess;
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
@@ -16,29 +15,31 @@ public class TcpPortWaiting {
   private static final int MILLISECONDS = 200;
   private final Messages messages = Messages.getInstance();
 
-  private int maxIterations = 30; // x*(x+1) * 0.1 seconds.
+  private int maxIterations = 60; // x*(x+1) * 0.1 seconds.
   private final Vertx vertx;
+  private final String name;
   private final String host;
   private final int port;
 
   /**
    * Create TCP port waiting utility.
    * @param vertx Vert.x handle
+   * @param name name of service or module
    * @param host host for server that utility it waiting for
    * @param port port for server; special value 0 will disable waiting for the server
    */
-  public TcpPortWaiting(Vertx vertx, String host, int port) {
+  public TcpPortWaiting(Vertx vertx, String name, String host, int port) {
     this.vertx = vertx;
     this.host = host;
     this.port = port;
+    this.name = name;
   }
 
   private Future<Void> tryConnect(NuProcess process, int count) {
-    logger.info("tryConnect() host {} port {} count {}", host, port, count);
+    logger.info("Try connect to service {} at {}:{} count {}", name, host, port, count);
     return tryConnect()
-        .onSuccess(res -> {
-          logger.info("Connected to service at host {} port {} count {}", host, port, count);
-        })
+        .onSuccess(res -> logger.info("Connected to service {} at {}:{} count {}",
+            name, host, port, count))
         .recover(cause -> {
           if (count < maxIterations && (process == null || process.isRunning())) {
             return Future.future(promise ->


### PR DESCRIPTION
There were two problems: 1) incorrect default host passed
for checking container readiness; 2) not waiting enough time
by default (changed from 30 to 60).

This PR also makes a different wait-connect message so that
module ID and host:port is shown together.