### PR TITLE
Facility to remove obsolete modules OKAPI-1024

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
@@ -263,8 +263,7 @@ public class MainVerticle extends AbstractVerticle {
           logger.debug("Creating the internal Okapi module {} with interface version {}",
               okapiModule, interfaceVersion);
           return moduleManager.createList(Collections.singletonList(md), true, true, true,
-              false, false
-          );
+              false);
         }).compose(x -> checkSuperTenant(okapiModule));
   }
 

--- a/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
@@ -39,6 +39,7 @@ import org.folio.okapi.managers.TenantManager;
 import org.folio.okapi.managers.TimerManager;
 import org.folio.okapi.service.ModuleStore;
 import org.folio.okapi.service.TenantStore;
+import org.folio.okapi.service.impl.ModuleStoreNull;
 import org.folio.okapi.service.impl.Storage;
 import org.folio.okapi.service.impl.Storage.InitMode;
 import org.folio.okapi.service.impl.TenantStoreNull;
@@ -174,7 +175,7 @@ public class MainVerticle extends AbstractVerticle {
       timerManager = new TimerManager(storage.getTimerStore(), false);
       internalModule.withTimerManager(timerManager);
     } else { // not really proxying, except to /_/deployment
-      moduleManager = new ModuleManager(null, true);
+      moduleManager = new ModuleManager(new ModuleStoreNull(), true);
       tenantManager = new TenantManager(moduleManager, new TenantStoreNull(), true);
       discoveryManager.setModuleManager(moduleManager);
       InternalModule internalModule = new InternalModule(
@@ -262,7 +263,7 @@ public class MainVerticle extends AbstractVerticle {
           logger.debug("Creating the internal Okapi module {} with interface version {}",
               okapiModule, interfaceVersion);
           return moduleManager.createList(Collections.singletonList(md), true, true, true,
-              false
+              false, false
           );
         }).compose(x -> checkSuperTenant(okapiModule));
   }

