### PR TITLE
Disable X-Okapi-Trace header by default OKAPI-1038

### DIFF
--- a/doc/guide.md
+++ b/doc/guide.md
@@ -934,11 +934,14 @@ Note: for this example to work it is important that the current directory
 of the Okapi is the top-level directory `.../okapi`.
 
 ```
-java -jar okapi-core/target/okapi-core-fat.jar dev
+java -Dtrace_headers=true -jar okapi-core/target/okapi-core-fat.jar dev
 ```
 
 The `dev` command tells to run it in development mode, which makes it start
 with a known clean state without any modules or tenants defined.
+
+Setting `trace_headers` to `true` makes Okapi return HTTP header
+`X-Okapi-Trace` with information about modules involved in a call.
 
 Okapi lists its PID (process ID) and says `API Gateway started`.  That
 means it is running, and listening on the default port which happens
@@ -2842,6 +2845,13 @@ leave it unmodified (default).
   Maximum number of iterations for deployment - before
   giving up (readiness check). Defaults to 60. A value, `n`, corresponds to roughly `n*n*0.2` seconds.
   This value, if set, overrides the `waitIterations` in the launch descriptor.
+* `trace_headers`: Controls whether Okapi adds X-Okapi-Trace headers. The
+ value is a boolean - `true` for enable, `false` for disable. Default is `false`.
+This property appeared in Okapi 4.10.0; trace header was always enabled
+before 4.10.0.
+* `enable_system_auth`: Controls whether Okapi checks token by calling Auth module
+when invoking system interfaces such as `_tenant`.
+The value is a boolean - `true` for enable, `false` for disable.  Default is `true`.
 
 #### Command
 

