### PR TITLE
Remove Future from return values

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/util/CorsHelper.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/CorsHelper.java
@@ -42,19 +42,16 @@ public class CorsHelper {
       tenantManager.get(tenantId)
           .onFailure(cause -> HttpResponse.responseError(ctx, 400, cause.getMessage()))
           .onSuccess(tenant -> {
-            tenantManager.getModuleCache(tenant)
-                .onFailure(cause -> HttpResponse.responseError(ctx, 500, cause.getMessage()))
-                .onSuccess(moduleCache -> {
-                  List<ModuleInstance> list = moduleCache.lookup(newPath, method, moduleId);
-                  for (ModuleInstance mi : list) {
-                    if (mi.isHandler() && mi.getRoutingEntry().isDelegateCors()) {
-                      ctx.data().put(DELEGATE_CORS, true);
-                      ctx.data().put(DELEGATE_CORS_MODULE_INSTANCE, mi);
-                      break;
-                    }
-                  }
-                  ctx.next();
-                });
+            ModuleCache moduleCache = tenantManager.getModuleCache(tenant);
+            List<ModuleInstance> list = moduleCache.lookup(newPath, method, moduleId);
+            for (ModuleInstance mi : list) {
+              if (mi.isHandler() && mi.getRoutingEntry().isDelegateCors()) {
+                ctx.data().put(DELEGATE_CORS, true);
+                ctx.data().put(DELEGATE_CORS_MODULE_INSTANCE, mi);
+                break;
+              }
+            }
+            ctx.next();
           });
     });
 


### PR DESCRIPTION
If a method always returns a succeeded Future containing the result
the Future is no needed and should be removed.

Unneccessary Future wrapping bloates the code.