### PR TITLE
Hazelcast 4.2.2, logging log4j2 OKAPI-1048

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/MainDeploy.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainDeploy.java
@@ -193,7 +193,7 @@ public class MainDeploy {
         interfacesConfig.setEnabled(true).addInterface(clusterHost);
       }
     }
-    hazelcastConfig.setProperty("hazelcast.logging.type", "log4j");
+    hazelcastConfig.setProperty("hazelcast.logging.type", "log4j2");
 
     HazelcastClusterManager mgr = new HazelcastClusterManager(hazelcastConfig);
     vopt.setClusterManager(mgr);

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
       <dependency>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast</artifactId>
-        <version>4.0.2</version>  <!-- https://github.com/vert-x3/vertx-hazelcast/blob/master/pom.xml -->
+        <version>4.2.2</version>  <!-- https://github.com/vert-x3/vertx-hazelcast/blob/master/pom.xml -->
       </dependency>
       <dependency>
         <groupId>com.hazelcast</groupId>


### PR DESCRIPTION
Upgrade Hazelcast from 4.0.2 to 4.2.2 which is
what Vert.x 4.2.1 is using anyway. And set logging
type to log4j2 (rather than log4j).