### PR TITLE
Fix Okapi discovery times out after 5 minutes OKAPI-992

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/managers/DiscoveryManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/DiscoveryManager.java
@@ -61,7 +61,7 @@ public class DiscoveryManager implements NodeListener {
   public Future<Void> init(Vertx vertx) {
     this.vertx = vertx;
     this.httpClient = new FuturisedHttpClient(vertx);
-    deliveryOptions = new DeliveryOptions().setSendTimeout(300000); // 5 minutes
+    deliveryOptions = new DeliveryOptions().setSendTimeout(36000000); // 1 hour
     return deployments.init(vertx, "discoveryList", false).compose(x ->
         nodes.init(vertx, "discoveryNodes", false));
   }


### PR DESCRIPTION
Increase to 1 hour. Blocks https://issues.folio.org/browse/FOLIO-3034
I'm going to merge as soon as one has approved. Just saying.