### PR TITLE
OKAPI-1056: Log4j 2.17.0 fixing self-referential lookups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.16.0</version>
+        <version>2.17.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
FOLIO is affected because Okapi and RMB use
https://github.com/folio-org/okapi/blob/v4.11.0/okapi-common/src/main/java/org/folio/okapi/common/logging/FolioLoggingContext.java

https://issues.folio.org/browse/OKAPI-1056

https://nvd.nist.gov/vuln/detail/CVE-2021-45105

https://logging.apache.org/log4j/2.x/security.html