### PR TITLE
OKAPI-1053: Add module users section to raml schema

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/bean/ModuleDescriptor.java
+++ b/okapi-core/src/main/java/org/folio/okapi/bean/ModuleDescriptor.java
@@ -36,7 +36,7 @@ public class ModuleDescriptor implements Comparable<ModuleDescriptor> {
   private UiModuleDescriptor uiDescriptor;
   private LaunchDescriptor launchDescriptor;
   private ModuleId[] replaces;
-  private ModuleUser[] user;
+  private ModuleUser user;
 
   public ModuleDescriptor() {
   }
@@ -486,11 +486,11 @@ public class ModuleDescriptor implements Comparable<ModuleDescriptor> {
     return id.getProduct();
   }
 
-  public ModuleUser[] getUser() {
+  public ModuleUser getUser() {
     return user;
   }
 
-  public void setUser(ModuleUser[] user) {
+  public void setUser(ModuleUser user) {
     this.user = user;
   }
 }

--- a/okapi-core/src/main/java/org/folio/okapi/bean/ModuleDescriptor.java
+++ b/okapi-core/src/main/java/org/folio/okapi/bean/ModuleDescriptor.java
@@ -36,6 +36,7 @@ public class ModuleDescriptor implements Comparable<ModuleDescriptor> {
   private UiModuleDescriptor uiDescriptor;
   private LaunchDescriptor launchDescriptor;
   private ModuleId[] replaces;
+  private ModuleUser[] user;
 
   public ModuleDescriptor() {
   }
@@ -483,5 +484,13 @@ public class ModuleDescriptor implements Comparable<ModuleDescriptor> {
   @JsonIgnore
   public String getProduct() {
     return id.getProduct();
+  }
+
+  public ModuleUser[] getUser() {
+    return user;
+  }
+
+  public void setUser(ModuleUser[] user) {
+    this.user = user;
   }
 }

--- a/okapi-core/src/main/java/org/folio/okapi/bean/ModuleUser.java
+++ b/okapi-core/src/main/java/org/folio/okapi/bean/ModuleUser.java
@@ -1,0 +1,33 @@
+package org.folio.okapi.bean;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Tells how a module is to be deployed. Either by exec'ing a command (and
+ * killing the process afterwards), or by using command lines to start and stop
+ * it.
+ */
+@JsonInclude(Include.NON_NULL)
+public class ModuleUser {
+
+  private String type;
+  private String[] permissions;
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  public String[] getPermissions() {
+    return permissions;
+  }
+
+  public void setPermissions(String[] permissions) {
+    this.permissions = permissions;
+  }
+}

--- a/okapi-core/src/main/raml/ModuleDescriptor.json
+++ b/okapi-core/src/main/raml/ModuleDescriptor.json
@@ -83,7 +83,7 @@
     },
     "user" : {
       "description": "Module user descriptor",
-      "$ref": "LaunchDescriptor.json"
+      "$ref": "ModuleUser.json"
     }
   },
   "required": ["id"]

--- a/okapi-core/src/main/raml/ModuleDescriptor.json
+++ b/okapi-core/src/main/raml/ModuleDescriptor.json
@@ -80,6 +80,10 @@
     "launchDescriptor": {
       "description": "Default deployment for this module",
       "$ref": "LaunchDescriptor.json"
+    },
+    "user" : {
+      "description": "Module user descriptor",
+      "$ref": "LaunchDescriptor.json"
     }
   },
   "required": ["id"]

--- a/okapi-core/src/main/raml/ModuleUser.json
+++ b/okapi-core/src/main/raml/ModuleUser.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "id": "LaunchDescriptor.json",
   "title": "LaunchDescriptor",
-  "description": "Specifies how a module is deployed and undeployed",
+  "description": "Specifies the user that should be created for the module",
   "type": [ "object", "null" ],
   "additionalProperties" : false,
   "properties": {

--- a/okapi-core/src/main/raml/ModuleUser.json
+++ b/okapi-core/src/main/raml/ModuleUser.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "LaunchDescriptor.json",
+  "title": "LaunchDescriptor",
+  "description": "Specifies how a module is deployed and undeployed",
+  "type": [ "object", "null" ],
+  "additionalProperties" : false,
+  "properties": {
+    "type": {
+      "description": "The type of the module user",
+      "type": ["string"]
+    },
+    "permissions": {
+      "description": "Permission ID (usually module.service.method or similar)",
+      "type": ["array", "null"],
+      "items": {"type": "string"}
+    }
+  }
+}
+

--- a/okapi-core/src/main/raml/ModuleUser.json
+++ b/okapi-core/src/main/raml/ModuleUser.json
@@ -8,15 +8,15 @@
   "properties": {
     "type": {
       "description": "The type of the module user",
-      "type": ["string"]
+      "type": "string",
+      "enum": ["module", "tenant"],
+      "default": "module"
     },
     "permissions": {
       "description": "Permission ID (usually module.service.method or similar)",
-      "type": ["array", "null"],
+      "type": "array",
       "items": {
-        "type": "string",
-        "enum": ["module", "tenant"],
-        "default": "module"
+        "type": "string"
       }
     }
   }

--- a/okapi-core/src/main/raml/ModuleUser.json
+++ b/okapi-core/src/main/raml/ModuleUser.json
@@ -13,7 +13,11 @@
     "permissions": {
       "description": "Permission ID (usually module.service.method or similar)",
       "type": ["array", "null"],
-      "items": {"type": "string"}
+      "items": {
+        "type": "string",
+        "enum": ["module", "tenant"],
+        "default": "module"
+      }
     }
   }
 }

--- a/okapi-core/src/test/resources/modules2.json
+++ b/okapi-core/src/test/resources/modules2.json
@@ -60,6 +60,14 @@
         }
       }
     }
+  },
+  "user": {
+    "type": "tenant",
+    "permissions": [
+      "inventory-storage.identifier-types.collection.get",
+      "inventory-storage.inventory-view.instances.collection.get",
+      "inventory-storage.alternative-title-types.collection.get"
+    ]
   }
 }, {
   "id" : "edge-orders-2.2.1",
@@ -90,6 +98,14 @@
         }
       }
     }
+  },
+  "user": {
+    "type": "tenant",
+    "permissions": [
+      "inventory-storage.identifier-types.collection.get",
+      "inventory-storage.inventory-view.instances.collection.get",
+      "inventory-storage.alternative-title-types.collection.get"
+    ]
   }
 }, {
   "id" : "edge-patron-4.2.0",


### PR DESCRIPTION
As discussed (Jakub Skoczen, Vince Bareau, Craig McNally) module descriptor should have section for module user metadata. This section should contain user type and the permissions, that should be assigned for the user.

Acceptance criteria:

The section "user" is added to the raml schema
The section contains "type" and "permissions" property