### PR TITLE
OKAPI-1051: Revert "OKAPI-1050: -Dlog4j2.formatMsgNoLookups=true"

### DIFF
--- a/dist/okapi.env
+++ b/dist/okapi.env
@@ -10,7 +10,7 @@
 #JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk-amd64/bin/java"
 
 # Add additional JVM space separated options here.
-OKAPI_JAVA_OPTS="-Djava.awt.headless=true -Dlog4j2.formatMsgNoLookups=true"
+OKAPI_JAVA_OPTS="-Djava.awt.headless=true"
 
 # Default Okapi settings
 OKAPI_USER="okapi"


### PR DESCRIPTION
This reverts commit 3bc30d8151dabeb9c90b555976906d796d375384.

The formatMsgNoLookups configuration is no longer needed
since we've upgraded to log4j 2.16.0.