### PR TITLE
OKAPI-1025: /_/proxy/tenants/{tenant_id}/upgrade with body

### DIFF
--- a/okapi-core/pom.xml
+++ b/okapi-core/pom.xml
@@ -153,7 +153,13 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
-      <version>3.4.6</version>
+      <version>3.11.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <version>3.11.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/okapi-core/src/main/java/org/folio/okapi/managers/InternalModule.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/InternalModule.java
@@ -15,6 +15,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.folio.okapi.bean.DeploymentDescriptor;
 import org.folio.okapi.bean.EnvEntry;
@@ -834,8 +835,13 @@ public class InternalModule {
     return tenantManager.installUpgradeDelete(tenantId, installId).map("");
   }
 
-  private Future<String> upgradeModulesForTenant(ProxyContext pc, String tenantId) {
-
+  private Future<String> upgradeModulesForTenant(ProxyContext pc, String tenantId, String body) {
+    if (! StringUtils.isEmpty(body)) {
+      return Future.failedFuture("/_/proxy/tenants/{tenant_id}/upgrade "
+          + "(upgrading to latest version) must not have a body. "
+          + "Use /_/proxy/tenants/{tenant_id}/install instead "
+          + "to specify which version to upgrade to.");
+    }
     TenantInstallOptions options = ModuleUtil.createTenantOptions(pc.getCtx().request().params());
     UUID installId = UUID.randomUUID();
     return tenantManager.installUpgradeCreate(tenantId, installId.toString(), pc, options, null)
@@ -1317,7 +1323,7 @@ public class InternalModule {
         }
         // /_/proxy/tenants/:id/upgrade
         if (n == 6 && m.equals(HttpMethod.POST) && segments[5].equals("upgrade")) {
-          return upgradeModulesForTenant(pc, decodedSegs[4]);
+          return upgradeModulesForTenant(pc, decodedSegs[4], req);
         }
         // /_/proxy/tenants/:id/interfaces
         if (n == 6 && m.equals(HttpMethod.GET) && segments[5].equals("interfaces")) {

--- a/okapi-core/src/main/raml/okapi.raml
+++ b/okapi-core/src/main/raml/okapi.raml
@@ -1040,8 +1040,9 @@ types:
                 text/plain:
     /upgrade:
       post:
-        description: Check if newer modules exist, and upgrade for tenant.
-          The response is a list of modules that should be enabled, disabled
+        description: Upgrade each module to the latest version. The upgrade is
+          rejected if it would violate the interface dependencies of the modules.
+          The response is a list of modules that have been enabled, disabled
           or upgraded to perform the upgrade.
         queryParameters:
           async:

--- a/okapi-core/src/test/java/org/folio/okapi/managers/InternalModuleTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/managers/InternalModuleTest.java
@@ -1,0 +1,72 @@
+package org.folio.okapi.managers;
+
+import static org.mockito.Mockito.*;
+
+import io.vertx.core.Future;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.assertj.core.api.WithAssertions;
+import org.folio.okapi.util.ProxyContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(VertxExtension.class)
+@ExtendWith(MockitoExtension.class)
+class InternalModuleTest implements WithAssertions {
+
+  Future<String> internalService(HttpMethod httpMethod, String path, String body) {
+    // deep stub is not a code smell because HttpServerRequest implementations
+    // don't have a public constructor
+    ProxyContext proxyContext = mock(ProxyContext.class, RETURNS_DEEP_STUBS);
+    when(proxyContext.getCtx().request().method()).thenReturn(httpMethod);
+    when(proxyContext.getCtx().normalizedPath()).thenReturn(path);
+    InternalModule internalModule = new InternalModule(
+        null, mock(TenantManager.class), null, null, null, null, "1.2.3");
+    return internalModule.internalService(body, proxyContext);
+  }
+
+  @Test
+  void upgradeModuleForTenantWithBody(VertxTestContext vtc) {
+    String body = "[{ \"id\":\"mod-users-17.3.0\", \"action\": \"enable\" }]";
+    internalService(HttpMethod.POST, "/_/proxy/tenants/diku/upgrade", body)
+        .onComplete(vtc.failing(t -> {
+          assertThat(t).hasMessageContaining("must not have a body");
+          vtc.completeNow();
+        }));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "/_/proxy/import/modules",
+    "/_/proxy/modules",
+    "/_/proxy/modules/:id",
+    "/_/proxy/tenants",
+    "/_/proxy/tenants/:id",
+    "/_/proxy/tenants/:id/interfaces/:int",
+    "/_/proxy/tenants/:id/timers",
+    "/_/proxy/tenants/:id/timers/:timer",
+    "/_/proxy/pull/modules",
+    "/_/proxy/health",
+    "/_/discovery/modules",
+    "/_/discovery/modules/:srvcid",
+    "/_/discovery/modules/:srvcid/:instid",
+    "/_/discovery/health",
+    "/_/discovery/health/:srvcId",
+    "/_/discovery/health/:srvcId/:instid",
+    "/_/env",
+    "/_/env/:name",
+    "/_/version",
+  })
+  void pathNotFound(String path, VertxTestContext vtc) {
+    internalService(HttpMethod.OPTIONS, path, null)
+        .onComplete(vtc.failing(t -> {
+          assertThat(t).hasMessageContainingAll("Unhandled internal module path", path);
+          vtc.completeNow();
+        }));
+  }
+
+}


### PR DESCRIPTION
/_/proxy/tenants/{tenant_id}/upgrade upgrades each module to the latest version
and therefore doesn't needs a body to list the version to upgrade to.

Steps to Reproduce:

* POST /_/proxy/tenants/{tenant_id}/upgrade with body

Expected Results:

Error message about the useless body.

Actual Results:

Upgrades to latest versions ignoring the version specified in the body.

Additional Information:

The documentation in
https://github.com/folio-org/okapi/blob/v4.8.2/okapi-core/src/main/raml/okapi.raml
correctly explains that no body is needed and it upgrades to the latest version.
(The wording can be improved, though.)

Okapi provides
 * /_/proxy/tenants/{tenant_id}/install
 * /_/proxy/tenants/{tenant_id}/upgrade

being misleading at first glance because one might assume that install is intended
for initial install and upgrade is intended for upgrades.
Rejecting upgrade with body will prevent any unintentional results.