### PR TITLE
OKAPI-1050: -Dlog4j2.formatMsgNoLookups=true for Debian/Ubuntu

### DIFF
--- a/dist/okapi.env
+++ b/dist/okapi.env
@@ -10,7 +10,7 @@
 #JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk-amd64/bin/java"
 
 # Add additional JVM space separated options here.
-OKAPI_JAVA_OPTS="-Djava.awt.headless=true"
+OKAPI_JAVA_OPTS="-Djava.awt.headless=true -Dlog4j2.formatMsgNoLookups=true"
 
 # Default Okapi settings
 OKAPI_USER="okapi"


### PR DESCRIPTION
Fixes the log4j remote execution security issue (CVE-2021-44228).