--- a/okapi-core/src/main/java/org/folio/okapi/ConfNames.java
+++ b/okapi-core/src/main/java/org/folio/okapi/ConfNames.java
@@ -14,6 +14,8 @@ public final class ConfNames {
 
   public static final String DEPLOY_WAIT_ITERATIONS = "deploy.waitIterations";
   public static final String DOCKER_URL = "dockerUrl";
+  public static final String ENABLE_TRACE_HEADERS = "trace_headers";
+  public static final String ENABLE_SYSTEM_AUTH = "enable_system_auth";
 
   private ConfNames() {
     throw new UnsupportedOperationException("Cannot instantiate utility class.");

--- a/okapi-core/src/main/raml/okapi.raml
+++ b/okapi-core/src/main/raml/okapi.raml
@@ -46,6 +46,7 @@ types:
           Location:
             description: URI to the descriptor of the deployed instance
           X-Okapi-Trace:
+            required: false
             description: Okapi trace and timing
         body:
           application/json:
@@ -71,6 +72,7 @@ types:
             type: DeploymentDescriptorList
         headers:
           X-Okapi-Trace:
+            required: false
             description: Okapi trace and timing
   /{instance_id}:
     get:
@@ -82,6 +84,7 @@ types:
               type: DeploymentDescriptor
           headers:
             X-Okapi-Trace:
+              required: false
               description: Okapi trace and timing
         404:
           description: Not Found
@@ -93,6 +96,7 @@ types:
         204:
           headers:
             X-Okapi-Trace:
+              required: false
               description: Okapi trace and timing
 
 /_/discovery/modules:
@@ -111,6 +115,7 @@ types:
           Location:
             description: URI to the registered instance
           X-Okapi-Trace:
+            required: false
             description: Okapi trace and timing
         body:
           application/json:
@@ -134,6 +139,7 @@ types:
         description: OK
         headers:
           X-Okapi-Trace:
+            required: false
             description: Okapi trace and timing
         body:
           application/json:
@@ -153,6 +159,7 @@ types:
         description: OK
         headers:
           X-Okapi-Trace:
+            required: false
             description: Okapi trace and timing
       400:
         description: Bad Request
@@ -172,6 +179,7 @@ types:
               type: DeploymentDescriptorList
           headers:
             X-Okapi-Trace:
+              required: false
               description: Okapi trace and timing
         400:
           description: Bad Request
@@ -192,6 +200,7 @@ types:
           description: No Content
           headers:
             X-Okapi-Trace:
+              required: false
               description: Okapi trace and timing
         404:
           description: Not Found
@@ -207,6 +216,7 @@ types:
                 type: DeploymentDescriptor
             headers:
               X-Okapi-Trace:
+                required: false
                 description: Okapi trace and timing
           404:
             description: Not Found
@@ -218,6 +228,7 @@ types:
           204:
             headers:
               X-Okapi-Trace:
+                required: false
                 description: Okapi trace and timing
           404:
             description: Not Found
@@ -234,6 +245,7 @@ types:
             type: HealthDescriptorList
         headers:
           X-Okapi-Trace:
+            required: false
             description: Okapi trace and timing
       400:
         description: Bad Request
@@ -253,6 +265,7 @@ types:
               type: HealthDescriptorList
           headers:
             X-Okapi-Trace:
+              required: false
               description: Okapi trace and timing
         404:
           description: Not Found
@@ -268,6 +281,7 @@ types:
                 type: HealthDescriptor
             headers:
               X-Okapi-Trace:
+                required: false
                 description: Okapi trace and timing
           404:
             description: Not Found
@@ -284,6 +298,7 @@ types:
             type: NodeDescriptorList
         headers:
           X-Okapi-Trace:
+            required: false
             description: Okapi trace and timing
       400:
         description: Bad Request
@@ -303,6 +318,7 @@ types:
         200:
           headers:
             X-Okapi-Trace:
+              required: false
               description: Okapi trace and timing
           body:
             application/json:
@@ -328,6 +344,7 @@ types:
               type: NodeDescriptor
           headers:
             X-Okapi-Trace:
+              required: false
               description: Okapi trace and timing
         400:
           description: Bad Request
@@ -372,6 +389,7 @@ types:
         description: OK
         headers:
           X-Okapi-Trace:
+            required: false
             description: Okapi trace and timing
       400:
         description: Bad Request
@@ -411,6 +429,7 @@ types:
         description: OK
         headers:
           X-Okapi-Trace:
+            required: true
             description: Okapi trace and timing
       400:
         description: Bad Request
@@ -454,6 +473,7 @@ types:
         description: Created
         headers:
           X-Okapi-Trace:
+            required: false
             description: Okapi trace and timing
           Location:
             description: URI to the created module instance
@@ -523,6 +543,7 @@ types:
       200:
         headers:
           X-Okapi-Trace:
+            required: false
             description: Okapi trace and timing
         body:
           application/json:
@@ -543,6 +564,7 @@ types:
         200:
           headers:
             X-Okapi-Trace:
+              required: false
               description: Okapi trace and timing
           body:
             application/json:
@@ -554,6 +576,7 @@ types:
         204:
           headers:
             X-Okapi-Trace:
+              required: false
               description: Okapi trace and timing
         400:
           description: Bad Request
@@ -575,6 +598,7 @@ types:
         description: Tenant has been created
         headers:
           X-Okapi-Trace:
+            required: false
             description: Okapi trace and timing
           Location:
             description: URI to the created tenant
@@ -592,6 +616,7 @@ types:
         description: List of tenants in a brief format
         headers:
           X-Okapi-Trace:
+            required: false
             description: Okapi trace and timing
         body:
           application/json:
@@ -603,6 +628,7 @@ types:
         200:
           headers:
             X-Okapi-Trace:
+              required: false
               description: Okapi trace and timing
           body:
             application/json:
@@ -620,6 +646,7 @@ types:
         200:
           headers:
             X-Okapi-Trace:
+              required: false
               description: Okapi trace and timing
           body:
             application/json:
@@ -638,6 +665,7 @@ types:
         204:
           headers:
             X-Okapi-Trace:
+              required: false
               description: Okapi trace and timing
         400:
           description: Bad Request
@@ -664,6 +692,7 @@ types:
             description: Created
             headers:
               X-Okapi-Trace:
+                required: false
                 description: Okapi trace and timing
               Location:
                 description: URI to the enabled module
@@ -738,6 +767,7 @@ types:
           200:
             headers:
               X-Okapi-Trace:
+                required: false
                 description: Okapi trace and timing
             body:
               application/json:
@@ -777,6 +807,7 @@ types:
             description: OK
             headers:
               X-Okapi-Trace:
+                required: false
                 description: Okapi trace and timing
           400:
             description: Bad Request
@@ -799,6 +830,7 @@ types:
             200:
               headers:
                 X-Okapi-Trace:
+                  required: false
                   description: Okapi trace and timing
               body:
                 application/json:
@@ -839,6 +871,7 @@ types:
               description: Created
               headers:
                 X-Okapi-Trace:
+                  required: false
                   description: Okapi trace and timing
                 Location:
                   description: URI to the enabled module
@@ -884,6 +917,7 @@ types:
               description: Gone
               headers:
                 X-Okapi-Trace:
+                  required: false
                   description: Okapi trace and timing
             400:
               description: Client Error
@@ -901,6 +935,7 @@ types:
                 type: InstallJobList
             headers:
               X-Okapi-Trace:
+                required: false
                 description: Okapi trace and timing
           400:
             description: User error
@@ -921,6 +956,7 @@ types:
             description: OK
             headers:
               X-Okapi-Trace:
+                required: false
                 description: Okapi trace and timing
           400:
             description: Bad Request
@@ -1014,6 +1050,7 @@ types:
                 type: TenantModuleDescriptorList
             headers:
               X-Okapi-Trace:
+                required: false
                 description: Okapi trace and timing
           201:
             description: Install job created (async mode)
@@ -1024,6 +1061,7 @@ types:
               Location:
                 description: URI to the install job
               X-Okapi-Trace:
+                required: false
                 description: Okapi trace and timing
           400:
             description: Bad Request
@@ -1048,6 +1086,7 @@ types:
                   type: InstallJob
               headers:
                 X-Okapi-Trace:
+                  required: false
                   description: Okapi trace and timing
             400:
               description: User error
@@ -1068,6 +1107,7 @@ types:
               description: OK
               headers:
                 X-Okapi-Trace:
+                  required: false
                   description: Okapi trace and timing
             400:
               description: User error
@@ -1146,6 +1186,7 @@ types:
                 type: TenantModuleDescriptorList
             headers:
               X-Okapi-Trace:
+                required: false
                 description: Okapi trace and timing
           201:
             description: Install job created (async mode)
@@ -1156,6 +1197,7 @@ types:
               Location:
                 description: URI to the install job
               X-Okapi-Trace:
+                required: false
                 description: Okapi trace and timing
           400:
             description: Bad Request
@@ -1186,6 +1228,7 @@ types:
           200:
             headers:
               X-Okapi-Trace:
+                required: false
                 description: Okapi trace and timing
             body:
               application/json:
@@ -1215,6 +1258,7 @@ types:
             200:
               headers:
                 X-Okapi-Trace:
+                  required: false
                   description: Okapi trace and timing
               body:
                 application/json:
@@ -1238,6 +1282,7 @@ types:
           200:
             headers:
               X-Okapi-Trace:
+                required: false
                 description: Okapi trace and timing
             body:
               application/json:
@@ -1268,6 +1313,7 @@ types:
             description: Patch OK
             headers:
               X-Okapi-Trace:
+                required: false
                 description: Okapi trace and timing
           400:
             description: Client Error
@@ -1288,6 +1334,7 @@ types:
             200:
               headers:
                 X-Okapi-Trace:
+                  required: false
                   description: Okapi trace and timing
               body:
                 application/json:
@@ -1317,6 +1364,7 @@ types:
               description: Patch OK
               headers:
                 X-Okapi-Trace:
+                  required: false
                   description: Okapi trace and timing
             400:
               description: Client Error
@@ -1342,6 +1390,7 @@ types:
             type: HealthStatusList
         headers:
           X-Okapi-Trace:
+            required: false
             description: Okapi trace and timing
       500:
         description: Server Error
@@ -1361,6 +1410,7 @@ types:
         description: OK
         headers:
           X-Okapi-Trace:
+            required: false
             description: Okapi trace and timing
         body:
           application/json:
@@ -1394,6 +1444,7 @@ types:
           Location:
             description: URI to the environment entry instance
           X-Okapi-Trace:
+            required: false
             description: Okapi trace and timing
         body:
           application/json:
@@ -1415,6 +1466,7 @@ types:
             type: EnvEntryList
         headers:
           X-Okapi-Trace:
+            required: false
             description: Okapi trace and timing
       400:
         description: Bad Request
@@ -1434,6 +1486,7 @@ types:
               type: EnvEntry
           headers:
             X-Okapi-Trace:
+              required: false
               description: Okapi trace and timing
         400:
           description: Bad Request
@@ -1453,6 +1506,7 @@ types:
         204:
           headers:
             X-Okapi-Trace:
+              required: false
               description: Okapi trace and timing
         404:
           description: Not Found
@@ -1470,6 +1524,7 @@ types:
           text/plain:
         headers:
           X-Okapi-Trace:
+            required: false
             description: Okapi trace and timing
       400:
         description: Bad Request

--- a/okapi-core/src/test/java/org/folio/okapi/ModuleTenantsTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ModuleTenantsTest.java
@@ -49,8 +49,9 @@ public class ModuleTenantsTest {
     vertx = Vertx.vertx();
     httpClient = vertx.createHttpClient();
     JsonObject conf = new JsonObject()
-      .put("port", Integer.toString(port))
-      .put("logWaitMs", 200);
+        .put("port", Integer.toString(port))
+        .put(ConfNames.ENABLE_TRACE_HEADERS, false)
+        .put("logWaitMs", 200);
 
     DeploymentOptions opt = new DeploymentOptions()
       .setConfig(conf);
@@ -292,11 +293,13 @@ public class ModuleTenantsTest {
 
     // run module
     c = api.createRestAssured3();
-    c.given().header("X-Okapi-Tenant", okapiTenant)
-      .body("Okapi").post("/testb/foo")
-      .then().log().ifValidationFails()
-      .statusCode(200)
-      .body(equalTo("Hello Okapi"));
+    String trace = c.given().header("X-Okapi-Tenant", okapiTenant)
+        .body("Okapi").post("/testb/foo")
+        .then().log().ifValidationFails()
+        .statusCode(200)
+        .body(equalTo("Hello Okapi"))
+        .extract().header("X-Okapi-Trace");
+    Assert.assertNull(trace); // test trace headers disabled by default.
 
     c = api.createRestAssured3();
     c.given().header("X-Okapi-Tenant", okapiTenant)

--- a/okapi-core/src/test/java/org/folio/okapi/ModuleTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ModuleTest.java
@@ -121,6 +121,7 @@ public class ModuleTest {
 
     conf.put("storage", value)
         .put(ConfNames.DEPLOY_WAIT_ITERATIONS, 30)
+        .put(ConfNames.ENABLE_TRACE_HEADERS, true)
         .put("port", "9230")
         .put("port_start", "9231")
         .put("port_end", "9237")

--- a/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
@@ -357,7 +357,7 @@ public class ProxyTest {
             .put("loglevel", "info")
             .put("port", Integer.toString(port))
             .put("healthPort", Integer.toString(portHealth))
-            .put("httpCache", true));
+            .put(ConfNames.ENABLE_TRACE_HEADERS, true));
     Promise<Void> promise = Promise.promise();
     vertx.deployVerticle(MainVerticle.class.getName(), opt, x -> promise.handle(x.mapEmpty()));
     return promise.future();


### PR DESCRIPTION
This, strickly speaking, a breaking change since the default
behavior has changed. But nothing, except reporting tools,
will be affected by this. Headers can be controlled with
config trace_headers.