--- a/okapi-core/src/main/java/org/folio/okapi/managers/InternalModule.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/InternalModule.java
@@ -985,7 +985,6 @@ public class InternalModule {
       final boolean check = ModuleUtil.getParamBoolean(params, "check", true);
       final boolean preRelease = ModuleUtil.getParamBoolean(params, "preRelease", true);
       final boolean npmSnapshot = ModuleUtil.getParamBoolean(params, "npmSnapshot", true);
-      final boolean deleteObsolete = ModuleUtil.getParamBoolean(params, "deleteObsolete", false);
       for (ModuleDescriptor md : list) {
         String validerr = md.validate(logger);
         if (!validerr.isEmpty()) {
@@ -993,8 +992,7 @@ public class InternalModule {
           return Future.failedFuture(new OkapiError(ErrorType.USER, validerr));
         }
       }
-      return moduleManager.createList(list, check, preRelease, npmSnapshot, false,
-          deleteObsolete);
+      return moduleManager.createList(list, check, preRelease, npmSnapshot, false);
     } catch (DecodeException ex) {
       return Future.failedFuture(new OkapiError(ErrorType.USER, ex.getMessage()));
     }

--- a/okapi-core/src/main/java/org/folio/okapi/managers/InternalModule.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/InternalModule.java
@@ -967,6 +967,7 @@ public class InternalModule {
       final boolean check = ModuleUtil.getParamBoolean(params, "check", true);
       final boolean preRelease = ModuleUtil.getParamBoolean(params, "preRelease", true);
       final boolean npmSnapshot = ModuleUtil.getParamBoolean(params, "npmSnapshot", true);
+      final boolean deleteObsolete = ModuleUtil.getParamBoolean(params, "deleteObsolete", false);
       for (ModuleDescriptor md : list) {
         String validerr = md.validate(logger);
         if (!validerr.isEmpty()) {
@@ -974,7 +975,8 @@ public class InternalModule {
           return Future.failedFuture(new OkapiError(ErrorType.USER, validerr));
         }
       }
-      return moduleManager.createList(list, check, preRelease, npmSnapshot, false);
+      return moduleManager.createList(list, check, preRelease, npmSnapshot, false,
+          deleteObsolete);
     } catch (DecodeException ex) {
       return Future.failedFuture(new OkapiError(ErrorType.USER, ex.getMessage()));
     }

--- a/okapi-core/src/main/java/org/folio/okapi/managers/InternalModule.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/InternalModule.java
@@ -217,6 +217,12 @@ public class InternalModule {
         + "    \"permissionsRequired\" : [ \"okapi.proxy.modules.post\" ], "
         + "    \"type\" : \"internal\" "
         + "   },"
+        + "   {"
+        + "    \"methods\" :  [ \"POST\" ],"
+        + "    \"pathPattern\" : \"/_/proxy/cleanup/modules\","
+        + "    \"permissionsRequired\" : [ \"okapi.proxy.cleanup.modules\" ], "
+        + "    \"type\" : \"internal\" "
+        + "   },"
         // Proxy service
         + "   {" // proxy, modules
         + "    \"methods\" :  [ \"POST\" ],"
@@ -474,7 +480,12 @@ public class InternalModule {
         + "   \"permissionName\" : \"okapi.proxy.pull.modules.post\", "
         + "   \"displayName\" : \"Okapi - get ModuleDescriptors\", "
         + "   \"description\" : \"Get MDs from another Okapi, maybe a repo\" "
-        + " },"
+        + " }, "
+        + " { "
+        + "   \"permissionName\" : \"okapi.proxy.cleanup.modules\", "
+        + "   \"displayName\" : \"Okapi - clean up obsolete snapshot modules\", "
+        + "   \"description\" : \"Clean up obsolete snapshot modules\" "
+        + " }, "
         + " { "
         + "   \"permissionName\" : \"okapi.proxy.tenants.list\", "
         + "   \"displayName\" : \"Okapi - list tenants\", "
@@ -605,7 +616,8 @@ public class InternalModule {
         + "   \"subPermissions\" : [ "
         + "     \"okapi.proxy.modules.list\", \"okapi.proxy.modules.get\", "
         + "     \"okapi.proxy.modules.post\", \"okapi.proxy.modules.put\", "
-        + "     \"okapi.proxy.modules.delete\", \"okapi.proxy.pull.modules.post\""
+        + "     \"okapi.proxy.modules.delete\", \"okapi.proxy.pull.modules.post\", "
+        + "     \"okapi.proxy.cleanup.modules\""
         + "   ]"
         + " }, "
         + " { "
@@ -997,6 +1009,17 @@ public class InternalModule {
     }
   }
 
+  private Future<String> cleanupModules(ProxyContext pc) {
+    try {
+      MultiMap params = pc.getCtx().request().params();
+      int saveReleases = ModuleUtil.getParamInteger(params, "saveReleases", null);
+      int saveSnapshots = ModuleUtil.getParamInteger(params, "saveSnapshots", null);
+    } catch (DecodeException ex) {
+      return Future.failedFuture(new OkapiError(ErrorType.USER, ex.getMessage()));
+    }
+    return Future.succeededFuture("");
+  }
+
   private Future<String> createModule(ProxyContext pc, String body) {
     try {
       final ModuleDescriptor md = Json.decodeValue(body, ModuleDescriptor.class);
@@ -1250,6 +1273,10 @@ public class InternalModule {
       if (segments[3].equals("import") && n == 5 && segments[4].equals("modules")
           && m.equals(HttpMethod.POST)) {
         return createModules(pc, req);
+      }
+      if (segments[3].equals("cleanup") && n == 5 && segments[4].equals("modules")
+          && m.equals(HttpMethod.POST)) {
+        return cleanupModules(pc);
       }
       if (segments[3].equals("modules")
           && moduleManager != null) {

--- a/okapi-core/src/main/java/org/folio/okapi/managers/InternalModule.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/InternalModule.java
@@ -1012,8 +1012,10 @@ public class InternalModule {
       MultiMap params = pc.getCtx().request().params();
       int saveReleases = ModuleUtil.getParamInteger(params, "saveReleases", null);
       int saveSnapshots = ModuleUtil.getParamInteger(params, "saveSnapshots", null);
+      boolean removeDependencies = ModuleUtil.getParamBoolean(params, "removeDependencies", false);
       return tenantManager.getEnabledModulesAllTenants().compose(inUse ->
-        moduleManager.deleteObsolete(inUse, saveReleases, saveSnapshots).map("")
+          moduleManager.deleteObsolete(inUse, saveReleases, saveSnapshots, removeDependencies)
+              .map("")
       );
     } catch (DecodeException ex) {
       return Future.failedFuture(new OkapiError(ErrorType.USER, ex.getMessage()));

--- a/okapi-core/src/main/java/org/folio/okapi/managers/InternalModule.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/InternalModule.java
@@ -1012,7 +1012,9 @@ public class InternalModule {
       MultiMap params = pc.getCtx().request().params();
       int saveReleases = ModuleUtil.getParamInteger(params, "saveReleases", null);
       int saveSnapshots = ModuleUtil.getParamInteger(params, "saveSnapshots", null);
-      return moduleManager.deleteObsolete(saveReleases, saveSnapshots).map("");
+      return tenantManager.getEnabledModulesAllTenants().compose(inUse ->
+        moduleManager.deleteObsolete(inUse, saveReleases, saveSnapshots).map("")
+      );
     } catch (DecodeException ex) {
       return Future.failedFuture(new OkapiError(ErrorType.USER, ex.getMessage()));
     }

--- a/okapi-core/src/main/java/org/folio/okapi/managers/InternalModule.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/InternalModule.java
@@ -1014,10 +1014,10 @@ public class InternalModule {
       MultiMap params = pc.getCtx().request().params();
       int saveReleases = ModuleUtil.getParamInteger(params, "saveReleases", null);
       int saveSnapshots = ModuleUtil.getParamInteger(params, "saveSnapshots", null);
+      return moduleManager.deleteObsolete(saveReleases, saveSnapshots).map("");
     } catch (DecodeException ex) {
       return Future.failedFuture(new OkapiError(ErrorType.USER, ex.getMessage()));
     }
-    return Future.succeededFuture("");
   }
 
   private Future<String> createModule(ProxyContext pc, String body) {

--- a/okapi-core/src/main/java/org/folio/okapi/managers/ModuleManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ModuleManager.java
@@ -167,8 +167,9 @@ public class ModuleManager {
   public Future<Void> delete(String id) {
     return modules.getAll()
         .compose(ares -> deleteCheckDep(id, ares))
-        .compose(res -> moduleStore.delete(id).mapEmpty())
-        .compose(res -> deleteInternal(id).mapEmpty());
+        .compose(res -> moduleStore.delete(id))
+        .compose(res -> deleteInternal(id))
+        .mapEmpty();
   }
 
   private Future<Void> deleteCheckDep(String id, LinkedHashMap<String, ModuleDescriptor> mods) {

--- a/okapi-core/src/main/java/org/folio/okapi/managers/ModuleManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ModuleManager.java
@@ -140,8 +140,8 @@ public class ModuleManager {
           }
           Future<Void> future = Future.succeededFuture();
           for (ModuleDescriptor md: obsolete) {
-            future = future.compose(x -> moduleStore.delete(md.getId()).mapEmpty());
-            future = future.compose(x -> modules.remove(md.getId()).mapEmpty());
+            future = future.compose(x -> moduleStore.delete(md.getId()))
+                           .compose(x -> modules.remove(md.getId())).mapEmpty();
           }
           return future;
         });

--- a/okapi-core/src/main/java/org/folio/okapi/managers/ModuleManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ModuleManager.java
@@ -130,7 +130,20 @@ public class ModuleManager {
         .compose(ares -> {
           List<ModuleDescriptor> newList = new LinkedList<>(ares.values());
           Future<Void> future = Future.succeededFuture();
-          for (ModuleDescriptor md: ModuleUtil.getObsolete(newList)) {
+          for (ModuleDescriptor md: ModuleUtil.getObsolete(newList, 1, 0)) {
+            future = future.compose(x -> moduleStore.delete(md.getId()).mapEmpty());
+            future = future.compose(x -> modules.remove(md.getId()).mapEmpty());
+          }
+          return future;
+        });
+  }
+
+  Future<Void> deleteObsolete(int saveReleases, int saveSnapshots) {
+    return modules.getAll()
+        .compose(ares -> {
+          List<ModuleDescriptor> newList = new LinkedList<>(ares.values());
+          Future<Void> future = Future.succeededFuture();
+          for (ModuleDescriptor md: ModuleUtil.getObsolete(newList, saveReleases, saveSnapshots)) {
             future = future.compose(x -> moduleStore.delete(md.getId()).mapEmpty());
             future = future.compose(x -> modules.remove(md.getId()).mapEmpty());
           }

--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -931,25 +931,29 @@ public class ProxyService {
     RoutingContext ctx = pc.getCtx();
 
     clientsEnd(bcontent, clientRequestList);
-    internalModule.internalService(req, pc).onFailure(cause ->
-        pc.responseError(OkapiError.getType(cause), cause)
-    ).onSuccess(resp -> {
-      int statusCode = pc.getCtx().response().getStatusCode();
-      if (statusCode == 200 && resp.isEmpty()) {
-        // Say "no content", if there isn't any
-        statusCode = 204;
-        pc.getCtx().response().setStatusCode(statusCode);
-      }
-      Buffer respBuf = Buffer.buffer(resp);
-      pc.setHandlerRes(statusCode);
-      makeTraceHeader(mi, statusCode, pc);
-      if (it.hasNext()) { // carry on with the pipeline
-        proxyR(it, pc, null, respBuf, new LinkedList<>());
-      } else { // produce a result
-        pc.closeTimer();
-        ctx.response().end(respBuf);
-      }
-    });
+    try {
+      internalModule.internalService(req, pc)
+          .onFailure(cause -> pc.responseError(OkapiError.getType(cause), cause))
+          .onSuccess(resp -> {
+            int statusCode = pc.getCtx().response().getStatusCode();
+            if (statusCode == 200 && resp.isEmpty()) {
+              // Say "no content", if there isn't any
+              statusCode = 204;
+              pc.getCtx().response().setStatusCode(statusCode);
+            }
+            Buffer respBuf = Buffer.buffer(resp);
+            pc.setHandlerRes(statusCode);
+            makeTraceHeader(mi, statusCode, pc);
+            if (it.hasNext()) { // carry on with the pipeline
+              proxyR(it, pc, null, respBuf, new LinkedList<>());
+            } else { // produce a result
+              pc.closeTimer();
+              ctx.response().end(respBuf);
+            }
+          });
+    } catch (Exception e) {
+      pc.responseError(ErrorType.INTERNAL, e);
+    }
   }
 
   private void proxyR(Iterator<ModuleInstance> it,
@@ -1017,7 +1021,12 @@ public class ProxyService {
           proxyRedirect(it, pc, stream, bcontent, clientRequestList, mi);
           break;
         case INTERNAL:
-          proxyInternal(it, pc, stream, bcontent, clientRequestList, mi);
+          try {
+            proxyInternal(it, pc, stream, bcontent, clientRequestList, mi);
+          } catch (Exception e) {
+            logger.error("AD: exception {}", e.getMessage(), e);
+            throw e;
+          }
           break;
         case REQUEST_RESPONSE_1_0:
           proxyRequestResponse10(it, pc, stream, bcontent, clientRequestList, mi);

--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -1021,12 +1021,7 @@ public class ProxyService {
           proxyRedirect(it, pc, stream, bcontent, clientRequestList, mi);
           break;
         case INTERNAL:
-          try {
-            proxyInternal(it, pc, stream, bcontent, clientRequestList, mi);
-          } catch (Exception e) {
-            logger.error("AD: exception {}", e.getMessage(), e);
-            throw e;
-          }
+          proxyInternal(it, pc, stream, bcontent, clientRequestList, mi);
           break;
         case REQUEST_RESPONSE_1_0:
           proxyRequestResponse10(it, pc, stream, bcontent, clientRequestList, mi);

--- a/okapi-core/src/main/java/org/folio/okapi/managers/PullManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/PullManager.java
@@ -169,8 +169,7 @@ public class PullManager {
         }
       }
       logger.info("pull: {} MDs to insert", mustAddList.size());
-      return moduleManager.createList(mustAddList, true, true,true,
-          true, false)
+      return moduleManager.createList(mustAddList, true, true,true, true)
           .map(briefList);
     });
   }

--- a/okapi-core/src/main/java/org/folio/okapi/managers/PullManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/PullManager.java
@@ -169,7 +169,8 @@ public class PullManager {
         }
       }
       logger.info("pull: {} MDs to insert", mustAddList.size());
-      return moduleManager.createList(mustAddList, true, true,true, true)
+      return moduleManager.createList(mustAddList, true, true,true,
+          true, false)
           .map(briefList);
     });
   }

--- a/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
@@ -1124,6 +1124,28 @@ public class TenantManager implements Liveness {
   }
 
   /**
+   * Return list of modules by all tenants.
+   * @return map with key of module ID, and value of one tenant using it (there could be others).
+   */
+  public Future<Map<String, String>> getEnabledModulesAllTenants() {
+    return tenants.getKeys().compose(kres -> {
+      Map<String,String> enabled = new HashMap<>();
+      Future<Void> future = Future.succeededFuture();
+      for (String tid : kres) {
+        future = future.compose(x -> tenants.get(tid)
+            .compose(t -> {
+              for (String m : t.getEnabled().keySet()) {
+                enabled.put(m, t.getId());
+              }
+              return Future.succeededFuture();
+            })
+        );
+      }
+      return future.map(x -> enabled);
+    });
+  }
+
+  /**
    * Load tenants from the store into the shared memory map.
    *
    * @return fut future

--- a/okapi-core/src/main/java/org/folio/okapi/service/ModuleStore.java
+++ b/okapi-core/src/main/java/org/folio/okapi/service/ModuleStore.java
@@ -10,8 +10,6 @@ public interface ModuleStore {
 
   Future<List<ModuleDescriptor>> getAll();
 
-  Future<Void> insert(ModuleDescriptor md);
-
   Future<Void> insert(List<ModuleDescriptor> mds);
 
   Future<Void> init(boolean reset);

--- a/okapi-core/src/main/java/org/folio/okapi/service/impl/ModuleStoreMongo.java
+++ b/okapi-core/src/main/java/org/folio/okapi/service/impl/ModuleStoreMongo.java
@@ -25,11 +25,6 @@ public class ModuleStoreMongo implements ModuleStore {
   }
 
   @Override
-  public Future<Void> insert(ModuleDescriptor md) {
-    return util.insert(md, md.getId());
-  }
-
-  @Override
   public Future<Void> insert(List<ModuleDescriptor> mds) {
     return util.insertBatch(mds);
   }

--- a/okapi-core/src/main/java/org/folio/okapi/service/impl/ModuleStoreNull.java
+++ b/okapi-core/src/main/java/org/folio/okapi/service/impl/ModuleStoreNull.java
@@ -1,0 +1,29 @@
+package org.folio.okapi.service.impl;
+
+import io.vertx.core.Future;
+import java.util.Collections;
+import java.util.List;
+import org.folio.okapi.bean.ModuleDescriptor;
+import org.folio.okapi.service.ModuleStore;
+
+public class ModuleStoreNull implements ModuleStore {
+  @Override
+  public Future<Boolean> delete(String id) {
+    return Future.succeededFuture(Boolean.TRUE);
+  }
+
+  @Override
+  public Future<List<ModuleDescriptor>> getAll() {
+    return Future.succeededFuture(Collections.emptyList());
+  }
+
+  @Override
+  public Future<Void> insert(List<ModuleDescriptor> mds) {
+    return Future.succeededFuture();
+  }
+
+  @Override
+  public Future<Void> init(boolean reset) {
+    return Future.succeededFuture();
+  }
+}

--- a/okapi-core/src/main/java/org/folio/okapi/service/impl/ModuleStorePostgres.java
+++ b/okapi-core/src/main/java/org/folio/okapi/service/impl/ModuleStorePostgres.java
@@ -23,11 +23,6 @@ public class ModuleStorePostgres implements ModuleStore {
   }
 
   @Override
-  public Future<Void> insert(ModuleDescriptor md) {
-    return pgTable.insert(md);
-  }
-
-  @Override
   public Future<Void> insert(List<ModuleDescriptor> mds) {
     return pgTable.insertBatch(mds);
   }

--- a/okapi-core/src/main/java/org/folio/okapi/service/impl/Storage.java
+++ b/okapi-core/src/main/java/org/folio/okapi/service/impl/Storage.java
@@ -49,7 +49,7 @@ public class Storage {
         timerStore = new TimerStoreMongo(mongo.getClient());
         break;
       case "inmemory":
-        moduleStore = null;
+        moduleStore = new ModuleStoreNull();
         tenantStore = new TenantStoreNull();
         deploymentStore = new DeploymentStoreNull();
         envStore = new EnvStoreNull();
@@ -96,12 +96,7 @@ public class Storage {
         .compose(res -> deploymentStore.init(reset))
         .compose(res -> tenantStore.init(reset))
         .compose(res -> timerStore.init(reset))
-        .compose(res -> {
-          if (moduleStore == null) {
-            return Future.succeededFuture();
-          }
-          return moduleStore.init(reset);
-        });
+        .compose(res -> moduleStore.init(reset));
   }
 
   public ModuleStore getModuleStore() {

--- a/okapi-core/src/main/java/org/folio/okapi/util/DepResolution.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/DepResolution.java
@@ -174,7 +174,7 @@ public final class DepResolution {
     if (list.isEmpty()) {
       return "";
     } else {
-      return String.join(". ", list);
+      return String.join("\n", list);
     }
   }
 

--- a/okapi-core/src/main/java/org/folio/okapi/util/ModuleUtil.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/ModuleUtil.java
@@ -5,7 +5,6 @@ import io.vertx.core.json.DecodeException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import org.folio.okapi.bean.InterfaceDescriptor;
 import org.folio.okapi.bean.ModuleDescriptor;
@@ -195,7 +194,7 @@ public final class ModuleUtil {
    * Return list of obsolete modules (for clean up).
    * <p>A module is considered a snapshot if it's part of earlier releases than saveReleases
    * *and* it is earlier than the latest saveSnapshots in that release</p>
-   * @param mdl list of modules to consider.
+   * @param mdl list of modules to consider - will be modified.
    * @param saveReleases number of latest non-snapshot releases that are preserved,
    * @param saveSnapshots number of latest snapshots releases that are preserved.
    * @return list of obsolete modules.
@@ -204,7 +203,7 @@ public final class ModuleUtil {
                                                    int saveReleases, int saveSnapshots) {
     mdl.sort(Collections.reverseOrder());
     Iterator<ModuleDescriptor> it = mdl.listIterator();
-    List<ModuleDescriptor> obsoleteList = new LinkedList<>();
+    List<ModuleDescriptor> obsoleteList = new ArrayList<>();
     ModuleId idPrev = null;
     int numberReleases = 0;
     int numberSnapshots = 0;

--- a/okapi-core/src/main/java/org/folio/okapi/util/ModuleUtil.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/ModuleUtil.java
@@ -58,6 +58,28 @@ public final class ModuleUtil {
     throw new DecodeException("Bad boolean for parameter " + name + ": " + v);
   }
 
+  /**
+   * Lookup integer query parameter in HTTP request.
+   * @param params HTTP server request parameters
+   * @param name name of query parameter
+   * @param defValue default value if omitted (or null if the parameter is mandatory)
+   * @return integer value
+   */
+  public static int getParamInteger(MultiMap params, String name, Integer defValue) {
+    String v = params.get(name);
+    if (v == null) {
+      if (defValue == null) {
+        throw new DecodeException("Missing value for parameter '" + name + "'");
+      }
+      return defValue;
+    }
+    try {
+      return Integer.parseInt(v);
+    } catch (NumberFormatException e) {
+      throw new DecodeException("Bad integer for parameter '" + name + "'");
+    }
+  }
+
   private static boolean interfaceCheck(
       InterfaceDescriptor[] interfaces, String interfaceStr, String scope) {
     if (interfaceStr == null) {

--- a/okapi-core/src/main/java/org/folio/okapi/util/ModuleUtil.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/ModuleUtil.java
@@ -5,6 +5,7 @@ import io.vertx.core.json.DecodeException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import org.folio.okapi.bean.InterfaceDescriptor;
 import org.folio.okapi.bean.ModuleDescriptor;
@@ -167,4 +168,37 @@ public final class ModuleUtil {
     }
     return str.toString();
   }
+
+  /**
+   * Return list of obsolete modules.
+   *
+   * <p>A module is considered obsolete if it's a snapshot *and* there is a higher
+   * non-snapshot version.
+   * @param mdl list of modules to consider
+   * @return list of obsolete modules.
+   */
+  public static List<ModuleDescriptor> getObsolete(List<ModuleDescriptor> mdl) {
+    mdl.sort(Collections.reverseOrder());
+    Iterator<ModuleDescriptor> it = mdl.listIterator();
+    List<ModuleDescriptor> obsoleteList = new LinkedList<>();
+    String product = "";
+    boolean removeSnapshotMode = false;
+    while (it.hasNext()) {
+      ModuleDescriptor md = it.next();
+      ModuleId id = new ModuleId(md.getId());
+      if (!product.equals(id.getProduct())) {
+        product = id.getProduct();
+        removeSnapshotMode = false;
+      }
+      if (id.hasPreRelease() || id.hasNpmSnapshot()) {
+        if (removeSnapshotMode) {
+          obsoleteList.add(md);
+        }
+      } else {
+        removeSnapshotMode = true;
+      }
+    }
+    return obsoleteList;
+  }
+
 }

--- a/okapi-core/src/main/java/org/folio/okapi/util/ModuleUtil.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/ModuleUtil.java
@@ -216,10 +216,9 @@ public final class ModuleUtil {
         numberReleases = 0;
         numberSnapshots = 0;
       }
-      if (id.hasPreRelease() || id.hasNpmSnapshot()) {
-        if (numberReleases >= saveReleases && numberSnapshots >= saveSnapshots) {
-          obsoleteList.add(md);
-        }
+      if ((id.hasPreRelease() || id.hasNpmSnapshot())
+          && numberReleases >= saveReleases && numberSnapshots >= saveSnapshots) {
+        obsoleteList.add(md);
       }
       if (diff >= -1 || id.hasNpmSnapshot()) {
         numberSnapshots++;
@@ -231,5 +230,4 @@ public final class ModuleUtil {
     }
     return obsoleteList;
   }
-
 }

--- a/okapi-core/src/main/raml/okapi.raml
+++ b/okapi-core/src/main/raml/okapi.raml
@@ -391,6 +391,42 @@ types:
         body:
           text/plain:
 
+/_/proxy/cleanup/modules:
+  description: Proxy modules service, clean up obsolete snapshot modules
+  post:
+    description: Remove module snapshot modules descriptors that are obsolete. A module is
+      considered obsolete if it is part of a release that is earlier than N latest releases (saveReleases) and
+      not part of the M latest snapshots in that release.
+    queryParameters:
+      saveReleases:
+        description: The latest releases where snapshots are never considered obsolete
+        type: integer
+        required: true
+      saveSnapshots:
+        description: The latest snapshots that are never considered obsolete (preserved)
+        type: integer
+        required: true
+    body:
+      application/json:
+    responses:
+      204:
+        description: OK
+        headers:
+          X-Okapi-Trace:
+            description: Okapi trace and timing
+      400:
+        description: Bad Request
+        body:
+          text/plain:
+      404:
+        description: Not Found
+        body:
+          text/plain:
+      500:
+        description: Server Error
+        body:
+          text/plain:
+
 /_/proxy/modules:
   description: Proxy modules service
   post:

--- a/okapi-core/src/main/raml/okapi.raml
+++ b/okapi-core/src/main/raml/okapi.raml
@@ -354,6 +354,11 @@ types:
         type: boolean
         required: false
         default: true
+      deleteObsolete:
+        description: Whether to remove obsolete modules as well.
+        type: boolean
+        required: false
+        default: false
       preRelease:
         description: Whether to allow pre-release modules in dependency check
         type: boolean
@@ -397,6 +402,11 @@ types:
         type: boolean
         required: false
         default: true
+      deleteObsolete:
+        description: Whether to remove obsolete modules as well
+        type: boolean
+        required: false
+        default: false
       preRelease:
         description: Whether to allow pre-release modules in dependency check
         type: boolean

--- a/okapi-core/src/main/raml/okapi.raml
+++ b/okapi-core/src/main/raml/okapi.raml
@@ -550,6 +550,10 @@ types:
           headers:
             X-Okapi-Trace:
               description: Okapi trace and timing
+        400:
+          description: Bad Request
+          body:
+            text/plain:
         404:
           description: Not Found
           body:

--- a/okapi-core/src/main/raml/okapi.raml
+++ b/okapi-core/src/main/raml/okapi.raml
@@ -401,8 +401,6 @@ types:
         description: The number of latest snapshots that are never considered obsolete (preserved)
         type: integer
         required: true
-    body:
-      application/json:
     responses:
       204:
         description: OK

--- a/okapi-core/src/main/raml/okapi.raml
+++ b/okapi-core/src/main/raml/okapi.raml
@@ -354,11 +354,6 @@ types:
         type: boolean
         required: false
         default: true
-      deleteObsolete:
-        description: Whether to remove obsolete modules as well.
-        type: boolean
-        required: false
-        default: false
       preRelease:
         description: Whether to allow pre-release modules in dependency check
         type: boolean
@@ -438,11 +433,6 @@ types:
         type: boolean
         required: false
         default: true
-      deleteObsolete:
-        description: Whether to remove obsolete modules as well
-        type: boolean
-        required: false
-        default: false
       preRelease:
         description: Whether to allow pre-release modules in dependency check
         type: boolean

--- a/okapi-core/src/main/raml/okapi.raml
+++ b/okapi-core/src/main/raml/okapi.raml
@@ -393,6 +393,11 @@ types:
       considered obsolete if it is part of a release that is earlier than N latest releases (saveReleases) and
       not part of the M latest snapshots in that release.
     queryParameters:
+      removeDependencies:
+        description: Force removal of modules that depend on obsolete snapshots
+        type: boolean
+        required: false
+        default: false
       saveReleases:
         description: The number of latest releases where snapshots are never considered obsolete
         type: integer

--- a/okapi-core/src/main/raml/okapi.raml
+++ b/okapi-core/src/main/raml/okapi.raml
@@ -394,11 +394,11 @@ types:
       not part of the M latest snapshots in that release.
     queryParameters:
       saveReleases:
-        description: The latest releases where snapshots are never considered obsolete
+        description: The number of latest releases where snapshots are never considered obsolete
         type: integer
         required: true
       saveSnapshots:
-        description: The latest snapshots that are never considered obsolete (preserved)
+        description: The number of latest snapshots that are never considered obsolete (preserved)
         type: integer
         required: true
     body:

--- a/okapi-core/src/main/resources/infra-messages/Messages_en.properties
+++ b/okapi-core/src/main/resources/infra-messages/Messages_en.properties
@@ -25,6 +25,7 @@
 10209=Cannot remove module {0} which is explicitly given
 10210=interface {0} required by module {1} is provided by multiple products: {2}
 10211=interface {0} required by module {1} not found
+10212=clean up modules: {0}
 
 #ProxyContent
 #--this error description could be improved--#

--- a/okapi-core/src/test/java/org/folio/okapi/ModuleTenantsTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ModuleTenantsTest.java
@@ -1546,7 +1546,7 @@ public class ModuleTenantsTest {
     Assert.assertTrue(
       "raml: " + c.getLastReport().toString(),
       c.getLastReport().isEmpty());
-    Assert.assertEquals("Missing dependency: basic-module-1.0.0-alpha requires unknown1: 1.0" + ". "
+    Assert.assertEquals("Missing dependency: basic-module-1.0.0-alpha requires unknown1: 1.0" + "\n"
       + "Missing dependency: basic-module-1.0.0-alpha requires unknown2: 2.0", r.getBody().asString());
     c = api.createRestAssured3();
     r = c.given()

--- a/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
@@ -100,7 +100,7 @@ public class ProxyTest {
 
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {
-    api = RamlLoaders.fromFile("src/main/raml").load("okapi.raml");
+    api = RamlLoaders.fromFile("src/main/raml").load("okapi.raml").failFast();
     RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
   }
 
@@ -544,7 +544,6 @@ public class ProxyTest {
 
   @Test
   public void test1(TestContext context) {
-    RestAssuredClient c;
     Response r;
     final String okapiTenant = "roskilde";
 
@@ -554,15 +553,11 @@ public class ProxyTest {
       + "  \"name\" : \"" + okapiTenant + "\"," + LS
       + "  \"description\" : \"Roskilde bibliotek\"" + LS
       + "}";
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docTenantRoskilde).post("/_/proxy/tenants")
       .then().statusCode(201)
       .body(equalTo(docTenantRoskilde));
-    Assert.assertTrue(
-      "raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     final String docBasic_1_0_0 = "{" + LS
       + "  \"id\" : \"basic-module-1.0.0\"," + LS
@@ -604,28 +599,19 @@ public class ProxyTest {
       + "\"java -Dport=%p -jar ../okapi-test-module/target/okapi-test-module-fat.jar\"" + LS
       + "  }" + LS
       + "}";
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docBasic_1_0_0).post("/_/proxy/modules").then().statusCode(201);
-    Assert.assertTrue(
-      "raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     /* missing action so this will fail */
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body("[ {\"id\" : \"basic-module-1.0.0\"} ]")
       .post("/_/proxy/tenants/" + okapiTenant + "/install?deploy=true")
       .then().statusCode(400)
       .body(equalTo("Missing action for id basic-module-1.0.0"));
-    Assert.assertTrue(
-      "raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body("[ {\"id\" : \"basic-module-1.0.0\", \"action\" : \"enable\"} ]")
       .post("/_/proxy/tenants/" + okapiTenant + "/install?deploy=true")
@@ -634,12 +620,8 @@ public class ProxyTest {
         + "  \"id\" : \"basic-module-1.0.0\"," + LS
         + "  \"action\" : \"enable\"" + LS
         + "} ]"));
-    Assert.assertTrue(
-      "raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    r = c.given()
+    r = given()
       .header("X-Okapi-Tenant", okapiTenant)
       .header("X-all-headers", "B")
       .get("/testb/hugo")
@@ -647,8 +629,7 @@ public class ProxyTest {
       .extract().response();
     Assert.assertTrue(r.body().asString().contains("X-Okapi-Match-Path-Pattern:/testb/{id}"));
 
-    c = api.createRestAssured3();
-    r = c.given()
+    r = given()
       .header("X-Okapi-Tenant", okapiTenant)
       .header("X-all-headers", "B")
       .get("/testb/client_id")
@@ -656,8 +637,7 @@ public class ProxyTest {
       .extract().response();
     Assert.assertTrue(r.body().asString().contains("X-Okapi-Match-Path-Pattern:/testb/client_id"));
 
-    c = api.createRestAssured3();
-    r = c.given()
+    r = given()
         .header("X-Okapi-Tenant", okapiTenant)
         .header("X-all-headers", "B")
         .get("/testb/client_id%2Fx")
@@ -667,8 +647,7 @@ public class ProxyTest {
 
     upload(context, okapiTenant, "/testb/client_id", 6);
 
-    c = api.createRestAssured3();
-    c.given()
+    given()
         .header("X-Okapi-Tenant", okapiTenant)
         .get("/testb/client_id/x")
         .then().statusCode(404);
@@ -687,7 +666,6 @@ public class ProxyTest {
 
   @Test
   public void testAdditionalToken(TestContext context) {
-    RestAssuredClient c;
     Response r;
     final String okapiTenant = "roskilde";
 
@@ -697,15 +675,11 @@ public class ProxyTest {
       + "  \"name\" : \"" + okapiTenant + "\"," + LS
       + "  \"description\" : \"Roskilde bibliotek\"" + LS
       + "}";
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docTenantRoskilde).post("/_/proxy/tenants")
       .then().statusCode(201)
       .body(equalTo(docTenantRoskilde));
-    Assert.assertTrue(
-      "raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     final String testAuthJar = "../okapi-test-auth-module/target/okapi-test-auth-module-fat.jar";
     final String docAuthModule = "{" + LS
@@ -735,14 +709,10 @@ public class ProxyTest {
       + "  }" + LS
       + "}";
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docAuthModule).post("/_/proxy/modules")
         .then().statusCode(201);
-    Assert.assertTrue(
-      "raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     final String docBasic_1_0_0 = "{" + LS
       + "  \"id\" : \"basic-module-1.0.0\"," + LS
@@ -775,16 +745,11 @@ public class ProxyTest {
       + "\"java -Dport=%p -jar ../okapi-test-module/target/okapi-test-module-fat.jar\"" + LS
       + "  }" + LS
       + "}";
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docBasic_1_0_0).post("/_/proxy/modules").then().statusCode(201);
-    Assert.assertTrue(
-      "raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body("["
         + " {\"id\" : \"basic-module-1.0.0\", \"action\" : \"enable\"},"
@@ -799,22 +764,18 @@ public class ProxyTest {
         + "  \"id\" : \"auth-module-1.0.0\"," + LS
         + "  \"action\" : \"enable\"" + LS
         + "} ]"));
-    Assert.assertTrue(
-      "raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     final String docLogin = "{" + LS
       + "  \"tenant\" : \"" + okapiTenant + "\"," + LS
       + "  \"username\" : \"peter\"," + LS
       + "  \"password\" : \"peter-password\"" + LS
       + "}";
-    final String okapiToken = c.given().header("Content-Type", "application/json").body(docLogin)
+    final String okapiToken = given().header("Content-Type", "application/json").body(docLogin)
       .header("X-Okapi-Tenant", okapiTenant).post("/authn/login")
       .then().statusCode(200).extract().header("X-Okapi-Token");
 
     // tenant but no token
-    c = api.createRestAssured3();
-    r = c.given()
+    r = given()
       .header("X-Okapi-Tenant", okapiTenant)
       .get("/testb/hugo")
       .then().statusCode(200)
@@ -822,16 +783,14 @@ public class ProxyTest {
     Assert.assertEquals("It works", r.getBody().asString());
 
     // token with implied tenant
-    c = api.createRestAssured3();
-    r = c.given()
+    r = given()
       .header("X-Okapi-Token", okapiToken)
       .get("/testb/hugo")
       .then().statusCode(200)
       .extract().response();
     Assert.assertEquals("It works", r.getBody().asString());
 
-    c = api.createRestAssured3();
-    r = c.given()
+    r = given()
       .header("X-all-headers", "B")
       .header("X-Okapi-Token", okapiToken)
       .header("X-Okapi-Additional-Token", "dummyJwt")
@@ -843,8 +802,7 @@ public class ProxyTest {
     // test module must NOT receive the X-Okapi-Additional-Token
     Assert.assertTrue(!b.contains("X-Okapi-Additional-Token"));
 
-    c = api.createRestAssured3();
-    c.given()
+    given()
       .header("X-all-headers", "B")
       .header("X-Okapi-Token", okapiToken)
       .header("X-Okapi-Additional-Token", "nomatch")
@@ -856,60 +814,40 @@ public class ProxyTest {
   public void testProxy(TestContext context) {
     final String okapiTenant = "roskilde";
 
-    RestAssuredClient c;
     Response r;
-
     String nodeListDoc = "[ {" + LS
       + "  \"nodeId\" : \"localhost\"," + LS
       + "  \"url\" : \"http://localhost:9230\"" + LS
       + "} ]";
 
-    c = api.createRestAssured3();
-    c.given().get("/_/discovery/nodes").then().statusCode(200)
+    api.createRestAssured3().given().get("/_/discovery/nodes").then().statusCode(200)
       .body(equalTo(nodeListDoc));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given().get("/_/discovery/nodes/gyf").then().statusCode(404);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    api.createRestAssured3().given().get("/_/discovery/nodes/gyf").then().statusCode(404);
 
-    c = api.createRestAssured3();
-    c.given().get("/_/discovery/nodes/localhost").then().statusCode(200);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    api.createRestAssured3().given().get("/_/discovery/nodes/localhost").then().statusCode(200);
 
-    c = api.createRestAssured3();
-    c.given()
+    given()
       .header("Content-Type", "application/json")
       .body("{ }").post("/_/xyz").then().statusCode(404);
-    Assert.assertEquals("RamlReport{requestViolations=[Resource '/_/xyz' is not defined], "
-      + "responseViolations=[], validationViolations=[]}",
-      c.getLastReport().toString());
 
     final String badDoc = "{" + LS
       + "  \"instId\" : \"BAD\"," + LS // the comma here makes it bad json!
       + "}";
-    c = api.createRestAssured3();
-    c.given()
+    given()
       .header("Content-Type", "application/json")
       .body(badDoc).post("/_/deployment/modules")
       .then().statusCode(400);
 
-    c = api.createRestAssured3();
-    c.given()
+    given()
       .header("Content-Type", "application/json")
       .body("{}").post("/_/deployment/modules")
       .then().statusCode(400);
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body("{\"srvcId\" : \"foo\"}").post("/_/deployment/modules")
       .then().statusCode(400);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     final String docUnknownJar = "{" + LS
       + "  \"srvcId\" : \"auth-1\"," + LS
@@ -919,14 +857,11 @@ public class ProxyTest {
       + "  }" + LS
       + "}";
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docUnknownJar).post("/_/deployment/modules")
       .then()
       .statusCode(400);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     final String docAuthDeployment = "{" + LS
       + "  \"srvcId\" : \"auth-1\"," + LS
@@ -936,22 +871,16 @@ public class ProxyTest {
       + "  }" + LS
       + "}";
 
-    c = api.createRestAssured3();
-    r = c.given()
+    r = api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docAuthDeployment).post("/_/deployment/modules")
       .then()
       .statusCode(201)
       .extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
     String locationAuthDeployment = r.getHeader("Location");
 
-    c = api.createRestAssured3();
-    String docAuthDiscovery = c.given().get(locationAuthDeployment)
+    String docAuthDiscovery = api.createRestAssured3().given().get(locationAuthDeployment)
       .then().statusCode(200).extract().body().asString();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     final String docAuthModule = "{" + LS
       + "  \"id\" : \"auth-1\"," + LS
@@ -981,19 +910,15 @@ public class ProxyTest {
     // Check that we fail on unknown route types
     final String docBadTypeModule
       = docAuthModule.replaceAll("request-response", "UNKNOWN-ROUTE-TYPE");
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docBadTypeModule).post("/_/proxy/modules")
       .then().statusCode(400);
 
-    c = api.createRestAssured3();
-    r = c.given()
+    r = api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docAuthModule).post("/_/proxy/modules").then().statusCode(201)
       .extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
     final String locationAuthModule = r.getHeader("Location");
 
     // PUT not defined for RAML
@@ -1026,19 +951,13 @@ public class ProxyTest {
       + "  \"requires\" : [ ]" + LS
       + "}";
 
-    c = api.createRestAssured3();
-    final String locationAuthModule2 = c.given()
+    final String locationAuthModule2 = api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docAuthModule2).post("/_/proxy/modules")
       .then().statusCode(201)
       .extract().header("Location");
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given().delete(locationAuthModule2).then().statusCode(204);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    api.createRestAssured3().given().delete(locationAuthModule2).then().statusCode(204);
 
     final String docSampleDeployment = "{" + LS
       + "  \"srvcId\" : \"sample-module-1\"," + LS
@@ -1051,22 +970,16 @@ public class ProxyTest {
       + "    } ]" + LS
       + "  }" + LS
       + "}";
-    c = api.createRestAssured3();
-    r = c.given()
+    r = api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docSampleDeployment).post("/_/deployment/modules")
       .then()
       .statusCode(201)
       .extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
     String locationSampleDeployment = r.getHeader("Location");
 
-    c = api.createRestAssured3();
-    String docSampleDiscovery = c.given().get(locationSampleDeployment)
-      .then().statusCode(200).extract().body().asString();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+    api.createRestAssured3().given().get(locationSampleDeployment)
+      .then().statusCode(200);
 
     final String docSampleModuleBadRequire = "{" + LS
       + "  \"id\" : \"sample-module-1\"," + LS
@@ -1078,8 +991,7 @@ public class ProxyTest {
       + "  \"routingEntries\" : [ ] " + LS
       + "}";
 
-    c = api.createRestAssured3();
-    c.given()
+    given()
       .header("Content-Type", "application/json")
       .body(docSampleModuleBadRequire).post("/_/proxy/modules").then().statusCode(400)
       .extract().response();
@@ -1097,11 +1009,9 @@ public class ProxyTest {
       + "  } ]," + LS
       + "}";
 
-    c = api.createRestAssured3();
-    c.given()
+    given()
       .header("Content-Type", "application/json")
-      .body(docSampleModuleBadVersion).post("/_/proxy/modules").then().statusCode(400)
-      .extract().response();
+      .body(docSampleModuleBadVersion).post("/_/proxy/modules").then().statusCode(400);
 
     final String docSampleModule = "{" + LS
       + "  \"id\" : \"sample-module-1\"," + LS
@@ -1131,19 +1041,16 @@ public class ProxyTest {
       + "  }" + LS
       + "}";
     logger.debug(docSampleModule);
-    c = api.createRestAssured3();
-    r = c.given()
+    r = api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docSampleModule).post("/_/proxy/modules")
       .then()
       .statusCode(201)
       .extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
     final String locationSampleModule = r.getHeader("Location");
 
     // Try to delete the auth module that our sample depends on
-    c.given().delete(locationAuthModule).then().statusCode(400);
+    api.createRestAssured3().given().delete(locationAuthModule).then().statusCode(400);
 
     // Create our tenant
     final String docTenantRoskilde = "{" + LS
@@ -1151,7 +1058,7 @@ public class ProxyTest {
       + "  \"name\" : \"" + okapiTenant + "\"," + LS
       + "  \"description\" : \"Roskilde bibliotek\"" + LS
       + "}";
-    c = api.createRestAssured3();
+    RestAssuredClient c = api.failFast(false).createRestAssured3();
     c.given()
       .header("Content-Type", "application/json")
       .body(docTenantRoskilde).post("/_/proxy/tenants/") // trailing slash fails
@@ -1162,16 +1069,12 @@ public class ProxyTest {
 
     // add tenant by using PUT (which will insert)
     final String locationTenantRoskilde = "/_/proxy/tenants/" + okapiTenant;
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docTenantRoskilde)
       .put(locationTenantRoskilde)
       .then().statusCode(200)
-      .body(equalTo(docTenantRoskilde))
-      .extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
+      .body(equalTo(docTenantRoskilde));
 
     // Try to enable sample without the auth that it requires
     final String docEnableWithoutDep = "{" + LS
@@ -1200,36 +1103,27 @@ public class ProxyTest {
       .then().statusCode(404);  // trailing slash is no good
 
     // Actually enable the auith
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docEnableAuth).post("/_/proxy/tenants/" + okapiTenant + "/modules")
       .then().statusCode(201).body(equalTo(docEnableAuth));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     given().get("/_/proxy/tenants/" + okapiTenant + "/modules/")
       .then().statusCode(404);  // trailing slash again
 
     // Get the list of one enabled module
-    c = api.createRestAssured3();
     final String exp1 = "[ {" + LS
       + "  \"id\" : \"auth-1\"" + LS
       + "} ]";
-    c.given().get("/_/proxy/tenants/" + okapiTenant + "/modules")
+    api.createRestAssured3().given().get("/_/proxy/tenants/" + okapiTenant + "/modules")
       .then().statusCode(200).body(equalTo(exp1));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     // get the auth enabled record
     final String expAuthEnabled = "{" + LS
       + "  \"id\" : \"auth-1\"" + LS
       + "}";
-    c = api.createRestAssured3();
-    c.given().get("/_/proxy/tenants/" + okapiTenant + "/modules/auth-1")
+    api.createRestAssured3().given().get("/_/proxy/tenants/" + okapiTenant + "/modules/auth-1")
       .then().statusCode(200).body(equalTo(expAuthEnabled));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     // Enable with bad JSON
     given()
@@ -1244,15 +1138,12 @@ public class ProxyTest {
     final String docEnableSample = "{" + LS
       + "  \"id\" : \"sample-module-1\"" + LS
       + "}";
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docEnableSample).post("/_/proxy/tenants/" + okapiTenant + "/modules")
       .then()
       .statusCode(201)
       .body(equalTo(docEnableSample));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     // Try to enable it again, should fail
     given()
@@ -1264,16 +1155,13 @@ public class ProxyTest {
     given().get("/_/proxy/tenants/" + okapiTenant + "/modules/")
       .then().statusCode(404); // trailing slash
 
-    c = api.createRestAssured3();
     final String expEnabledBoth = "[ {" + LS
       + "  \"id\" : \"auth-1\"" + LS
       + "}, {" + LS
       + "  \"id\" : \"sample-module-1\"" + LS
       + "} ]";
-    c.given().get("/_/proxy/tenants/" + okapiTenant + "/modules")
+    api.createRestAssured3().given().get("/_/proxy/tenants/" + okapiTenant + "/modules")
       .then().statusCode(200).body(equalTo(expEnabledBoth));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     // Try to disable the auth module for the tenant.
     // Ought to fail, because it is needed by sample module
@@ -1286,21 +1174,15 @@ public class ProxyTest {
       + "  \"name\" : \"Roskilde-library\"," + LS
       + "  \"description\" : \"Roskilde bibliotek\"" + LS
       + "}";
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docTenant).put("/_/proxy/tenants/" + okapiTenant)
       .then().statusCode(200)
       .body(equalTo(docTenant));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     // Check that both modules are still enabled
-    c = api.createRestAssured3();
-    c.given().get("/_/proxy/tenants/" + okapiTenant + "/modules")
+    api.createRestAssured3().given().get("/_/proxy/tenants/" + okapiTenant + "/modules")
       .then().statusCode(200).body(equalTo(expEnabledBoth));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     // Request without any X-Okapi headers
     given()
@@ -1507,114 +1389,75 @@ public class ProxyTest {
       + "    \"permissionsRequired\" : [ ]" + LS
       + "  } ]" + LS
       + "}";
-    c = api.createRestAssured3();
-    r = c.given()
+    r = api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docSample2Module).post("/_/proxy/modules").then().statusCode(201)
       .extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
     final String locationSample2Module = r.getHeader("Location");
 
     // 2nd sample module. We only create it in discovery and give it same URL as
     // for sample-module (first one). Then we delete it again.
-    c = api.createRestAssured3();
     final String docSample2Deployment = "{" + LS
       + "  \"instId\" : \"sample2-inst\"," + LS
       + "  \"srvcId\" : \"sample-module2-1\"," + LS
       + "  \"url\" : \"http://localhost:9232\"" + LS
       + "}";
-    r = c.given()
+    r = api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docSample2Deployment).post("/_/discovery/modules")
       .then()
       .statusCode(201).extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
     final String locationSample2Discovery = r.header("Location");
 
     // Get the sample-2
-    c = api.createRestAssured3();
-    c.given().get("/_/discovery/modules/sample-module2-1")
+    api.createRestAssured3().given().get("/_/discovery/modules/sample-module2-1")
       .then().statusCode(200);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     // and its instance
-    c = api.createRestAssured3();
-    c.given().get("/_/discovery/modules/sample-module2-1/sample2-inst")
+    api.createRestAssured3().given().get("/_/discovery/modules/sample-module2-1/sample2-inst")
       .then().statusCode(200);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     // Get with unknown instanceId AND serviceId
-    c = api.createRestAssured3();
-    c.given().get("/_/discovery/modules/foo/xyz")
+    api.createRestAssured3().given().get("/_/discovery/modules/foo/xyz")
       .then().statusCode(404);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     // Get with unknown instanceId
-    c = api.createRestAssured3();
-    c.given().get("/_/discovery/modules/sample-module2-1/xyz")
+    api.createRestAssured3().given().get("/_/discovery/modules/sample-module2-1/xyz")
       .then().statusCode(404);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     // Get with unknown serviceId
-    c = api.createRestAssured3();
-    c.given().get("/_/discovery/modules/foo/sample2-inst")
+    api.createRestAssured3().given().get("/_/discovery/modules/foo/sample2-inst")
       .then().statusCode(404);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     // health check
-    c = api.createRestAssured3();
-    c.given().get("/_/discovery/health")
+    api.createRestAssured3().given().get("/_/discovery/health")
       .then().statusCode(200);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     // health for sample2
-    c = api.createRestAssured3();
-    c.given().get("/_/discovery/health/sample-module2-1")
+    api.createRestAssured3().given().get("/_/discovery/health/sample-module2-1")
       .then().statusCode(200);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     // health for an instance
-    c = api.createRestAssured3();
-    c.given().get("/_/discovery/health/sample-module2-1/sample2-inst")
+    api.createRestAssured3().given().get("/_/discovery/health/sample-module2-1/sample2-inst")
       .then().statusCode(200);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     // Health with unknown instanceId
-    c = api.createRestAssured3();
-    c.given().get("/_/discovery/health/sample-module2-1/xyz")
+    api.createRestAssured3().given().get("/_/discovery/health/sample-module2-1/xyz")
       .then().statusCode(404);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     // health with unknown serviceId
-    c = api.createRestAssured3();
-    c.given().get("/_/discovery/health/foo/sample2-inst")
+    api.createRestAssured3().given().get("/_/discovery/health/foo/sample2-inst")
       .then().statusCode(404);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     // enable sample2
     final String docEnableSample2 = "{" + LS
       + "  \"id\" : \"sample-module2-1\"" + LS
       + "}";
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docEnableSample2).post("/_/proxy/tenants/" + okapiTenant + "/modules")
       .then().statusCode(201)
       .body(equalTo(docEnableSample2));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     // disable it, and re-enable.
     // Later we will check that we got the right calls in its
@@ -1655,13 +1498,10 @@ public class ProxyTest {
       + "    \"permissionsRequired\" : [ ]" + LS
       + "  } ]" + LS
       + "}";
-    c = api.createRestAssured3();
-    r = c.given()
+    r = api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docSample3Module).post("/_/proxy/modules").then().statusCode(201)
       .extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
     final String locationSample3Module = r.getHeader("Location");
 
     // 3rd sample module. We only create it in discovery and give it same URL as
@@ -1671,14 +1511,11 @@ public class ProxyTest {
       + "  \"srvcId\" : \"sample-module3-1\"," + LS
       + "  \"url\" : \"http://localhost:9232\"" + LS
       + "}";
-    c = api.createRestAssured3();
-    r = c.given()
+    r = api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docSample3Deployment).post("/_/discovery/modules")
       .then()
       .statusCode(201).extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
     final String locationSample3Inst = r.getHeader("Location");
     logger.debug("Deployed: locationSample3Inst " + locationSample3Inst);
 
@@ -1688,7 +1525,7 @@ public class ProxyTest {
       + "  \"srvcId\" : \"sample-module2-1\"," + LS
       + "  \"url\" : \"http://localhost:9232\"" + LS
       + "}";
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docSample3DeploymentError).post("/_/discovery/modules")
       .then()
@@ -1697,36 +1534,24 @@ public class ProxyTest {
     final String docEnableSample3 = "{" + LS
       + "  \"id\" : \"sample-module3-1\"" + LS
       + "}";
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docEnableSample3).post("/_/proxy/tenants/" + okapiTenant + "/modules")
       .then().statusCode(201)
       .header("Location", equalTo("/_/proxy/tenants/" + okapiTenant + "/modules/sample-module3-1"))
       .body(equalTo(docEnableSample3));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .get("/_/proxy/tenants/" + okapiTenant + "/modules")
       .then().statusCode(200);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .get("/_/proxy/tenants/" + "unknown" + "/modules")
       .then().statusCode(404);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .get("/_/proxy/tenants/" + "unknown" + "/modules/unknown")
       .then().statusCode(404);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     given().header("X-Okapi-Tenant", okapiTenant)
       .header("X-Okapi-Token", okapiToken)
@@ -1774,7 +1599,6 @@ public class ProxyTest {
       .body("OkapiX").post("/testb")
       .then().statusCode(200).body(equalTo("hej <test>hej OkapiX</test>"));
 
-    c = api.createRestAssured3();
     final String exp4Modules = "[ {" + LS
       + "  \"id\" : \"auth-1\"" + LS
       + "}, {" + LS
@@ -1784,18 +1608,13 @@ public class ProxyTest {
       + "}, {" + LS
       + "  \"id\" : \"sample-module3-1\"" + LS
       + "} ]";
-    c.given().get(locationTenantRoskilde + "/modules")
+    api.createRestAssured3().given().get(locationTenantRoskilde + "/modules")
       .then().statusCode(200)
       .body(equalTo(exp4Modules));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given().delete(locationTenantRoskilde + "/modules/sample-module3-1")
+    api.createRestAssured3().given().delete(locationTenantRoskilde + "/modules/sample-module3-1")
       .then().statusCode(204);
-    Assert.assertTrue(c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
     final String exp3Modules = "[ {" + LS
       + "  \"id\" : \"auth-1\"" + LS
       + "}, {" + LS
@@ -1803,29 +1622,19 @@ public class ProxyTest {
       + "}, {" + LS
       + "  \"id\" : \"sample-module2-1\"" + LS
       + "} ]";
-    c.given().get(locationTenantRoskilde + "/modules")
+    api.createRestAssured3().given().get(locationTenantRoskilde + "/modules")
       .then().statusCode(200)
       .body(equalTo(exp3Modules));
-    Assert.assertTrue(c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given().get("/_/discovery/modules")
+    api.createRestAssured3().given().get("/_/discovery/modules")
       .then().statusCode(200);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     // make sample 2 disappear from discovery!
-    c = api.createRestAssured3();
-    c.given().delete(locationSample2Discovery)
+    api.createRestAssured3().given().delete(locationSample2Discovery)
       .then().statusCode(204);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given().get("/_/discovery/modules")
+    api.createRestAssured3().given().get("/_/discovery/modules")
       .then().statusCode(200);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     given().header("X-Okapi-Tenant", okapiTenant)
       .header("X-Okapi-Token", okapiToken)
@@ -1834,39 +1643,27 @@ public class ProxyTest {
       .then().statusCode(404); // because sample2 was removed
 
     // Disable the sample module. No tenant-destroy for sample
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .delete("/_/proxy/tenants/" + okapiTenant + "/modules/sample-module-1?purge=true")
       .then().statusCode(204);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
     // Disable the sample2 module + auth-1. It has a tenant request handler which is
     // no longer invoked, so it does not matter we don't have a running instance
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .delete("/_/proxy/tenants/" + okapiTenant + "/modules")
       .then().statusCode(204);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     given()
       .get("/_/proxy/tenants/" + okapiTenant + "/modules")
       .then().statusCode(200).body(equalTo("[ ]"));
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .delete("/_/proxy/tenants/unknown-tenant/modules")
       .then().statusCode(404);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given().delete(locationTenantRoskilde)
+    api.createRestAssured3().given().delete(locationTenantRoskilde)
       .then().statusCode(204);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     // Clean up, so the next test starts with a clean slate
     given().delete(locationSample3Inst).then().statusCode(204);
@@ -1895,7 +1692,6 @@ public class ProxyTest {
   @Test
   public void testRedirect(TestContext context) {
     Async async = context.async();
-    RestAssuredClient c;
     Response r;
     final String okapiTenant = "roskilde";
 
@@ -1906,15 +1702,12 @@ public class ProxyTest {
       + "  \"description\" : \"Roskilde bibliotek\"" + LS
       + "}";
 
-    c = api.createRestAssured3();
-    r = c.given()
+    r = api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docTenantRoskilde).post("/_/proxy/tenants")
       .then().statusCode(201)
       .log().ifValidationFails()
       .extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
     final String locationTenantRoskilde = r.getHeader("Location");
 
     // Set up, deploy, and enable a sample module
@@ -1956,8 +1749,7 @@ public class ProxyTest {
       + "  }" + LS
       + "}";
 
-    c = api.createRestAssured3();
-    r = c.given()
+    r = api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docSampleModule).post("/_/proxy/modules").then().statusCode(201)
       .extract().response();
@@ -1968,25 +1760,19 @@ public class ProxyTest {
       + "  \"nodeId\" : \"localhost\"" + LS
       + "}";
 
-    c = api.createRestAssured3();
-    r = c.given().header("Content-Type", "application/json")
+    r = api.createRestAssured3().given().header("Content-Type", "application/json")
       .body(docSampleDeploy).post("/_/discovery/modules")
       .then().statusCode(201)
       .extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
     String locationSampleDeployment = r.getHeader("Location");
 
     final String docEnableSample = "{" + LS
       + "  \"id\" : \"sample-module-1\"" + LS
       + "}";
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docEnableSample).post("/_/proxy/tenants/" + okapiTenant + "/modules")
       .then().statusCode(201).body(equalTo(docEnableSample));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     given()
       .header("X-Okapi-Tenant", okapiTenant)
@@ -2063,8 +1849,7 @@ public class ProxyTest {
       + "  }" + LS
       + "}";
 
-    c = api.createRestAssured3();
-    r = c.given()
+    r = api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docHeaderModule).post("/_/proxy/modules").then().statusCode(201)
       .extract().response();
@@ -2075,25 +1860,19 @@ public class ProxyTest {
       + "  \"nodeId\" : \"localhost\"" + LS
       + "}";
 
-    c = api.createRestAssured3();
-    r = c.given().header("Content-Type", "application/json")
+    r = api.createRestAssured3().given().header("Content-Type", "application/json")
       .body(docHeaderDeploy).post("/_/discovery/modules")
       .then().statusCode(201)
       .extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
     String locationHeaderDeployment = r.getHeader("Location");
 
     final String docEnableHeader = "{" + LS
       + "  \"id\" : \"header-module-1\"" + LS
       + "}";
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docEnableHeader).post("/_/proxy/tenants/" + okapiTenant + "/modules")
       .then().statusCode(201).body(equalTo(docEnableHeader));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     given()
       .header("X-Okapi-Tenant", okapiTenant)
@@ -2199,7 +1978,6 @@ public class ProxyTest {
   @Test
   public void testRequestOnly(TestContext context) {
     final String okapiTenant = "roskilde";
-    RestAssuredClient c;
     Response r;
 
     // add tenant
@@ -2208,16 +1986,12 @@ public class ProxyTest {
       + "  \"name\" : \"" + okapiTenant + "\"," + LS
       + "  \"description\" : \"Roskilde bibliotek\"" + LS
       + "}";
-    c = api.createRestAssured3();
-    r = c.given()
+    r = api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docTenantRoskilde).post("/_/proxy/tenants")
       .then().statusCode(201)
       .body(equalTo(docTenantRoskilde))
       .extract().response();
-    Assert.assertTrue(
-      "raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
     final String locationTenantRoskilde = r.getHeader("Location");
 
     final String docRequestPre = "{" + LS
@@ -2231,12 +2005,9 @@ public class ProxyTest {
         + "    \"permissionsRequired\" : [ ]" + LS
         + "  } ]" + LS
         + "}";
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docRequestPre).post("/_/proxy/modules").then().statusCode(201);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     final String docRequestPost = "{" + LS
       + "  \"id\" : \"request-post-1.0.0\"," + LS
@@ -2249,12 +2020,9 @@ public class ProxyTest {
       + "    \"permissionsRequired\" : [ ]" + LS
       + "  } ]" + LS
       + "}";
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docRequestPost).post("/_/proxy/modules").then().statusCode(201);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     final String docRequestOnly = "{" + LS
         + "  \"id\" : \"request-only-1.0.0\"," + LS
@@ -2271,12 +2039,9 @@ public class ProxyTest {
         + "\"java -Dport=%p -jar ../okapi-test-module/target/okapi-test-module-fat.jar\"" + LS
         + "  }" + LS
         + "}";
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docRequestOnly).post("/_/proxy/modules").then().statusCode(201);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     final String testAuthJar = "../okapi-test-auth-module/target/okapi-test-auth-module-fat.jar";
     final String docAuthModule = "{" + LS
@@ -2305,12 +2070,9 @@ public class ProxyTest {
       + "    \"exec\" : \"java -Dport=%p -jar " + testAuthJar + "\"" + LS
       + "  }" + LS
       + "}";
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docAuthModule).post("/_/proxy/modules").then().statusCode(201);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     final String docSample = "{" + LS
         + "  \"id\" : \"sample-module-1.0.0\"," + LS
@@ -2332,15 +2094,11 @@ public class ProxyTest {
         + "\"java -Dport=%p -jar ../okapi-test-module/target/okapi-test-module-fat.jar\"" + LS
         + "  }" + LS
         + "}";
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docSample).post("/_/proxy/modules").then().statusCode(201);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body("[ {\"id\" : \"sample-module-1.0.0\", \"action\" : \"enable\"},"
         + " {\"id\" : \"request-only-1.0.0\", \"action\" : \"enable\"} ]")
@@ -2353,9 +2111,6 @@ public class ProxyTest {
         + "  \"id\" : \"request-only-1.0.0\"," + LS
         + "  \"action\" : \"enable\"" + LS
         + "} ]"));
-    Assert.assertTrue(
-      "raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     given().header("X-Okapi-Tenant", okapiTenant)
       .header("Content-Type", "text/plain")
@@ -2379,12 +2134,9 @@ public class ProxyTest {
       + "  \"url\" : \"http://localhost:" + Integer.toString(portPre) + "\"" + LS
       + "}";
 
-    c = api.createRestAssured3();
-    c.given().header("Content-Type", "application/json")
+    api.createRestAssured3().given().header("Content-Type", "application/json")
       .body(nodeDoc1).post("/_/discovery/modules")
       .then().statusCode(201);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     final String nodeDoc2 = "{" + LS
       + "  \"instId\" : \"localhost-" + Integer.toString(portPost) + "\"," + LS
@@ -2392,15 +2144,11 @@ public class ProxyTest {
       + "  \"url\" : \"http://localhost:" + Integer.toString(portPost) + "\"" + LS
       + "}";
 
-    c = api.createRestAssured3();
-    c.given().header("Content-Type", "application/json")
+    api.createRestAssured3().given().header("Content-Type", "application/json")
       .body(nodeDoc2).post("/_/discovery/modules")
       .then().statusCode(201);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body("[ {\"id\" : \"request-pre-1.0.0\", \"action\" : \"enable\"},"
         + " {\"id\" : \"auth-f-module-1\", \"action\" : \"enable\"},"
@@ -2417,9 +2165,6 @@ public class ProxyTest {
         + "  \"id\" : \"request-only-1.0.0\"," + LS
         + "  \"action\" : \"disable\"" + LS
         + "} ]"));
-    Assert.assertTrue(
-      "raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     // login and get token
     final String docLogin = "{" + LS
@@ -2448,8 +2193,7 @@ public class ProxyTest {
       .delete("/testb")
       .then().statusCode(204).log().ifValidationFails();
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body("[ {\"id\" : \"request-post-1.0.0\", \"action\" : \"enable\"} ]")
       .post("/_/proxy/tenants/" + okapiTenant + "/install?deploy=true")
@@ -2507,15 +2251,11 @@ public class ProxyTest {
         + "\"java -Dport=%p -jar ../okapi-test-module/target/okapi-test-module-fat.jar\"" + LS
         + "  }" + LS
         + "}";
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body(docSample2).post("/_/proxy/modules").then().statusCode(201);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body("[ {\"id\" : \"sample-module-1.0.1\", \"action\" : \"enable\"} ]")
         .post("/_/proxy/tenants/" + okapiTenant + "/install?deploy=true")
@@ -2525,9 +2265,6 @@ public class ProxyTest {
             + "  \"from\" : \"sample-module-1.0.0\"," + LS
             + "  \"action\" : \"enable\"" + LS
             + "} ]"));
-    Assert.assertTrue(
-        "raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
     given().header("X-Okapi-Tenant", okapiTenant)
         .header("X-Okapi-Token", okapiToken)
@@ -2551,7 +2288,6 @@ public class ProxyTest {
 
   @Test
   public void testEdgeCase(TestContext context) {
-    RestAssuredClient c;
     final String superTenant = "supertenant";
 
     final String testAuthJar = "../okapi-test-auth-module/target/okapi-test-auth-module-fat.jar";
@@ -2582,13 +2318,9 @@ public class ProxyTest {
       + "  }" + LS
       + "}";
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docAuthModule).post("/_/proxy/modules").then().statusCode(201);
-    Assert.assertTrue(
-      "raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     final String docBasic_1_0_0 = "{" + LS
       + "  \"id\" : \"basic-module-1.0.0\"," + LS
@@ -2621,13 +2353,9 @@ public class ProxyTest {
       + "\"java -Dport=%p -jar ../okapi-test-module/target/okapi-test-module-fat.jar\"" + LS
       + "  }" + LS
       + "}";
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docBasic_1_0_0).post("/_/proxy/modules").then().statusCode(201);
-    Assert.assertTrue(
-      "raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     final String docEdge_1_0_0 = "{" + LS
       + "  \"id\" : \"edge-module-1.0.0\"," + LS
@@ -2643,13 +2371,9 @@ public class ProxyTest {
       + "  } ]," + LS
       + "  \"requires\" : [ ]" + LS
       + "}";
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docEdge_1_0_0).post("/_/proxy/modules").then().statusCode(201);
-    Assert.assertTrue(
-      "raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     final String nodeDiscoverEdge = "{" + LS
       + "  \"instId\" : \"localhost-" + Integer.toString(portEdge) + "\"," + LS
@@ -2657,15 +2381,11 @@ public class ProxyTest {
       + "  \"url\" : \"http://localhost:" + Integer.toString(portEdge) + "\"" + LS
       + "}";
 
-    c = api.createRestAssured3();
-    c.given().header("Content-Type", "application/json")
+    api.createRestAssured3().given().header("Content-Type", "application/json")
       .body(nodeDiscoverEdge).post("/_/discovery/modules")
       .then().statusCode(201);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body("["
         + " {\"id\" : \"edge-module-1.0.0\", \"action\" : \"enable\"},"
@@ -2673,16 +2393,13 @@ public class ProxyTest {
         + "]")
       .post("/_/proxy/tenants/" + superTenant + "/install?deploy=true")
       .then().statusCode(200).log().ifValidationFails();
-    Assert.assertTrue(
-      "raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     final String docLogin = "{" + LS
       + "  \"tenant\" : \"" + "supertenant" + "\"," + LS
       + "  \"username\" : \"peter\"," + LS
       + "  \"password\" : \"peter-password\"" + LS
       + "}";
-    final String okapiToken = c.given().header("Content-Type", "application/json").body(docLogin)
+    final String okapiToken = given().header("Content-Type", "application/json").body(docLogin)
       .header("X-Okapi-Tenant", "supertenant").post("/authn/login")
       .then().statusCode(200).extract().header("X-Okapi-Token");
 
@@ -2699,7 +2416,6 @@ public class ProxyTest {
       + "  \"name\" : \"" + okapiTenant + "\"," + LS
       + "  \"description\" : \"Roskilde bibliotek\"" + LS
       + "}";
-    c = api.createRestAssured3();
     given()
       .header("X-Okapi-Token", okapiToken)
       .header("Content-Type", "application/json")
@@ -2713,8 +2429,7 @@ public class ProxyTest {
       .body("Okapi").get("/edge/roskilde")
       .then().statusCode(404).log().ifValidationFails();
 
-    c = api.createRestAssured3();
-    c.given()
+    given()
       .header("X-Okapi-Token", okapiToken)
       .header("Content-Type", "application/json")
       .body("["
@@ -2724,65 +2439,56 @@ public class ProxyTest {
       .post("/_/proxy/tenants/" + okapiTenant + "/install?deploy=true")
       .then().statusCode(200).log().ifValidationFails();
 
-    c.given()
+    given()
       .header("Content-Type", "text/plain")
       .header("Accept", "text/xml")
       .body("Okapi").get("/edge/roskilde")
       .then().statusCode(200).log().ifValidationFails()
       .body(equalTo("It works"));
 
-    c.given()
+    given()
       .header("Content-Type", "text/plain")
       .header("Accept", "text/xml")
       .body("Okapi").get("/edge/unknown")
       .then().statusCode(400).log().ifValidationFails()
       .body(equalTo("No such Tenant unknown"));
 
-    c.given()
+    given()
         .header("X-Okapi-Token", okapiToken)
         .delete("/_/proxy/tenants/supertenant/modules/edge-module-1.0.0").then().statusCode(204);
 
-    c.given()
+    given()
         .header("X-Okapi-Token", okapiToken)
         .delete("/_/proxy/tenants/supertenant/modules/basic-module-1.0.0").then().statusCode(204);
 
-    c.given()
+    given()
         .header("X-Okapi-Token", okapiToken)
         .delete("/_/proxy/tenants/supertenant/modules/auth-module-1.0.0").then().statusCode(204);
 
-    c.given()
+    api.createRestAssured3().given()
       .delete("/_/discovery/modules")
       .then().statusCode(204).log().ifValidationFails();
   }
 
   void addAndDeploy(JsonObject moduleObj, String moduleName, int port) {
-    RestAssuredClient c;
     moduleObj.put("id", moduleName);
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body(moduleObj.encode()).post("/_/proxy/modules").then().statusCode(201);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
     final JsonObject deployObj = new JsonObject()
         .put("instId", UUID.randomUUID().toString())
         .put("srvcId", moduleName)
         .put("url", "http://localhost:" + port);
 
-    c = api.createRestAssured3();
-    c.given().header("Content-Type", "application/json")
+    api.createRestAssured3().given().header("Content-Type", "application/json")
         .body(deployObj.encode()).post("/_/discovery/modules")
         .then().statusCode(201);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
   }
 
   @Test
   public void testTimer(TestContext context) {
-    RestAssuredClient c;
-
     JsonObject docA_obj = new JsonObject()
         .put("provides", new JsonArray()
             .add(new JsonObject()
@@ -2885,35 +2591,27 @@ public class ProxyTest {
 
     final String okapiTenant = "roskilde";
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .get("/_/proxy/tenants/" + okapiTenant + "/timers")
         .then().statusCode(200)
         .body("$", hasSize(0));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
     // add tenant
     final String docTenantRoskilde = "{" + LS
       + "  \"id\" : \"" + okapiTenant + "\"" + LS
       + "}";
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docTenantRoskilde).post("/_/proxy/tenants")
       .then().statusCode(201)
       .body(equalTo(docTenantRoskilde));
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .get("/_/proxy/tenants/" + okapiTenant + "/timers")
         .then().statusCode(200)
         .body("$", hasSize(0));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body("["
         + " {\"id\" : \"a-module-1.0.0\", \"action\" : \"enable\"},"
@@ -2921,8 +2619,6 @@ public class ProxyTest {
         + "]")
       .post("/_/proxy/tenants/" + okapiTenant + "/install?deploy=true")
       .then().statusCode(200);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     Awaitility.await().atMost(1, TimeUnit.SECONDS).untilAsserted(
         () -> Assertions.assertThat(timerDelaySum.get(0)).isGreaterThan(1));
@@ -2931,42 +2627,30 @@ public class ProxyTest {
     Awaitility.await().atMost(1, TimeUnit.SECONDS).untilAsserted(
         () -> Assertions.assertThat(timerDelaySum.get(2)).isGreaterThan(2));
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .get("/_/proxy/tenants/" + okapiTenant + "/timers/foo")
         .then().statusCode(404);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
     // not even part of RAML / MD
     given()
         .get("/_/proxy/tenants/" + okapiTenant + "/timers/a/b/c")
         .then().statusCode(404);
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .get("/_/proxy/tenants/" + okapiTenant + "/timers")
         .then().statusCode(200)
         .body("$", hasSize(4));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .get("/_/proxy/tenants/" + okapiTenant + "/timers/timer-module_0")
         .then().statusCode(200)
         .body("id", is("timer-module_0"))
         .body("modified", is(false));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .get("/_/proxy/tenants/" + "badtenant" + "/timers/timer-module_0")
         .then().statusCode(404)
         .body(containsString("badtenant"));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
     given()
         .header("Content-Type", "application/json")
@@ -2988,62 +2672,44 @@ public class ProxyTest {
         .put("id", "timer-module_0")
         .put("routingEntry", routingEntry);
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body(patchObj.encode())
         .patch("/_/proxy/tenants/" + okapiTenant + "/timers")
             .then().statusCode(204);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
     // patch same data again
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body(routingEntry.encode())
         .patch("/_/proxy/tenants/" + okapiTenant + "/timers/timer-module_0")
         .then().statusCode(204);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body("["
             + " {\"id\" : \"timer-module-1.0.1\", \"action\" : \"enable\"}"
             + "]")
         .post("/_/proxy/tenants/" + okapiTenant + "/install?deploy=true")
         .then().statusCode(200);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .get("/_/proxy/tenants/" + okapiTenant + "/timers/timer-module_0")
         .then().statusCode(200)
         .body("routingEntry.delay", is("2"))
         .body("modified", is(true));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .get("/_/proxy/tenants/" + okapiTenant + "/timers/timer-module_1")
         .then().statusCode(200)
         .body("routingEntry.delay", is("20"))
         .body("modified", is(false));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .get("/_/proxy/tenants/" + okapiTenant + "/timers/timer-module_2")
         .then().statusCode(200)
         .body("routingEntry.delay", is("5"))
         .body("modified", is(false));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
     given()
         .header("X-Okapi-Tenant", okapiTenant)
@@ -3053,16 +2719,13 @@ public class ProxyTest {
         .then().statusCode(200);
 
     // disable the timer
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body(new JsonObject()
             .put("unit", "millisecond")
             .put("delay", "0").encode())
         .patch("/_/proxy/tenants/" + okapiTenant + "/timers/timer-module_0")
         .then().statusCode(204);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
     timerDelaySum.clear();
 
@@ -3073,8 +2736,7 @@ public class ProxyTest {
     Assertions.assertThat(timerDelaySum.containsKey(0)).isFalse();
 
     // enable it again
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body(new JsonObject()
             .put("id", "timer-module_0")
@@ -3083,67 +2745,49 @@ public class ProxyTest {
                 .put("delay", "2")).encode())
         .patch("/_/proxy/tenants/" + okapiTenant + "/timers")
         .then().statusCode(204);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
     // disable and enable (quickly)
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body("["
         + " {\"id\" : \"timer-module-1.0.1\", \"action\" : \"disable\"}"
         + "]")
       .post("/_/proxy/tenants/" + okapiTenant + "/install?deploy=true")
       .then().statusCode(200);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body("["
         + " {\"id\" : \"timer-module-1.0.0\", \"action\" : \"enable\"}"
         + "]")
       .post("/_/proxy/tenants/" + okapiTenant + "/install?deploy=true")
       .then().statusCode(200);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     // reset timer
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body("{}")
         .patch("/_/proxy/tenants/" + okapiTenant + "/timers/timer-module_0")
         .then().statusCode(204);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
     // reset timer for other timer
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body("{}")
         .patch("/_/proxy/tenants/" + okapiTenant + "/timers/timer-module_1")
         .then().statusCode(204);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
     // see that values are back to that of module
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .get("/_/proxy/tenants/" + okapiTenant + "/timers/timer-module_0")
         .then().statusCode(200)
         .body("id", is("timer-module_0"))
         .body("routingEntry.unit", is("millisecond"))
         .body("routingEntry.delay", is("10"))
         .body("modified", is(false));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
     // disable for some time...
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body("["
         + " {\"id\" : \"timer-module-1.0.0\", \"action\" : \"disable\"}"
@@ -3157,34 +2801,25 @@ public class ProxyTest {
     }
 
     // check that timer gone
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .get("/_/proxy/tenants/" + okapiTenant + "/timers/timer-module_0")
         .then().statusCode(404);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
     // try to reset a timer for module that's gone
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body("{}")
         .patch("/_/proxy/tenants/" + okapiTenant + "/timers/timer-module_1")
         .then().statusCode(404).body(containsString("timer-module_1"));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
     // enable again
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body("["
         + " {\"id\" : \"timer-module-1.0.0\", \"action\" : \"enable\"}"
         + "]")
       .post("/_/proxy/tenants/" + okapiTenant + "/install?deploy=true")
       .then().statusCode(200).log().ifValidationFails();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     try {
       TimeUnit.MILLISECONDS.sleep(100);
@@ -3192,16 +2827,13 @@ public class ProxyTest {
     }
 
     // disable and remove tenant as well
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body("["
         + " {\"id\" : \"timer-module-1.0.0\", \"action\" : \"disable\"}"
         + "]")
       .post("/_/proxy/tenants/" + okapiTenant + "/install?deploy=true")
       .then().statusCode(200).log().ifValidationFails();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     given()
       .header("Content-Type", "application/json")
@@ -3216,22 +2848,19 @@ public class ProxyTest {
     timerDelaySum.clear();
     timerDelayStatus = 400;
     // add tenant 2nd time
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body(docTenantRoskilde).post("/_/proxy/tenants")
         .then().statusCode(201)
         .body(equalTo(docTenantRoskilde));
-    c = api.createRestAssured3();
-    c.given()
+
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body("["
             + " {\"id\" : \"timer-module-1.0.0\", \"action\" : \"enable\"}"
             + "]")
         .post("/_/proxy/tenants/" + okapiTenant + "/install?deploy=true")
         .then().statusCode(200);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
     try {
       TimeUnit.MILLISECONDS.sleep(50);
@@ -3242,16 +2871,13 @@ public class ProxyTest {
     Assertions.assertThat(timerDelaySum.get(2)).isGreaterThan(2);
 
     // disable and remove tenant as well
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body("["
             + " {\"id\" : \"timer-module-1.0.0\", \"action\" : \"disable\"}"
             + "]")
         .post("/_/proxy/tenants/" + okapiTenant + "/install?deploy=true")
         .then().statusCode(200).log().ifValidationFails();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
     given()
         .header("Content-Type", "application/json")
@@ -3262,9 +2888,6 @@ public class ProxyTest {
 
   @Test
   public void testTenantInit(TestContext context) {
-    RestAssuredClient c;
-    Response r;
-
     timerPermissions.clear();
 
     final String docTimer_1_0_0 = "{" + LS
@@ -3302,12 +2925,9 @@ public class ProxyTest {
       + "  } ]" + LS
       + "}";
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docTimer_1_0_0).post("/_/proxy/modules").then().statusCode(201);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     final String nodeDoc1 = "{" + LS
       + "  \"instId\" : \"localhost-" + Integer.toString(portTimer) + "\"," + LS
@@ -3315,12 +2935,9 @@ public class ProxyTest {
       + "  \"url\" : \"http://localhost:" + Integer.toString(portTimer) + "\"" + LS
       + "}";
 
-    c = api.createRestAssured3();
-    c.given().header("Content-Type", "application/json")
+    api.createRestAssured3().given().header("Content-Type", "application/json")
       .body(nodeDoc1).post("/_/discovery/modules")
       .then().statusCode(201);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     final String okapiTenant = "roskilde";
     // add tenant
@@ -3329,34 +2946,28 @@ public class ProxyTest {
       + "  \"name\" : \"" + okapiTenant + "\"," + LS
       + "  \"description\" : \"Roskilde bibliotek\"" + LS
       + "}";
-    c = api.createRestAssured3();
     given()
       .header("Content-Type", "application/json")
       .body(docTenantRoskilde).post("/_/proxy/tenants")
       .then().statusCode(201)
       .body(equalTo(docTenantRoskilde));
 
-    c = api.createRestAssured3();
-    String body = c.given().header("Content-Type", "application/json")
+    String body = api.createRestAssured3().given().header("Content-Type", "application/json")
       .get("/_/proxy/tenants/" + okapiTenant + "/modules")
       .then().statusCode(200).extract().body().asString();
     JsonArray ar = new JsonArray(body);
     Assert.assertEquals(0, ar.size());
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body("["
         + " {\"id\" : \"timer-module-1.0.0\", \"action\" : \"enable\"}"
         + "]")
       .post("/_/proxy/tenants/" + okapiTenant + "/install")
       .then().statusCode(200).log().ifValidationFails();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     Assert.assertEquals(0, timerPermissions.size());
-    c = api.createRestAssured3();
-    body = c.given().header("Content-Type", "application/json")
+    body = api.createRestAssured3().given().header("Content-Type", "application/json")
       .get("/_/proxy/tenants/" + okapiTenant + "/modules")
       .then().statusCode(200).extract().body().asString();
     ar = new JsonArray(body);
@@ -3415,12 +3026,9 @@ public class ProxyTest {
       + "  } ]" + LS
       + "}";
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docTimer_1_0_1).post("/_/proxy/modules").then().statusCode(201);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     Assert.assertEquals(0, timerPermissions.size());
 
@@ -3451,32 +3059,22 @@ public class ProxyTest {
         + "    \"displayName\": \"e\"" + LS
         + "  } ]" + LS
         + "}";
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docEdge_1_0_0).post("/_/proxy/modules").then().statusCode(201);
-    Assert.assertTrue(
-      "raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
-
 
     final String nodeDiscoverEdge = "{" + LS
       + "  \"instId\" : \"localhost-" + Integer.toString(portEdge) + "\"," + LS
       + "  \"srvcId\" : \"edge-module-1.0.0\"," + LS
       + "  \"url\" : \"http://localhost:" + Integer.toString(portEdge) + "\"" + LS
       + "}";
-    c = api.createRestAssured3();
-    c.given().header("Content-Type", "application/json")
+    api.createRestAssured3().given().header("Content-Type", "application/json")
       .body(nodeDiscoverEdge).post("/_/discovery/modules")
       .then().statusCode(201);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
-
     Assert.assertEquals(0, timerPermissions.size());
 
     // deploy, but with no running instance of timer-module-1.0.1
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body("["
         + " {\"id\" : \"edge-module-1.0.0\", \"action\" : \"enable\"},"
@@ -3485,8 +3083,6 @@ public class ProxyTest {
       .post("/_/proxy/tenants/" + okapiTenant + "/install")
       .then().statusCode(400).log().ifValidationFails()
       .body(containsString("No running instances for module timer-module-1.0.1. Can not invoke /_/tenant"));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     Assert.assertEquals(0, timerPermissions.size());
 
@@ -3495,23 +3091,16 @@ public class ProxyTest {
       + "  \"srvcId\" : \"timer-module-1.0.1\"," + LS
       + "  \"url\" : \"http://localhost:" + Integer.toString(portTimer) + "\"" + LS
       + "}";
-    c = api.createRestAssured3();
-    c.given().header("Content-Type", "application/json")
+    api.createRestAssured3().given().header("Content-Type", "application/json")
       .body(nodeDoc2).post("/_/discovery/modules")
       .then().statusCode(201);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given().header("Content-Type", "application/json")
+    api.createRestAssured3().given().header("Content-Type", "application/json")
       .get("/_/proxy/tenants/" + okapiTenant + "/modules")
       .then().statusCode(200).body(containsString("timer-module-1.0.0"));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     timerTenantInitStatus = 400;
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body("["
         + " {\"id\" : \"edge-module-1.0.0\", \"action\" : \"enable\"},"
@@ -3520,26 +3109,20 @@ public class ProxyTest {
       .post("/_/proxy/tenants/" + okapiTenant + "/install")
       .then().statusCode(400).log().ifValidationFails()
       .body(containsString("POST request for timer-module-1.0.1 /_/tenant failed with 400: timer response"));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     Assert.assertEquals(0, timerPermissions.size());
 
-    c = api.createRestAssured3();
-    body = c.given().header("Content-Type", "application/json")
+    body = api.createRestAssured3().given().header("Content-Type", "application/json")
       .get("/_/proxy/tenants/" + okapiTenant + "/modules")
       .then().statusCode(200).extract().body().asString();
     ar = new JsonArray(body);
     Assert.assertEquals(2, ar.size());
     Assert.assertEquals("edge-module-1.0.0", ar.getJsonObject(0).getString("id"));
     Assert.assertEquals("timer-module-1.0.0", ar.getJsonObject(1).getString("id"));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     timerTenantInitStatus = 200;
     timerTenantPermissionsStatus = 400;
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body("["
         + " {\"id\" : \"edge-module-1.0.0\", \"action\" : \"enable\"},"
@@ -3549,25 +3132,19 @@ public class ProxyTest {
       .then().statusCode(400).log().ifValidationFails()
       .body(containsString("POST request for timer-module-1.0.1 "
         +"/permissionscall failed with 400: timer permissions response"));
-     Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     Assert.assertEquals(0, timerPermissions.size());
 
-    c = api.createRestAssured3();
-    body = c.given().header("Content-Type", "application/json")
+    body = api.createRestAssured3().given().header("Content-Type", "application/json")
       .get("/_/proxy/tenants/" + okapiTenant + "/modules")
       .then().statusCode(200).extract().body().asString();
     ar = new JsonArray(body);
     Assert.assertEquals(2, ar.size());
     Assert.assertEquals("edge-module-1.0.0", ar.getJsonObject(0).getString("id"));
     Assert.assertEquals("timer-module-1.0.0", ar.getJsonObject(1).getString("id"));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     timerTenantPermissionsStatus = 200;
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body("["
         + " {\"id\" : \"edge-module-1.0.0\", \"action\" : \"enable\"},"
@@ -3575,8 +3152,6 @@ public class ProxyTest {
         + "]")
       .post("/_/proxy/tenants/" + okapiTenant + "/install")
       .then().statusCode(200).log().ifValidationFails();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     Assert.assertEquals(timerPermissions.encodePrettily(), 2, timerPermissions.size());
     Assert.assertTrue(timerPermissions.containsKey("timer-module-1.0.1"));
@@ -3584,27 +3159,21 @@ public class ProxyTest {
 
     // re-enable edge-module and check that permissions for it are available at tenant-init
     timerPermissions.clear();
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body("["
             + " {\"id\" : \"edge-module-1.0.0\", \"action\" : \"disable\"}"
             + "]")
         .post("/_/proxy/tenants/" + okapiTenant + "/install")
         .then().statusCode(200).log().ifValidationFails();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body("["
             + " {\"id\" : \"edge-module-1.0.0\", \"action\" : \"enable\"}"
             + "]")
         .post("/_/proxy/tenants/" + okapiTenant + "/install")
         .then().statusCode(200).log().ifValidationFails();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
     Assert.assertNotNull(edgePermissionsAtInit);
 
     given()
@@ -3613,7 +3182,6 @@ public class ProxyTest {
       .header("Accept", "text/plain")
       .body("Okapi").post("/timercall/1")
       .then().statusCode(200).log().ifValidationFails();
-
 
     final String docTimer_1_0_2 = "{" + LS
       + "  \"id\" : \"timer-module-1.0.2\"," + LS
@@ -3659,30 +3227,22 @@ public class ProxyTest {
       + "    \"displayName\": \"d\"" + LS
       + "  } ]" + LS
       + "}";
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docTimer_1_0_2).post("/_/proxy/modules").then().statusCode(201);
-    Assert.assertTrue(
-      "raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     final String nodeDoc3 = "{" + LS
       + "  \"instId\" : \"localhost2-" + Integer.toString(portTimer) + "\"," + LS
       + "  \"srvcId\" : \"timer-module-1.0.2\"," + LS
       + "  \"url\" : \"http://localhost:" + Integer.toString(portTimer) + "\"" + LS
       + "}";
-    c = api.createRestAssured3();
-    c.given().header("Content-Type", "application/json")
+    api.createRestAssured3().given().header("Content-Type", "application/json")
       .body(nodeDoc3).post("/_/discovery/modules")
       .then().statusCode(201);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     timerTenantPermissionsStatus = 400;
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body("["
         + " {\"id\" : \"timer-module\", \"action\" : \"enable\"}"
@@ -3691,14 +3251,10 @@ public class ProxyTest {
       .then().statusCode(400).log().ifValidationFails()
       .body(containsString("POST request for timer-module-1.0.2 "
         +"/permissionscall failed with 400: timer permissions response"));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
-
   }
 
   @Test
   public void testTenantFailedUpgrade(TestContext context) {
-    RestAssuredClient c;
 
     final String okapiTenant = "roskilde";
     // add tenant
@@ -3707,7 +3263,6 @@ public class ProxyTest {
       + "  \"name\" : \"" + okapiTenant + "\"," + LS
       + "  \"description\" : \"Roskilde bibliotek\"" + LS
       + "}";
-    c = api.createRestAssured3();
     given()
       .header("Content-Type", "application/json")
       .body(docTenantRoskilde).post("/_/proxy/tenants")
@@ -3804,84 +3359,59 @@ public class ProxyTest {
       + "  } ]" + LS
       + "}";
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docTimer_1_0_0).post("/_/proxy/modules").then().statusCode(201);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     final String deployDocTimer_1_0_0 = "{" + LS
       + "  \"instId\" : \"localhost-1-" + Integer.toString(portTimer) + "\"," + LS
       + "  \"srvcId\" : \"timer-module-1.0.0\"," + LS
       + "  \"url\" : \"http://localhost:" + Integer.toString(portTimer) + "\"" + LS
       + "}";
-    c = api.createRestAssured3();
-    c.given().header("Content-Type", "application/json")
+    api.createRestAssured3().given().header("Content-Type", "application/json")
       .body(deployDocTimer_1_0_0).post("/_/discovery/modules")
       .then().statusCode(201);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docBusiness_1_0_0).post("/_/proxy/modules").then().statusCode(201);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     final String deployDocBusiness_1_0_0 = "{" + LS
       + "  \"instId\" : \"localhost-2-" + Integer.toString(portTimer) + "\"," + LS
       + "  \"srvcId\" : \"business-module-1.0.0\"," + LS
       + "  \"url\" : \"http://localhost:" + Integer.toString(portTimer) + "\"" + LS
       + "}";
-    c = api.createRestAssured3();
-    c.given().header("Content-Type", "application/json")
+    api.createRestAssured3().given().header("Content-Type", "application/json")
       .body(deployDocBusiness_1_0_0).post("/_/discovery/modules")
       .then().statusCode(201);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docTimer_2_0_0).post("/_/proxy/modules").then().statusCode(201);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     final String deployDocTimer_2_0_0 = "{" + LS
       + "  \"instId\" : \"localhost-3-" + Integer.toString(portTimer) + "\"," + LS
       + "  \"srvcId\" : \"timer-module-2.0.0\"," + LS
       + "  \"url\" : \"http://localhost:" + Integer.toString(portTimer) + "\"" + LS
       + "}";
-    c = api.createRestAssured3();
-    c.given().header("Content-Type", "application/json")
+    api.createRestAssured3().given().header("Content-Type", "application/json")
       .body(deployDocTimer_2_0_0).post("/_/discovery/modules")
       .then().statusCode(201);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(docBusiness_2_0_0).post("/_/proxy/modules").then().statusCode(201);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     final String deployDocBusiness_2_0_0 = "{" + LS
       + "  \"instId\" : \"localhost-4-" + Integer.toString(portTimer) + "\"," + LS
       + "  \"srvcId\" : \"business-module-2.0.0\"," + LS
       + "  \"url\" : \"http://localhost:" + Integer.toString(portTimer) + "\"" + LS
       + "}";
-    c = api.createRestAssured3();
-    c.given().header("Content-Type", "application/json")
+    api.createRestAssured3().given().header("Content-Type", "application/json")
       .body(deployDocBusiness_2_0_0).post("/_/discovery/modules")
       .then().statusCode(201);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body("[ {\"id\" : \"business-module-1.0.0\", \"action\" : \"enable\"}, {\"id\" : \"timer-module-1.0.0\", \"action\" : \"enable\"} ]")
       .post("/_/proxy/tenants/" + okapiTenant + "/install")
@@ -3893,12 +3423,8 @@ public class ProxyTest {
         + "  \"id\" : \"business-module-1.0.0\"," + LS
         + "  \"action\" : \"enable\"" + LS
         + "} ]"));
-    Assert.assertTrue(
-      "raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .post("/_/proxy/tenants/" + okapiTenant + "/upgrade?simulate=true")
       .then().statusCode(200).log().ifValidationFails()
@@ -3911,25 +3437,17 @@ public class ProxyTest {
         + "  \"from\" : \"business-module-1.0.0\"," + LS
         + "  \"action\" : \"enable\"" + LS
         + "} ]"));
-    Assert.assertTrue(
-      "raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     /* this will try to upgrade both, but business-module-2.0.0 tenant init fails,
      so business-module-1.0.0 stays but timer-module is upgrade (no _tenant interface) */
     timerTenantInitStatus = 400; // make business-module tenant init fail
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .post("/_/proxy/tenants/" + okapiTenant + "/upgrade")
       .then().statusCode(400).log().ifValidationFails()
       .body(equalTo("POST request for business-module-2.0.0 /_/tenant failed with 400: timer response"));
-    Assert.assertTrue(
-      "raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .get("/_/proxy/tenants/" + okapiTenant + "/modules")
       .then().statusCode(200).log().ifValidationFails()
       .body(equalTo("[ {" + LS
@@ -3937,12 +3455,8 @@ public class ProxyTest {
         + "}, {" + LS
         + "  \"id\" : \"timer-module-2.0.0\"" + LS
         + "} ]"));
-    Assert.assertTrue(
-      "raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body("[ {\"id\" : \"timer-module-2.0.0\", \"action\" : \"disable\"} ]")
       .post("/_/proxy/tenants/" + okapiTenant + "/install?simulate=true")
@@ -3954,54 +3468,34 @@ public class ProxyTest {
         + "  \"id\" : \"timer-module-2.0.0\"," + LS
         + "  \"action\" : \"disable\"" + LS
         + "} ]"));
-    Assert.assertTrue(
-      "raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     // works, because timer-module-2.0.0 does not have tenant interface
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .delete("/_/proxy/tenants/" + okapiTenant + "/modules/timer-module-2.0.0")
       .then().statusCode(204).log().ifValidationFails();
-    Assert.assertTrue(
-      "raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .get("/_/proxy/tenants/" + okapiTenant + "/modules")
       .then().statusCode(200).log().ifValidationFails()
       .body(equalTo("[ {" + LS
         + "  \"id\" : \"business-module-1.0.0\"" + LS
         + "} ]"));
-    Assert.assertTrue(
-      "raml: " + c.getLastReport().toString(),
-      c.getLastReport().isEmpty());
 
     // disable also fails with 400
     Assert.assertEquals(400, timerTenantInitStatus);
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .delete("/_/proxy/tenants/" + okapiTenant + "/modules")
         .then().statusCode(400).log().ifValidationFails()
         .body(equalTo("POST request for business-module-1.0.0 /_/tenant/disable failed with 400: timer response"));
-    Assert.assertTrue(
-        "raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
     // however, purge does not
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .delete("/_/proxy/tenants/" + okapiTenant + "/modules?purge=true")
         .then().statusCode(204).log().ifValidationFails();
-    Assert.assertTrue(
-        "raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
     // tenant init fails, but is not called because in next tests invoke=false
     Assert.assertEquals(400, timerTenantInitStatus);
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body("[ {\"id\" : \"business-module-1.0.0\", \"action\" : \"enable\"}, {\"id\" : \"timer-module-1.0.0\", \"action\" : \"enable\"} ]")
         .post("/_/proxy/tenants/" + okapiTenant + "/install?invoke=false")
@@ -4013,17 +3507,10 @@ public class ProxyTest {
             + "  \"id\" : \"business-module-1.0.0\"," + LS
             + "  \"action\" : \"enable\"" + LS
             + "} ]"));
-    Assert.assertTrue(
-        "raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .delete("/_/proxy/tenants/" + okapiTenant + "/modules?invoke=false")
         .then().statusCode(204).log().ifValidationFails();
-    Assert.assertTrue(
-        "raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
   }
 
   @Test
@@ -4033,10 +3520,9 @@ public class ProxyTest {
 
     String moduleId = "module-1.0.0";
     setupBasicModule(tenant, moduleId, "1.1", false, false, false);
-    RestAssuredClient c = api.createRestAssured3();
 
     String body = new JsonObject().put("id", "test").encode();
-    c.given()
+    given()
         .header("Content-Type", "application/json")
         .header("X-Okapi-Tenant", tenant)
         .body(body)
@@ -4050,7 +3536,7 @@ public class ProxyTest {
     listenTimer.close().onComplete(x -> async.complete());
     async.await();
 
-    c.given()
+    given()
         .header("Content-Type", "application/json")
         .header("X-Okapi-Tenant", tenant)
         .body(body)
@@ -4143,8 +3629,7 @@ public class ProxyTest {
         Assert.assertTrue(hasPermReplaces(permissions));
       }
       // proxy calls
-      RestAssuredClient c = api.createRestAssured3();
-      Response r = c.given()
+      Response r = given()
         .header("Content-Type", "application/json")
         .header("X-Okapi-Token", getOkapiToken(tenant))
         .body(body).post("/regularcall")
@@ -4183,10 +3668,8 @@ public class ProxyTest {
     setupBasicModule(tenant, moduleId, "1.1", false, false, false);
     setupBasicAuth(tenant, authModuleId);
 
-    RestAssuredClient c = api.createRestAssured3();
-
     // no CORS delegate preflight
-    c.given()
+    given()
       .header(HttpHeaders.ORIGIN.toString(), "http://localhost")
       .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD.toString(), HttpMethod.POST.name())
       .options("/_/invoke/tenant/" + tenant + "/regularcall")
@@ -4198,7 +3681,7 @@ public class ProxyTest {
       .log().ifValidationFails();
 
     // no CORS delegate
-    c.given()
+    given()
       .header("Content-Type", "application/json")
       .header("X-Okapi-Token", getOkapiToken(tenant))
       .header("Origin", "http://localhost")
@@ -4210,7 +3693,7 @@ public class ProxyTest {
       .log().ifValidationFails();
 
     // with CORS delegate preflight
-    c.given()
+    given()
       .header(HttpHeaders.ORIGIN.toString(), "http://localhost")
       .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD.toString(), HttpMethod.POST.name())
       .options("/_/invoke/tenant/" + tenant + "/corscall")
@@ -4222,7 +3705,7 @@ public class ProxyTest {
       .log().ifValidationFails();
 
     // with CORS delegate
-    c.given()
+    given()
       .header("Content-Type", "application/json")
       .header("X-Okapi-Token", getOkapiToken(tenant))
       .header("Origin", "http://localhost")
@@ -4234,7 +3717,7 @@ public class ProxyTest {
       .log().ifValidationFails();
 
     // with CORS delegate and query parameter
-    c.given()
+    given()
       .header("Content-Type", "application/json")
       .header("X-Okapi-Token", getOkapiToken(tenant))
       .header("Origin", "http://localhost")
@@ -4255,8 +3738,7 @@ public class ProxyTest {
   // add basic tenant
   private void setupBasicTenant(String tenant) {
     String tenantJson = new JsonObject().put("id", tenant).encode();
-    RestAssuredClient c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(tenantJson).post("/_/proxy/tenants")
       .then().statusCode(201);
@@ -4269,8 +3751,7 @@ public class ProxyTest {
       .put("username", "peter")
       .put("password", "peter-password")
       .encode();
-    RestAssuredClient c = api.createRestAssured3();
-    return c.given()
+    return given()
       .header("Content-Type", "application/json")
       .header("X-Okapi-Tenant", tenant)
       .body(loginJson).post("/authn/login")
@@ -4323,8 +3804,7 @@ public class ProxyTest {
       .encodePrettily();
 
     // registration
-    RestAssuredClient c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(mdJson).post("/_/proxy/modules")
       .then().statusCode(201).log().ifValidationFails();
@@ -4334,7 +3814,7 @@ public class ProxyTest {
       .put("id", authModuleId)
       .put("action", "enable"))
       .encode();
-    c.given()
+    api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body(installJson)
       .post("/_/proxy/tenants/" + tenant + "/install?deploy=true")
@@ -4375,8 +3855,7 @@ public class ProxyTest {
         .encodePrettily();
 
     // registration
-    RestAssuredClient c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body(mdJson).post("/_/proxy/modules")
         .then().statusCode(201).log().ifValidationFails();
@@ -4387,7 +3866,7 @@ public class ProxyTest {
         .put("srvcId", moduleId)
         .put("url", "http://localhost:" + Integer.toString(portTimer))
         .encode();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body(discoveryJson).post("/_/discovery/modules")
         .then().statusCode(201).log().ifValidationFails();
@@ -4396,7 +3875,7 @@ public class ProxyTest {
     String installJson = new JsonArray()
         .add(new JsonObject().put("id", moduleId).put("action", "enable"))
         .encode();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body(installJson)
         .post("/_/proxy/tenants/" + tenant + "/install")
@@ -4483,7 +3962,7 @@ public class ProxyTest {
                         .put("methods", new JsonArray().add("POST"))
                         .put("pathPattern", "/corscall")
                         .put("permissionsRequired", new JsonArray())
-                        .put("delegateCORS", "true")))))
+                        .put("delegateCORS", true)))))
         .put("requires", new JsonArray());
 
     JsonArray permSets = new JsonArray()
@@ -4509,8 +3988,7 @@ public class ProxyTest {
     String mdJson = mdJsonObj.put("permissionSets", permSets).encodePrettily();
 
     // registration
-    RestAssuredClient c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body(mdJson).post("/_/proxy/modules")
         .then().statusCode(201).log().ifValidationFails();
@@ -4521,7 +3999,7 @@ public class ProxyTest {
         .put("srvcId", moduleId)
         .put("url", "http://localhost:" + Integer.toString(portTimer))
         .encode();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body(discoveryJson).post("/_/discovery/modules")
         .then().statusCode(201).log().ifValidationFails();
@@ -4530,7 +4008,7 @@ public class ProxyTest {
     String installJson = new JsonArray()
         .add(new JsonObject().put("id", moduleId).put("action", "enable"))
         .encode();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body(installJson)
         .post("/_/proxy/tenants/" + tenant + "/install")
@@ -4539,7 +4017,6 @@ public class ProxyTest {
 
   @Test
   public void testCleanupModules(TestContext context) {
-    RestAssuredClient c;
 
     given()
         .header("Content-Type", "application/json")
@@ -4551,20 +4028,13 @@ public class ProxyTest {
         .body("{}").post("/_/proxy/cleanup/modules?saveReleases=1")
         .then().statusCode(400)
         .body(is("Missing value for parameter 'saveSnapshots'"));
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .post("/_/proxy/cleanup/modules?saveReleases=1&saveSnapshots=2")
         .then().statusCode(204);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
-
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .get("/_/proxy/modules")
         .then().statusCode(200)
         .body("$", hasSize(1));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
     InterfaceDescriptor[] interfaceDescriptors = new InterfaceDescriptor[1];
     InterfaceDescriptor interfaceDescriptor = interfaceDescriptors[0] = new InterfaceDescriptor();
@@ -4585,129 +4055,86 @@ public class ProxyTest {
     md.setRequires(interfaceDescriptors);
     modules.add(md);
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body(Json.encodePrettily(modules)).post("/_/proxy/import/modules")
         .then().statusCode(204);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .get("/_/proxy/modules")
         .then().statusCode(200)
         .body("$", hasSize(5))
         .body("[0].id", is("moduleA-1.0.0-SNAPSHOT.1"))
         .body("[1].id", is("moduleA-1.0.0-SNAPSHOT.2"));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .post("/_/proxy/cleanup/modules?saveReleases=0&saveSnapshots=1")
         .then().statusCode(400)
         .body(is("clean up modules: Missing dependency: moduleB-1.0.0 requires intA: 1.0"));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .delete("/_/proxy/modules/moduleB-1.0.0")
         .then().statusCode(204);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .post("/_/proxy/cleanup/modules?saveReleases=0&saveSnapshots=1")
         .then().statusCode(204);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .get("/_/proxy/modules")
         .then().statusCode(200)
         .body("$", hasSize(3))
         .body("[0].id", is("moduleA-1.0.0-SNAPSHOT.2"));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
   }
 
   @Test
   public void testCleanupModules2(TestContext context) {
-    RestAssuredClient c;
-    Response r;
     final String okapiTenant = "roskilde";
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body(new JsonObject().put("id", okapiTenant).encode()).post("/_/proxy/tenants")
         .then().statusCode(201);
-    Assert.assertTrue(
-        "raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
     List<ModuleDescriptor> modules = new LinkedList<>();
     modules.add(new ModuleDescriptor("moduleA-1.0.0-SNAPSHOT.1"));
     modules.add(new ModuleDescriptor("moduleA-1.0.0-SNAPSHOT.2"));
     modules.add(new ModuleDescriptor("moduleA-1.0.0"));
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body(Json.encodePrettily(modules)).post("/_/proxy/import/modules")
         .then().statusCode(204);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
     JsonArray installReq = new JsonArray().add(new JsonObject().put("id",  "moduleA-1.0.0-SNAPSHOT.1").put("action", "enable"));
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body(installReq.encode())
         .post("/_/proxy/tenants/" + okapiTenant + "/install")
         .then().statusCode(200).log().ifValidationFails()
         .body(equalTo(installReq.encodePrettily()));
-    Assert.assertTrue(
-        "raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .post("/_/proxy/cleanup/modules?saveReleases=0&saveSnapshots=1")
         .then().statusCode(400)
         .body(is("delete: module moduleA-1.0.0-SNAPSHOT.1 is used by tenant roskilde"));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
     installReq = new JsonArray().add(new JsonObject().put("id",  "moduleA-1.0.0-SNAPSHOT.1").put("action", "disable"));
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body(installReq.encode())
         .post("/_/proxy/tenants/" + okapiTenant + "/install")
         .then().statusCode(200).log().ifValidationFails()
         .body(equalTo(installReq.encodePrettily()));
-    Assert.assertTrue(
-        "raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .post("/_/proxy/cleanup/modules?saveReleases=0&saveSnapshots=1")
         .then().statusCode(204);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
   }
 
   @Test
   public void testImportModules(TestContext context) {
-    RestAssuredClient c;
-
     given()
         .header("Content-Type", "application/json")
         .body("{\"id\":").post("/_/proxy/import/modules")
@@ -4718,13 +4145,10 @@ public class ProxyTest {
         .body("[]").post("/_/proxy/import/modules?check=foo")
         .then().statusCode(400).body(equalTo("Bad boolean for parameter check: foo"));
 
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body("[]").post("/_/proxy/import/modules")
         .then().statusCode(204);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
     ModuleDescriptor mdA = new ModuleDescriptor();
     mdA.setId("moduleA-1.0.0");
@@ -4735,37 +4159,25 @@ public class ProxyTest {
     mdB.setRequires("intA", "1.0");
     List<ModuleDescriptor> modules = new LinkedList<>();
     modules.add(mdB);
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body(Json.encodePrettily(modules)).post("/_/proxy/import/modules")
         .then().statusCode(400).body(equalTo("Missing dependency: moduleB-1.0.0 requires intA: 1.0"));
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
     // try again, but without checking .. therefore it should succeed
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body(Json.encodePrettily(modules)).post("/_/proxy/import/modules?check=false&preRelease=false&npmSnapshot=false")
         .then().statusCode(204);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
     // remove again..
-    c = api.createRestAssured3();
-    c.given().delete("/_/proxy/modules/" + mdB.getId()).then().statusCode(204);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
+    api.createRestAssured3().given().delete("/_/proxy/modules/" + mdB.getId()).then().statusCode(204);
 
     modules.add(mdA);
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body(Json.encodePrettily(modules)).post("/_/proxy/import/modules")
         .then().statusCode(400);
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
     ModuleDescriptor mdC = new ModuleDescriptor();
     mdC.setId("moduleC-1.0.0");
@@ -4856,19 +4268,12 @@ public class ProxyTest {
   @Test
   public void testRequestResponse(TestContext context) {
     final String okapiTenant = "roskilde";
-    RestAssuredClient c;
-    Response r;
 
     // add tenant
-    c = api.createRestAssured3();
-    r = c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body(new JsonObject().put("id", okapiTenant).encode()).post("/_/proxy/tenants")
-        .then().statusCode(201)
-        .extract().response();
-    Assert.assertTrue(
-        "raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
+        .then().statusCode(201);
 
     final String docRequestPre = "{" + LS
         + "  \"id\" : \"module-pre-1.0.0\"," + LS
@@ -4880,13 +4285,10 @@ public class ProxyTest {
         + "    \"permissionsRequired\" : [ ]" + LS
         + "  } ]" + LS
         + "}";
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body(docRequestPre).post("/_/proxy/modules").then().statusCode(201)
         .extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
     String nodeDoc1 = "{" + LS
         + "  \"instId\" : \"localhost-1\"," + LS
@@ -4907,13 +4309,10 @@ public class ProxyTest {
         + "    \"permissionsRequired\" : [ ]" + LS
         + "  } ]" + LS
         + "}";
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body(docRequestPost).post("/_/proxy/modules").then().statusCode(201)
         .extract().response();
-    Assert.assertTrue("raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
     nodeDoc1 = "{" + LS
         + "  \"instId\" : \"localhost-2\"," + LS
@@ -4938,7 +4337,7 @@ public class ProxyTest {
         + "  } ]," + LS
         + "  \"requires\" : [ ]" + LS
         + "}";
-    given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body(docTimer_1_0_0).post("/_/proxy/modules").then().statusCode(201)
         .extract().response();
@@ -4953,16 +4352,12 @@ public class ProxyTest {
         .then().statusCode(201);
 
     JsonArray installReq = new JsonArray().add(new JsonObject().put("id",  "timer-module-1.0.0").put("action", "enable"));
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body(installReq.encode())
         .post("/_/proxy/tenants/" + okapiTenant + "/install?deploy=true")
         .then().statusCode(200).log().ifValidationFails()
         .body(equalTo(installReq.encodePrettily()));
-    Assert.assertTrue(
-        "raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
     given().header("X-Okapi-Tenant", okapiTenant)
         .header("Content-Type", "text/plain")
@@ -4973,16 +4368,12 @@ public class ProxyTest {
         .body(equalTo("Okapi"));
 
     installReq = new JsonArray().add(new JsonObject().put("id",  "module-pre-1.0.0").put("action", "enable"));
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body(installReq.encode())
         .post("/_/proxy/tenants/" + okapiTenant + "/install?deploy=true")
         .then().statusCode(200).log().ifValidationFails()
         .body(equalTo(installReq.encodePrettily()));
-    Assert.assertTrue(
-        "raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
     given().header("X-Okapi-Tenant", okapiTenant)
         .header("Content-Type", "text/plain; charset=UTF-8")
@@ -4998,16 +4389,12 @@ public class ProxyTest {
         .header("Content-Encoding", "gzip");
 
     installReq = new JsonArray().add(new JsonObject().put("id",  "module-post-1.0.0").put("action", "enable"));
-    c = api.createRestAssured3();
-    c.given()
+    api.createRestAssured3().given()
         .header("Content-Type", "application/json")
         .body(installReq.encode())
         .post("/_/proxy/tenants/" + okapiTenant + "/install?deploy=true")
         .then().statusCode(200).log().ifValidationFails()
         .body(equalTo(installReq.encodePrettily()));
-    Assert.assertTrue(
-        "raml: " + c.getLastReport().toString(),
-        c.getLastReport().isEmpty());
 
     given().header("X-Okapi-Tenant", okapiTenant)
         .header("Content-Type", "text/plain; charset=UTF-8")

--- a/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
@@ -4553,8 +4553,7 @@ public class ProxyTest {
         .body(is("Missing value for parameter 'saveSnapshots'"));
     c = api.createRestAssured3();
     c.given()
-        .header("Content-Type", "application/json")
-        .body("{}").post("/_/proxy/cleanup/modules?saveReleases=1&saveSnapshots=2")
+        .post("/_/proxy/cleanup/modules?saveReleases=1&saveSnapshots=2")
         .then().statusCode(204);
     Assert.assertTrue("raml: " + c.getLastReport().toString(),
         c.getLastReport().isEmpty());
@@ -4606,8 +4605,7 @@ public class ProxyTest {
 
     c = api.createRestAssured3();
     c.given()
-        .header("Content-Type", "application/json")
-        .body("{}").post("/_/proxy/cleanup/modules?saveReleases=0&saveSnapshots=1")
+        .post("/_/proxy/cleanup/modules?saveReleases=0&saveSnapshots=1")
         .then().statusCode(400)
         .body(is("clean up modules: Missing dependency: moduleB-1.0.0 requires intA: 1.0"));
     Assert.assertTrue("raml: " + c.getLastReport().toString(),
@@ -4623,8 +4621,7 @@ public class ProxyTest {
 
     c = api.createRestAssured3();
     c.given()
-        .header("Content-Type", "application/json")
-        .body("{}").post("/_/proxy/cleanup/modules?saveReleases=0&saveSnapshots=1")
+        .post("/_/proxy/cleanup/modules?saveReleases=0&saveSnapshots=1")
         .then().statusCode(204);
     Assert.assertTrue("raml: " + c.getLastReport().toString(),
         c.getLastReport().isEmpty());
@@ -4681,8 +4678,7 @@ public class ProxyTest {
 
     c = api.createRestAssured3();
     c.given()
-        .header("Content-Type", "application/json")
-        .body("{}").post("/_/proxy/cleanup/modules?saveReleases=0&saveSnapshots=1")
+        .post("/_/proxy/cleanup/modules?saveReleases=0&saveSnapshots=1")
         .then().statusCode(400)
         .body(is("delete: module moduleA-1.0.0-SNAPSHOT.1 is used by tenant roskilde"));
     Assert.assertTrue("raml: " + c.getLastReport().toString(),
@@ -4702,8 +4698,7 @@ public class ProxyTest {
 
     c = api.createRestAssured3();
     c.given()
-        .header("Content-Type", "application/json")
-        .body("{}").post("/_/proxy/cleanup/modules?saveReleases=0&saveSnapshots=1")
+        .post("/_/proxy/cleanup/modules?saveReleases=0&saveSnapshots=1")
         .then().statusCode(204);
     Assert.assertTrue("raml: " + c.getLastReport().toString(),
         c.getLastReport().isEmpty());

--- a/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
@@ -4538,6 +4538,35 @@ public class ProxyTest {
   }
 
   @Test
+  public void testObsoleteModules(TestContext context) {
+    RestAssuredClient c;
+
+    ModuleDescriptor mdA = new ModuleDescriptor();
+    mdA.setId("moduleA-1.0.0-SNAPSHOT.1");
+
+    List<ModuleDescriptor> modules = new LinkedList<>();
+    modules.add(mdA);
+    c = api.createRestAssured3();
+    c.given()
+        .header("Content-Type", "application/json")
+        .body(Json.encodePrettily(modules)).post("/_/proxy/import/modules?deleteObsolete=true")
+        .then().statusCode(204);
+    Assert.assertTrue("raml: " + c.getLastReport().toString(),
+        c.getLastReport().isEmpty());
+
+    mdA.setId("moduleA-1.0.0");
+    modules = new LinkedList<>();
+    modules.add(mdA);
+    c = api.createRestAssured3();
+    c.given()
+        .header("Content-Type", "application/json")
+        .body(Json.encodePrettily(modules)).post("/_/proxy/import/modules?deleteObsolete=true")
+        .then().statusCode(204);
+    Assert.assertTrue("raml: " + c.getLastReport().toString(),
+        c.getLastReport().isEmpty());
+  }
+
+  @Test
   public void testImportModules(TestContext context) {
     RestAssuredClient c;
 

--- a/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
@@ -4070,15 +4070,11 @@ public class ProxyTest {
     api.createRestAssured3().given()
         .post("/_/proxy/cleanup/modules?saveReleases=0&saveSnapshots=1")
         .then().statusCode(400)
-        .body(is("clean up modules: Missing dependency: moduleB-1.0.0 requires intA: 1.0"));
+        .body(containsString("Missing dependency: moduleB-1.0.0 requires intA: 1.0"));
 
+    // this will also remove moduleB-1.0.0
     api.createRestAssured3().given()
-        .header("Content-Type", "application/json")
-        .delete("/_/proxy/modules/moduleB-1.0.0")
-        .then().statusCode(204);
-
-    api.createRestAssured3().given()
-        .post("/_/proxy/cleanup/modules?saveReleases=0&saveSnapshots=1")
+        .post("/_/proxy/cleanup/modules?saveReleases=0&saveSnapshots=1&removeDependencies=true")
         .then().statusCode(204);
 
     api.createRestAssured3().given()

--- a/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
@@ -4538,6 +4538,29 @@ public class ProxyTest {
   }
 
   @Test
+  public void testCleanupModules(TestContext context) {
+    RestAssuredClient c;
+
+    c = api.createRestAssured3();
+    given()
+        .header("Content-Type", "application/json")
+        .body("{}").post("/_/proxy/cleanup/modules?saveSnapshots=2")
+        .then().statusCode(400)
+        .body(is("Missing value for parameter 'saveReleases'"));
+    given()
+        .header("Content-Type", "application/json")
+        .body("{}").post("/_/proxy/cleanup/modules?saveReleases=1")
+        .then().statusCode(400)
+        .body(is("Missing value for parameter 'saveSnapshots'"));
+    c.given()
+        .header("Content-Type", "application/json")
+        .body("{}").post("/_/proxy/cleanup/modules?saveReleases=1&saveSnapshots=2")
+        .then().statusCode(204);
+    Assert.assertTrue("raml: " + c.getLastReport().toString(),
+        c.getLastReport().isEmpty());
+  }
+
+  @Test
   public void testObsoleteModules(TestContext context) {
     RestAssuredClient c;
 

--- a/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
@@ -4574,21 +4574,15 @@ public class ProxyTest {
 
     List<ModuleDescriptor> modules = new LinkedList<>();
 
-    ModuleDescriptor md = new ModuleDescriptor();
-    md.setId("moduleA-1.0.0-SNAPSHOT.1"); // this snapshot requires intA provided by moduleB-1.0.0
-    md.setProvides(interfaceDescriptors);
+    ModuleDescriptor md = new ModuleDescriptor("moduleA-1.0.0-SNAPSHOT.1");
+    md.setProvides(interfaceDescriptors); // this snapshot requires intA provided by moduleB-1.0.0
     modules.add(md);
 
-    md = new ModuleDescriptor();
-    md.setId("moduleA-1.0.0-SNAPSHOT.2");
-    modules.add(md);
+    modules.add(new ModuleDescriptor("moduleA-1.0.0-SNAPSHOT.2"));
 
-    md = new ModuleDescriptor();
-    md.setId("moduleA-1.0.0");
-    modules.add(md);
+    modules.add(new ModuleDescriptor("moduleA-1.0.0"));
 
-    md = new ModuleDescriptor();
-    md.setId("moduleB-1.0.0");
+    md = new ModuleDescriptor("moduleB-1.0.0");
     md.setRequires(interfaceDescriptors);
     modules.add(md);
 
@@ -4661,18 +4655,9 @@ public class ProxyTest {
         c.getLastReport().isEmpty());
 
     List<ModuleDescriptor> modules = new LinkedList<>();
-
-    ModuleDescriptor md = new ModuleDescriptor();
-    md.setId("moduleA-1.0.0-SNAPSHOT.1");
-    modules.add(md);
-
-    md = new ModuleDescriptor();
-    md.setId("moduleA-1.0.0-SNAPSHOT.2");
-    modules.add(md);
-
-    md = new ModuleDescriptor();
-    md.setId("moduleA-1.0.0");
-    modules.add(md);
+    modules.add(new ModuleDescriptor("moduleA-1.0.0-SNAPSHOT.1"));
+    modules.add(new ModuleDescriptor("moduleA-1.0.0-SNAPSHOT.2"));
+    modules.add(new ModuleDescriptor("moduleA-1.0.0"));
 
     c = api.createRestAssured3();
     c.given()

--- a/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
@@ -4020,12 +4020,12 @@ public class ProxyTest {
 
     given()
         .header("Content-Type", "application/json")
-        .body("{}").post("/_/proxy/cleanup/modules?saveSnapshots=2")
+        .post("/_/proxy/cleanup/modules?saveSnapshots=2")
         .then().statusCode(400)
         .body(is("Missing value for parameter 'saveReleases'"));
     given()
         .header("Content-Type", "application/json")
-        .body("{}").post("/_/proxy/cleanup/modules?saveReleases=1")
+        .post("/_/proxy/cleanup/modules?saveReleases=1")
         .then().statusCode(400)
         .body(is("Missing value for parameter 'saveSnapshots'"));
     api.createRestAssured3().given()
@@ -4097,10 +4097,10 @@ public class ProxyTest {
         .body(new JsonObject().put("id", okapiTenant).encode()).post("/_/proxy/tenants")
         .then().statusCode(201);
 
-    List<ModuleDescriptor> modules = new LinkedList<>();
-    modules.add(new ModuleDescriptor("moduleA-1.0.0-SNAPSHOT.1"));
-    modules.add(new ModuleDescriptor("moduleA-1.0.0-SNAPSHOT.2"));
-    modules.add(new ModuleDescriptor("moduleA-1.0.0"));
+    List<ModuleDescriptor> modules = List.of(
+        new ModuleDescriptor("moduleA-1.0.0-SNAPSHOT.1"),
+        new ModuleDescriptor("moduleA-1.0.0-SNAPSHOT.2"),
+        new ModuleDescriptor("moduleA-1.0.0"));
 
     api.createRestAssured3().given()
         .header("Content-Type", "application/json")

--- a/okapi-core/src/test/java/org/folio/okapi/util/ModuleUtilTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/ModuleUtilTest.java
@@ -163,7 +163,7 @@ class ModuleUtilTest {
   }
 
   @Test
-  void testGetObsolete2() {
+  void testGetObsoleteBackend() {
     String ids[] = new String [] {
         "mod-a-0.9.0-SNAPSHOT.3",
         "mod-a-1.0.0-SNAPSHOT.4",
@@ -188,5 +188,30 @@ class ModuleUtilTest {
     assertThat(obsolete.get(2).getId()).isEqualTo("mod-a-0.8.0-SNAPSHOT.2");
     assertThat(obsolete.get(3).getId()).isEqualTo("mod-a-0.8.0-SNAPSHOT.1");
   }
+
+  @Test
+  void testGetObsoleteUI() {
+    String ids[] = new String [] {
+        "a-2.3.100078",
+        "a-2.3.100079",
+        "a-2.3.0",
+        "a-2.4.0",
+        "a-2.4.10000104",
+        "a-2.4.10000105",
+        "a-2.4.10000106",
+    };
+    List<ModuleDescriptor> mds = new LinkedList<>();
+    for (int i = 0; i < ids.length; i++) {
+      ModuleDescriptor md = new ModuleDescriptor();
+      md.setId(ids[i]);
+      mds.add(md);
+    }
+    assertThat(mds.size()).isEqualTo(7);
+    List<ModuleDescriptor> obsolete = ModuleUtil.getObsolete(mds);
+    assertThat(obsolete.size()).isEqualTo(2);
+    assertThat(obsolete.get(0).getId()).isEqualTo("a-2.3.100079");
+    assertThat(obsolete.get(1).getId()).isEqualTo("a-2.3.100078");
+  }
+
 
 }

--- a/okapi-core/src/test/java/org/folio/okapi/util/ModuleUtilTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/ModuleUtilTest.java
@@ -156,7 +156,7 @@ class ModuleUtilTest {
 
   @Test
   void testGetObsolete1() {
-    assertThat(modulesList.size()).isEqualTo(104);
+    assertThat(modulesList).hasSize(104);
     List<ModuleDescriptor> obsolete = ModuleUtil.getObsolete(modulesList, 1, 0);
     assertThat(obsolete.isEmpty()).isTrue();
   }

--- a/okapi-core/src/test/java/org/folio/okapi/util/ModuleUtilTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/ModuleUtilTest.java
@@ -223,7 +223,6 @@ class ModuleUtilTest {
     assertThat(obsolete.get(0).getId()).isEqualTo("mod-a-0.8.0-SNAPSHOT.1");
   }
 
-
   @Test
   void testGetObsoleteUI() {
     String ids[] = new String [] {

--- a/okapi-core/src/test/java/org/folio/okapi/util/ModuleUtilTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/ModuleUtilTest.java
@@ -174,14 +174,13 @@ class ModuleUtilTest {
         "mod-a-0.8.0",
     };
     List<ModuleDescriptor> mds = new LinkedList<>();
-    for (int i = 0; i < ids.length; i++) {
-      mds.add(new ModuleDescriptor(ids[i]));
+    for (String id : ids) {
+      mds.add(new ModuleDescriptor(id));
     }
-    assertThat(mds.size()).isEqualTo(8);
 
     // remove all snapshots except for latest version
     List<ModuleDescriptor> obsolete = ModuleUtil.getObsolete(mds, 1, 0);
-    assertThat(obsolete.size()).isEqualTo(4);
+    assertThat(obsolete).hasSize(4);
     assertThat(obsolete.get(0).getId()).isEqualTo("mod-a-1.0.0-SNAPSHOT.4");
     assertThat(obsolete.get(1).getId()).isEqualTo("mod-a-0.9.0-SNAPSHOT.3");
     assertThat(obsolete.get(2).getId()).isEqualTo("mod-a-0.8.0-SNAPSHOT.2");
@@ -189,7 +188,7 @@ class ModuleUtilTest {
 
     // remove all snapshots
     obsolete = ModuleUtil.getObsolete(mds, 0, 0);
-    assertThat(obsolete.size()).isEqualTo(6);
+    assertThat(obsolete).hasSize(6);
     assertThat(obsolete.get(0).getId()).isEqualTo("mod-b-1.0.0-SNAPSHOT.1");
     assertThat(obsolete.get(1).getId()).isEqualTo("mod-a-1.1.0-SNAPSHOT.5");
     assertThat(obsolete.get(2).getId()).isEqualTo("mod-a-1.0.0-SNAPSHOT.4");
@@ -199,21 +198,21 @@ class ModuleUtilTest {
 
     // remove all snapshots except latest in all releases
     obsolete = ModuleUtil.getObsolete(mds, 0, 1);
-    assertThat(obsolete.size()).isEqualTo(2);
+    assertThat(obsolete).hasSize(2);
     assertThat(obsolete.get(0).getId()).isEqualTo("mod-a-0.9.0-SNAPSHOT.3");
     assertThat(obsolete.get(1).getId()).isEqualTo("mod-a-0.8.0-SNAPSHOT.1");
 
     // remove all snapshots except latest 2 in all releases
     obsolete = ModuleUtil.getObsolete(mds, 0, 2);
-    assertThat(obsolete.size()).isEqualTo(0);
+    assertThat(obsolete).isEmpty();
 
     obsolete = ModuleUtil.getObsolete(mds, 3, 0);
-    assertThat(obsolete.size()).isEqualTo(2);
+    assertThat(obsolete).hasSize(2);
     assertThat(obsolete.get(0).getId()).isEqualTo("mod-a-0.8.0-SNAPSHOT.2");
     assertThat(obsolete.get(1).getId()).isEqualTo("mod-a-0.8.0-SNAPSHOT.1");
 
     obsolete = ModuleUtil.getObsolete(mds, 3, 1);
-    assertThat(obsolete.size()).isEqualTo(1);
+    assertThat(obsolete).hasSize(1);
     assertThat(obsolete.get(0).getId()).isEqualTo("mod-a-0.8.0-SNAPSHOT.1");
   }
 
@@ -229,21 +228,21 @@ class ModuleUtilTest {
         "a-2.4.10000106",
     };
     List<ModuleDescriptor> mds = new LinkedList<>();
-    for (int i = 0; i < ids.length; i++) {
-      mds.add(new ModuleDescriptor(ids[i]));
+    for (String id : ids) {
+      mds.add(new ModuleDescriptor(id));
     }
-    assertThat(mds.size()).isEqualTo(7);
+
     List<ModuleDescriptor> obsolete = ModuleUtil.getObsolete(mds, 1, 0);
-    assertThat(obsolete.size()).isEqualTo(2);
+    assertThat(obsolete).hasSize(2);
     assertThat(obsolete.get(0).getId()).isEqualTo("a-2.3.100079");
     assertThat(obsolete.get(1).getId()).isEqualTo("a-2.3.100078");
 
     obsolete = ModuleUtil.getObsolete(mds, 1, 1);
-    assertThat(obsolete.size()).isEqualTo(1);
+    assertThat(obsolete).hasSize(1);
     assertThat(obsolete.get(0).getId()).isEqualTo("a-2.3.100078");
 
     obsolete = ModuleUtil.getObsolete(mds, 2, 0);
-    assertThat(obsolete.size()).isEqualTo(0);
+    assertThat(obsolete).isEmpty();
   }
 
   @Test

--- a/okapi-core/src/test/java/org/folio/okapi/util/ModuleUtilTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/ModuleUtilTest.java
@@ -161,7 +161,7 @@ class ModuleUtilTest {
   @Test
   void testGetObsolete1() {
     assertThat(modulesList.size()).isEqualTo(104);
-    List<ModuleDescriptor> obsolete = ModuleUtil.getObsolete(modulesList);
+    List<ModuleDescriptor> obsolete = ModuleUtil.getObsolete(modulesList, 1, 0);
     assertThat(obsolete.isEmpty()).isTrue();
   }
 
@@ -184,13 +184,45 @@ class ModuleUtilTest {
       mds.add(md);
     }
     assertThat(mds.size()).isEqualTo(8);
-    List<ModuleDescriptor> obsolete = ModuleUtil.getObsolete(mds);
+
+    // remove all snapshots except for latest version
+    List<ModuleDescriptor> obsolete = ModuleUtil.getObsolete(mds, 1, 0);
     assertThat(obsolete.size()).isEqualTo(4);
     assertThat(obsolete.get(0).getId()).isEqualTo("mod-a-1.0.0-SNAPSHOT.4");
     assertThat(obsolete.get(1).getId()).isEqualTo("mod-a-0.9.0-SNAPSHOT.3");
     assertThat(obsolete.get(2).getId()).isEqualTo("mod-a-0.8.0-SNAPSHOT.2");
     assertThat(obsolete.get(3).getId()).isEqualTo("mod-a-0.8.0-SNAPSHOT.1");
+
+    // remove all snapshots
+    obsolete = ModuleUtil.getObsolete(mds, 0, 0);
+    assertThat(obsolete.size()).isEqualTo(6);
+    assertThat(obsolete.get(0).getId()).isEqualTo("mod-b-1.0.0-SNAPSHOT.1");
+    assertThat(obsolete.get(1).getId()).isEqualTo("mod-a-1.1.0-SNAPSHOT.5");
+    assertThat(obsolete.get(2).getId()).isEqualTo("mod-a-1.0.0-SNAPSHOT.4");
+    assertThat(obsolete.get(3).getId()).isEqualTo("mod-a-0.9.0-SNAPSHOT.3");
+    assertThat(obsolete.get(4).getId()).isEqualTo("mod-a-0.8.0-SNAPSHOT.2");
+    assertThat(obsolete.get(5).getId()).isEqualTo("mod-a-0.8.0-SNAPSHOT.1");
+
+    // remove all snapshots except latest in all releases
+    obsolete = ModuleUtil.getObsolete(mds, 0, 1);
+    assertThat(obsolete.size()).isEqualTo(2);
+    assertThat(obsolete.get(0).getId()).isEqualTo("mod-a-0.9.0-SNAPSHOT.3");
+    assertThat(obsolete.get(1).getId()).isEqualTo("mod-a-0.8.0-SNAPSHOT.1");
+
+    // remove all snapshots except latest 2 in all releases
+    obsolete = ModuleUtil.getObsolete(mds, 0, 2);
+    assertThat(obsolete.size()).isEqualTo(0);
+
+    obsolete = ModuleUtil.getObsolete(mds, 3, 0);
+    assertThat(obsolete.size()).isEqualTo(2);
+    assertThat(obsolete.get(0).getId()).isEqualTo("mod-a-0.8.0-SNAPSHOT.2");
+    assertThat(obsolete.get(1).getId()).isEqualTo("mod-a-0.8.0-SNAPSHOT.1");
+
+    obsolete = ModuleUtil.getObsolete(mds, 3, 1);
+    assertThat(obsolete.size()).isEqualTo(1);
+    assertThat(obsolete.get(0).getId()).isEqualTo("mod-a-0.8.0-SNAPSHOT.1");
   }
+
 
   @Test
   void testGetObsoleteUI() {
@@ -210,10 +242,17 @@ class ModuleUtilTest {
       mds.add(md);
     }
     assertThat(mds.size()).isEqualTo(7);
-    List<ModuleDescriptor> obsolete = ModuleUtil.getObsolete(mds);
+    List<ModuleDescriptor> obsolete = ModuleUtil.getObsolete(mds, 1, 0);
     assertThat(obsolete.size()).isEqualTo(2);
     assertThat(obsolete.get(0).getId()).isEqualTo("a-2.3.100079");
     assertThat(obsolete.get(1).getId()).isEqualTo("a-2.3.100078");
+
+    obsolete = ModuleUtil.getObsolete(mds, 1, 1);
+    assertThat(obsolete.size()).isEqualTo(1);
+    assertThat(obsolete.get(0).getId()).isEqualTo("a-2.3.100078");
+
+    obsolete = ModuleUtil.getObsolete(mds, 2, 0);
+    assertThat(obsolete.size()).isEqualTo(0);
   }
 
   @Test

--- a/okapi-core/src/test/java/org/folio/okapi/util/ModuleUtilTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/ModuleUtilTest.java
@@ -158,7 +158,7 @@ class ModuleUtilTest {
   void testGetObsolete1() {
     assertThat(modulesList).hasSize(104);
     List<ModuleDescriptor> obsolete = ModuleUtil.getObsolete(modulesList, 1, 0);
-    assertThat(obsolete.isEmpty()).isTrue();
+    assertThat(obsolete).isEmpty();
   }
 
   @Test

--- a/okapi-core/src/test/java/org/folio/okapi/util/ModuleUtilTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/ModuleUtilTest.java
@@ -154,4 +154,39 @@ class ModuleUtilTest {
     list.add(md);
     assertThat(ModuleUtil.moduleList(list)).isEqualTo("foo-1.0.0, bar-2.0.0");
   }
+
+  @Test
+  void testGetObsolete1() {
+    assertThat(modulesList.size()).isEqualTo(104);
+    List<ModuleDescriptor> obsolete = ModuleUtil.getObsolete(modulesList);
+    assertThat(obsolete.isEmpty()).isTrue();
+  }
+
+  @Test
+  void testGetObsolete2() {
+    String ids[] = new String [] {
+        "mod-a-0.9.0-SNAPSHOT.3",
+        "mod-a-1.0.0-SNAPSHOT.4",
+        "mod-a-1.0.0",
+        "mod-b-1.0.0-SNAPSHOT.1",
+        "mod-a-1.1.0-SNAPSHOT.5",
+        "mod-a-0.8.0-SNAPSHOT.1",
+        "mod-a-0.8.0-SNAPSHOT.2",
+        "mod-a-0.8.0",
+    };
+    List<ModuleDescriptor> mds = new LinkedList<>();
+    for (int i = 0; i < ids.length; i++) {
+      ModuleDescriptor md = new ModuleDescriptor();
+      md.setId(ids[i]);
+      mds.add(md);
+    }
+    assertThat(mds.size()).isEqualTo(8);
+    List<ModuleDescriptor> obsolete = ModuleUtil.getObsolete(mds);
+    assertThat(obsolete.size()).isEqualTo(4);
+    assertThat(obsolete.get(0).getId()).isEqualTo("mod-a-1.0.0-SNAPSHOT.4");
+    assertThat(obsolete.get(1).getId()).isEqualTo("mod-a-0.9.0-SNAPSHOT.3");
+    assertThat(obsolete.get(2).getId()).isEqualTo("mod-a-0.8.0-SNAPSHOT.2");
+    assertThat(obsolete.get(3).getId()).isEqualTo("mod-a-0.8.0-SNAPSHOT.1");
+  }
+
 }

--- a/okapi-core/src/test/java/org/folio/okapi/util/ModuleUtilTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/ModuleUtilTest.java
@@ -1,6 +1,9 @@
 package org.folio.okapi.util;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import io.vertx.core.MultiMap;
+import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.JsonArray;
 import java.io.IOException;
 import java.util.LinkedList;
@@ -213,5 +216,14 @@ class ModuleUtilTest {
     assertThat(obsolete.get(1).getId()).isEqualTo("a-2.3.100078");
   }
 
-
+  @Test
+  void testGetParamInteger() {
+    MultiMap params = MultiMap.caseInsensitiveMultiMap();
+    assertThat(ModuleUtil.getParamInteger(params, "x", 1)).isEqualTo(1);
+    assertThrows(DecodeException.class, () -> ModuleUtil.getParamInteger(params, "x", null));
+    params.add("x", "2");
+    assertThat(ModuleUtil.getParamInteger(params, "x", 1)).isEqualTo(2);
+    params.add("y", "bad");
+    assertThrows(DecodeException.class, () -> ModuleUtil.getParamInteger(params, "y", 1));
+  }
 }

--- a/okapi-core/src/test/java/org/folio/okapi/util/ModuleUtilTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/ModuleUtilTest.java
@@ -175,9 +175,7 @@ class ModuleUtilTest {
     };
     List<ModuleDescriptor> mds = new LinkedList<>();
     for (int i = 0; i < ids.length; i++) {
-      ModuleDescriptor md = new ModuleDescriptor();
-      md.setId(ids[i]);
-      mds.add(md);
+      mds.add(new ModuleDescriptor(ids[i]));
     }
     assertThat(mds.size()).isEqualTo(8);
 
@@ -232,9 +230,7 @@ class ModuleUtilTest {
     };
     List<ModuleDescriptor> mds = new LinkedList<>();
     for (int i = 0; i < ids.length; i++) {
-      ModuleDescriptor md = new ModuleDescriptor();
-      md.setId(ids[i]);
-      mds.add(md);
+      mds.add(new ModuleDescriptor(ids[i]));
     }
     assertThat(mds.size()).isEqualTo(7);
     List<ModuleDescriptor> obsolete = ModuleUtil.getObsolete(mds, 1, 0);


### PR DESCRIPTION
New service `/_/proxy/cleanup/modules?saveReleases=`N`&saveSnapshots=`M

where
 N is the number of latest releases where snapshots are never considered obsolete
 M is the number of latest snapshots that are never considered obsolete (preserved)

Remove method Future<Void> insert(ModuleDescriptor md) from
ModuleStore interface as it's no longer in use with OKAPI-1023
work.