### PR TITLE
OKAPI-1063: Bump dependencies: Vert.x 4.2.3, log4j 2.17.1, etc.

### DIFF
--- a/okapi-common/pom.xml
+++ b/okapi-common/pom.xml
@@ -128,7 +128,6 @@
       <plugin>
         <groupId>pl.project13.maven</groupId>
         <artifactId>git-commit-id-plugin</artifactId>
-        <version>2.2.1</version>
         <executions>
           <execution>
             <id>get-the-git-infos</id>

--- a/okapi-core/pom.xml
+++ b/okapi-core/pom.xml
@@ -200,7 +200,7 @@
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
-      <version>4.0.3</version>
+      <version>4.1.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -271,7 +271,6 @@
       <plugin>
         <groupId>pl.project13.maven</groupId>
         <artifactId>git-commit-id-plugin</artifactId>
-        <version>2.2.1</version>
         <executions>
           <execution>
             <id>get-the-git-infos</id>

--- a/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
@@ -3988,7 +3988,7 @@ public class ProxyTest {
     given()
         .header("Content-Type", "application/json")
         .body("{\"id\":").post("/_/proxy/import/modules")
-        .then().statusCode(400).body(containsString("Cannot deserialize instance"));
+        .then().statusCode(400).body(containsString("Cannot deserialize"));
 
     given()
         .header("Content-Type", "application/json")

--- a/okapi-core/src/test/java/org/folio/okapi/service/impl/PostgresHandleTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/service/impl/PostgresHandleTest.java
@@ -71,16 +71,16 @@ class PostgresHandleTest extends PgTestBase implements WithAssertions {
   void hostAndPort(Vertx vertx) {
     PostgresHandle postgresHandle = new PostgresHandle(vertx,
         new JsonObject().put("postgres_host", "example.com").put("postgres_port", "9876"));
-    assertThat(postgresHandle.getOptions())
-    .extracting("getHost", "getPort").containsExactly("example.com", 9876);
+    assertThat(postgresHandle.getOptions().getHost()).isEqualTo("example.com");
+    assertThat(postgresHandle.getOptions().getPort()).isEqualTo(9876);
   }
 
   @Test
   void ignoreInvalidPortNumber(Vertx vertx) {
     PostgresHandle postgresHandle = new PostgresHandle(vertx,
         new JsonObject().put("postgres_port", "q"));
-    assertThat(postgresHandle.getOptions())
-    .extracting("getHost", "getPort").containsExactly("localhost", 5432);
+    assertThat(postgresHandle.getOptions().getHost()).isEqualTo("localhost");
+    assertThat(postgresHandle.getOptions().getPort()).isEqualTo(5432);
   }
 
   static private JsonObject config() {

--- a/okapi-test-auth-module/pom.xml
+++ b/okapi-test-auth-module/pom.xml
@@ -65,7 +65,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.0.1</version>
         <executions>
          <execution>
             <id>filter-descriptor-inputs</id>

--- a/okapi-test-module/pom.xml
+++ b/okapi-test-module/pom.xml
@@ -56,7 +56,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.0.1</version>
         <executions>
          <execution>
             <id>filter-descriptor-inputs</id>
@@ -142,7 +141,6 @@
       <plugin>
         <groupId>pl.project13.maven</groupId>
         <artifactId>git-commit-id-plugin</artifactId>
-        <version>2.2.1</version>
         <executions>
           <execution>
             <id>get-the-git-infos</id>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.2.2</version> <!-- also update depending versions below! -->
+        <version>4.2.3</version> <!-- also update depending versions below! -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -67,7 +67,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.17.0</version>
+        <version>2.17.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -96,12 +96,12 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.13.1</version>
+        <version>4.13.2</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
-        <version>3.16.1</version>
+        <version>3.22.0</version>
       </dependency>
       <dependency>
         <groupId>com.zaxxer</groupId>
@@ -122,7 +122,7 @@
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>5.7.1</version>
+        <version>5.8.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -173,6 +173,18 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
           <version>3.2.0</version>
+        </plugin>
+
+        <plugin>
+           <groupId>org.apache.maven.plugins</groupId>
+           <artifactId>maven-resources-plugin</artifactId>
+           <version>3.2.0</version>
+        </plugin>
+
+        <plugin>
+          <groupId>pl.project13.maven</groupId>
+          <artifactId>git-commit-id-plugin</artifactId>
+          <version>4.9.10</version>
         </plugin>
 
       </plugins>


### PR DESCRIPTION
Update Vert.x from 4.2.2 to 4.2.3
Update log4j from 2.17.0 to 2.17.1
Update awaitility from 4.0.3 to 4.1.1
Update junit from 4.13.1 to 4.13.2
Update junit-bom from 5.7.1 to 5.8.2
Update assertj-core from 3.16.1 to 3.22.0
Update maven-resources-plugin from 3.0.1 to 3.2.0
Update git-commit-id-plugin from 2.2.1 to 4.9.10