### PR TITLE
OKAPI-876 Simplify CORS delegate and support preflight too

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
@@ -308,7 +308,7 @@ public class MainVerticle extends AbstractVerticle {
     logger.debug("Setting up routes");
 
     //handle CORS
-    CorsHelper.addCorsHandler(router);
+    CorsHelper.addCorsHandler(router, tenantManager);
 
     if (proxyService != null) {
       router.routeWithRegex("^/_/invoke/tenant/[^/ ]+/.*")

--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -36,9 +36,9 @@ import org.folio.okapi.bean.ModuleDescriptor;
 import org.folio.okapi.bean.ModuleInstance;
 import org.folio.okapi.bean.RoutingEntry;
 import org.folio.okapi.bean.RoutingEntry.ProxyType;
-import org.folio.okapi.bean.Tenant;
 import org.folio.okapi.common.Config;
 import org.folio.okapi.common.ErrorType;
+import org.folio.okapi.common.HttpResponse;
 import org.folio.okapi.common.Messages;
 import org.folio.okapi.common.OkapiClient;
 import org.folio.okapi.common.OkapiLogger;
@@ -565,15 +565,6 @@ public class ProxyService {
                     stream.resume();
                     return; // ctx already set up
                   }
-                  // check delegate CORS and reroute if necessary
-                  if (CorsHelper.checkCorsDelegate(ctx, l)) {
-                    // HTTP code 100 is chosen purely as metrics tag placeholder
-                    MetricsHelper.recordHttpServerProcessingTime(pc.getSample(), pc.getTenant(),
-                        100, pc.getCtx().request().method().name(), pc.getHandlerModuleInstance());
-                    stream.resume();
-                    ctx.reroute(ctx.request().path());
-                    return;
-                  }
 
                   pc.setModList(l);
 
@@ -752,7 +743,7 @@ public class ProxyService {
     }
     clientRequest.headers().setAll(ctx.request().headers());
     clientRequest.headers().remove("Content-Length");
-    final String phase = mi.getRoutingEntry().getPhase();
+    final String phase = mi == null ? "" : mi.getRoutingEntry().getPhase();
     if (!XOkapiHeaders.FILTER_AUTH.equals(phase)) {
       clientRequest.headers().remove(XOkapiHeaders.ADDITIONAL_TOKEN);
     }
@@ -1313,13 +1304,37 @@ public class ProxyService {
         .replaceFirst("^/_/invoke/tenant/([^/ ]+)/.*$", "$1");
     String newPath = origPath
         .replaceFirst("^/_/invoke/tenant/[^/ ]+(/.*$)", "$1");
-    if (qry != null && !qry.isEmpty()) {
-      // vert.x 3.5 clears the parameters on reroute, so we pass them in ctx
-      ctx.data().put(REDIRECTQUERY, qry);
+
+    // delegate CORS for preflight request
+    if (HttpMethod.OPTIONS.equals(ctx.request().method())
+        && ctx.data().containsKey(CorsHelper.DELEGATE_CORS)) {
+      ModuleInstance mi = (ModuleInstance) ctx.data().get(CorsHelper.DELEGATE_CORS_MODULE_INSTANCE);
+      resolveUrls(Arrays.asList(mi));
+      RequestOptions requestOptions = new RequestOptions().setMethod(ctx.request().method())
+          .setAbsoluteURI(mi.getUrl() + newPath);
+      Future<HttpClientRequest> fut = httpClient.request(requestOptions);
+      fut.onFailure(cause -> HttpResponse.responseError(ctx, 500, cause.getMessage()));
+      fut.onSuccess(clientRequest -> {
+        copyHeaders(clientRequest, ctx, null);
+        clientRequest.end();
+        clientRequest.response()
+            .onFailure(cause -> HttpResponse.responseError(ctx, 500, cause.getMessage()))
+            .onSuccess(res -> {
+              ctx.response().setStatusCode(res.statusCode());
+              ctx.response().headers().addAll(res.headers());
+              sanitizeAuthHeaders(ctx.response().headers());
+              ctx.response().end();
+            });
+      });
+    } else {
+      if (qry != null && !qry.isEmpty()) {
+        // vert.x 3.5 clears the parameters on reroute, so we pass them in ctx
+        ctx.data().put(REDIRECTQUERY, qry);
+      }
+      ctx.request().headers().add(XOkapiHeaders.TENANT, tid);
+      logger.debug("redirectProxy: '{}' '{}'", tid, newPath);
+      ctx.reroute(newPath);
     }
-    ctx.request().headers().add(XOkapiHeaders.TENANT, tid);
-    logger.debug("redirectProxy: '{}' '{}'", tid, newPath);
-    ctx.reroute(newPath);
   }
 
   public Future<Void> autoDeploy(ModuleDescriptor md) {

--- a/okapi-core/src/main/java/org/folio/okapi/util/CorsHelper.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/CorsHelper.java
@@ -3,11 +3,12 @@ package org.folio.okapi.util;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.Router;
-import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.CorsHandler;
 import java.util.List;
 import org.folio.okapi.bean.ModuleInstance;
+import org.folio.okapi.common.HttpResponse;
 import org.folio.okapi.common.XOkapiHeaders;
+import org.folio.okapi.managers.TenantManager;
 
 /**
  * Customized CORS handling.
@@ -18,8 +19,8 @@ import org.folio.okapi.common.XOkapiHeaders;
  */
 public class CorsHelper {
 
-  private static final String CHECK_DELEGATE_CORS = "check-delegate-CORS";
-  private static final String DELEGATE_CORS = "delegate-CORS";
+  public static final String DELEGATE_CORS = "delegate-CORS";
+  public static final String DELEGATE_CORS_MODULE_INSTANCE = "delegate-CORS-module-instance";
 
   private CorsHelper() {
   }
@@ -29,57 +30,60 @@ public class CorsHelper {
    *
    * @param router - {@link Router}
    */
-  public static void addCorsHandler(Router router) {
+  public static void addCorsHandler(Router router, final TenantManager tenantManager) {
 
+    // set delegate CORS for special cases
     router.routeWithRegex("^/_/invoke/tenant/[^/ ]+/.*").handler(ctx -> {
-      ctx.data().put(CHECK_DELEGATE_CORS, true);
-      ctx.next();
+      String origPath = ctx.request().path();
+      String tenantId = origPath.replaceFirst("^/_/invoke/tenant/([^/ ]+)/.*$", "$1");
+      String newPath = origPath.replaceFirst("^/_/invoke/tenant/[^/ ]+(/.*$)", "$1");
+      String meth = ctx.request().getHeader(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD);
+      HttpMethod method = meth != null ? HttpMethod.valueOf(meth) : ctx.request().method();
+      String moduleId = ctx.request().getHeader(XOkapiHeaders.MODULE_ID);
+      tenantManager.get(tenantId)
+          .onFailure(cause -> HttpResponse.responseError(ctx, 400, cause.getMessage()))
+          .onSuccess(tenant -> {
+            tenantManager.getModuleCache(tenant)
+                .onFailure(cause -> HttpResponse.responseError(ctx, 500, cause.getMessage()))
+                .onSuccess(moduleCache -> {
+                  List<ModuleInstance> list = moduleCache.lookup(newPath, method, moduleId);
+                  for (ModuleInstance mi : list) {
+                    if (mi.isHandler() && mi.getRoutingEntry().isDelegateCors()) {
+                      ctx.data().put(DELEGATE_CORS, true);
+                      ctx.data().put(DELEGATE_CORS_MODULE_INSTANCE, mi);
+                      break;
+                    }
+                  }
+                  ctx.next();
+                });
+          });
     });
 
+    // check delegate CORS
     router.route().handler(ctx -> {
       if (ctx.data().containsKey(DELEGATE_CORS)) {
         ctx.next();
       } else {
         CorsHandler.create("*")
-          .allowedMethod(HttpMethod.PUT)
-          .allowedMethod(HttpMethod.PATCH)
-          .allowedMethod(HttpMethod.DELETE)
-          .allowedMethod(HttpMethod.GET)
-          .allowedMethod(HttpMethod.POST)
-          .allowedHeader(HttpHeaders.CONTENT_TYPE.toString())
-          .allowedHeader(XOkapiHeaders.TENANT)
-          .allowedHeader(XOkapiHeaders.TOKEN)
-          .allowedHeader(XOkapiHeaders.AUTHORIZATION)
-          .allowedHeader(XOkapiHeaders.REQUEST_ID) //expose response headers
-          .allowedHeader(XOkapiHeaders.MODULE_ID)
-          .exposedHeader(HttpHeaders.LOCATION.toString())
-          .exposedHeader(XOkapiHeaders.TRACE)
-          .exposedHeader(XOkapiHeaders.TOKEN)
-          .exposedHeader(XOkapiHeaders.AUTHORIZATION)
-          .exposedHeader(XOkapiHeaders.REQUEST_ID)
-          .exposedHeader(XOkapiHeaders.MODULE_ID).handle(ctx);
+            .allowedMethod(HttpMethod.PUT)
+            .allowedMethod(HttpMethod.PATCH)
+            .allowedMethod(HttpMethod.DELETE)
+            .allowedMethod(HttpMethod.GET)
+            .allowedMethod(HttpMethod.POST)
+            .allowedHeader(HttpHeaders.CONTENT_TYPE.toString())
+            .allowedHeader(XOkapiHeaders.TENANT)
+            .allowedHeader(XOkapiHeaders.TOKEN)
+            .allowedHeader(XOkapiHeaders.AUTHORIZATION)
+            .allowedHeader(XOkapiHeaders.REQUEST_ID) // expose response headers
+            .allowedHeader(XOkapiHeaders.MODULE_ID)
+            .exposedHeader(HttpHeaders.LOCATION.toString())
+            .exposedHeader(XOkapiHeaders.TRACE)
+            .exposedHeader(XOkapiHeaders.TOKEN)
+            .exposedHeader(XOkapiHeaders.AUTHORIZATION)
+            .exposedHeader(XOkapiHeaders.REQUEST_ID)
+            .exposedHeader(XOkapiHeaders.MODULE_ID).handle(ctx);
       }
     });
-  }
-
-  /**
-   * Check CORS delegate to decide if reroute if necessary.
-   *
-   * @param ctx             - {@link RoutingContext}
-   * @param moduleInstances a list of {@link ModuleInstance}
-   * @return true if reroute if needed, false otherwise
-   */
-  public static boolean checkCorsDelegate(
-      RoutingContext ctx, List<ModuleInstance> moduleInstances) {
-    if (ctx.data().containsKey(CHECK_DELEGATE_CORS)) {
-      ctx.data().remove(CHECK_DELEGATE_CORS);
-      if (moduleInstances.stream().anyMatch(mi ->
-          mi.isHandler() && mi.getRoutingEntry().isDelegateCors())) {
-        ctx.data().put(DELEGATE_CORS, true);
-        return true;
-      }
-    }
-    return false;
   }
 
 }

--- a/okapi-core/src/main/java/org/folio/okapi/util/CorsHelper.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/CorsHelper.java
@@ -33,10 +33,9 @@ public class CorsHelper {
   public static void addCorsHandler(Router router, final TenantManager tenantManager) {
 
     // set delegate CORS for special cases
-    router.routeWithRegex("^/_/invoke/tenant/[^/ ]+/.*").handler(ctx -> {
-      String origPath = ctx.request().path();
-      String tenantId = origPath.replaceFirst("^/_/invoke/tenant/([^/ ]+)/.*$", "$1");
-      String newPath = origPath.replaceFirst("^/_/invoke/tenant/[^/ ]+(/.*$)", "$1");
+    router.routeWithRegex("^/_/invoke/tenant/([^/ ]+)(/.*)").handler(ctx -> {
+      String tenantId = ctx.pathParam("param0");
+      String newPath = ctx.pathParam("param1");
       String meth = ctx.request().getHeader(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD);
       HttpMethod method = meth != null ? HttpMethod.valueOf(meth) : ctx.request().method();
       String moduleId = ctx.request().getHeader(XOkapiHeaders.MODULE_ID);

--- a/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
@@ -290,6 +290,11 @@ public class ProxyTest {
     } else if (HttpMethod.GET.equals(request.method())) {
       response.setStatusCode(200);
       response.end("");
+    } else if (HttpMethod.OPTIONS.equals(request.method()) && p.startsWith("/corscall")) {
+      response.putHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "localhost");
+      response.putHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, "POST");
+      response.setStatusCode(204);
+      response.end();
     } else {
       response.setStatusCode(404);
       response.end("Unsupported method");
@@ -4181,6 +4186,18 @@ public class ProxyTest {
 
     RestAssuredClient c = api.createRestAssured3();
 
+    // no CORS delegate preflight
+    c.given()
+      .header(HttpHeaders.ORIGIN.toString(), "http://localhost")
+      .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD.toString(), HttpMethod.POST.name())
+      .options("/_/invoke/tenant/" + tenant + "/regularcall")
+      .then()
+      .header(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN.toString(), "*")
+      .header(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS.toString(), notNullValue())
+      .header(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS.toString(), notNullValue())
+      .statusCode(204)
+      .log().ifValidationFails();
+
     // no CORS delegate
     c.given()
       .header("Content-Type", "application/json")
@@ -4191,6 +4208,18 @@ public class ProxyTest {
       .then()
       .header(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS.toString(), notNullValue())
       .statusCode(200)
+      .log().ifValidationFails();
+
+    // with CORS delegate preflight
+    c.given()
+      .header(HttpHeaders.ORIGIN.toString(), "http://localhost")
+      .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD.toString(), HttpMethod.POST.name())
+      .options("/_/invoke/tenant/" + tenant + "/corscall")
+      .then()
+      .header(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN.toString(), "localhost")
+      .header(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS.toString(), nullValue())
+      .header(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS.toString(), "POST")
+      .statusCode(204)
       .log().ifValidationFails();
 
     // with CORS delegate


### PR DESCRIPTION
Please see https://issues.folio.org/browse/OKAPI-876. 
- Check CORS delegate just once to be efficient
- Allow preflight/OPTIONS to be delegated too