### PR TITLE
Vert.x 4.2.2, Netty 4.1.72.Final fixing header request smuggling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.2.1</version> <!-- also update depending versions below! -->
+        <version>4.2.2</version> <!-- also update depending versions below! -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
https://issues.folio.org/browse/OKAPI-1057

https://vertx.io/blog/eclipse-vert-x-4-2-2/

https://github.com/netty/netty/security/advisories/GHSA-wx5j-54mm-rqqq

https://nvd.nist.gov/vuln/detail/CVE-2021-43797