### PR TITLE
Add ModuleDescriptor constructor with id

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/bean/ModuleDescriptor.java
+++ b/okapi-core/src/main/java/org/folio/okapi/bean/ModuleDescriptor.java
@@ -40,6 +40,10 @@ public class ModuleDescriptor implements Comparable<ModuleDescriptor> {
   public ModuleDescriptor() {
   }
 
+  public ModuleDescriptor(String id) {
+    setId(id);
+  }
+
   /**
    * Copy constructor with id and tags from original.
    *

--- a/okapi-core/src/test/java/org/folio/okapi/bean/ModuleDescriptorTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/bean/ModuleDescriptorTest.java
@@ -90,4 +90,11 @@ public class ModuleDescriptorTest {
     assertEquals(3, perms.length);
     assertTrue(Json.encode(perms).contains("regular"));
   }
+
+  @Test
+  public void testConstructorWithId() {
+    ModuleDescriptor md = new ModuleDescriptor("foo-1.2.3");
+    assertEquals("foo-1.2.3", md.getId());
+    assertEquals("foo", md.getProduct());
+  }
 }

--- a/okapi-core/src/test/java/org/folio/okapi/util/ModuleUtilTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/ModuleUtilTest.java
@@ -141,17 +141,13 @@ class ModuleUtilTest {
 
   @Test
   void testModuleList() {
-    List<ModuleDescriptor> list = new LinkedList<>();
+    List<ModuleDescriptor> list = List.of();
     assertThat(ModuleUtil.moduleList(list)).isEmpty();
 
-    ModuleDescriptor md = new ModuleDescriptor();
-    md.setId("foo-1.0.0");
-    list.add(md);
+    list = List.of(new ModuleDescriptor("foo-1.0.0"));
     assertThat(ModuleUtil.moduleList(list)).isEqualTo("foo-1.0.0");
 
-    md = new ModuleDescriptor();
-    md.setId("bar-2.0.0");
-    list.add(md);
+    list = List.of(new ModuleDescriptor("foo-1.0.0"), new ModuleDescriptor("bar-2.0.0"));
     assertThat(ModuleUtil.moduleList(list)).isEqualTo("foo-1.0.0, bar-2.0.0");
   }
 }


### PR DESCRIPTION
Reduces boilerplate code in tests, see example in ModuleUtilTest.