### PR TITLE
npmSnapshot/preRelease only filter OKAPI-1065

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
@@ -262,7 +262,7 @@ public class MainVerticle extends AbstractVerticle {
           }
           logger.debug("Creating the internal Okapi module {} with interface version {}",
               okapiModule, interfaceVersion);
-          return moduleManager.createList(Collections.singletonList(md), true, true, true,
+          return moduleManager.createList(Collections.singletonList(md), true, null, null,
               false);
         }).compose(x -> checkSuperTenant(okapiModule));
   }

--- a/okapi-core/src/main/java/org/folio/okapi/managers/InternalModule.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/InternalModule.java
@@ -982,8 +982,8 @@ public class InternalModule {
     try {
       MultiMap params = pc.getCtx().request().params();
       final boolean check = ModuleUtil.getParamBoolean(params, "check", true);
-      final boolean preRelease = ModuleUtil.getParamBoolean(params, "preRelease", true);
-      final boolean npmSnapshot = ModuleUtil.getParamBoolean(params, "npmSnapshot", true);
+      final Boolean preRelease = ModuleUtil.getParamVersionFilter(params, "preRelease");
+      final Boolean npmSnapshot = ModuleUtil.getParamVersionFilter(params, "npmSnapshot");
       for (ModuleDescriptor md : list) {
         String validerr = md.validate(logger);
         if (!validerr.isEmpty()) {
@@ -1041,7 +1041,7 @@ public class InternalModule {
       if (!body.isEmpty()) {
         skipModules = Json.decodeValue(body, skipModules.getClass());
       }
-      return moduleManager.getModulesWithFilter(true, true, Arrays.asList(skipModules))
+      return moduleManager.getModulesWithFilter(null, null, Arrays.asList(skipModules))
           .compose(mdl -> {
             try {
               MultiMap params = pc.getCtx().request().params();

--- a/okapi-core/src/main/java/org/folio/okapi/managers/PullManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/PullManager.java
@@ -169,14 +169,14 @@ public class PullManager {
         }
       }
       logger.info("pull: {} MDs to insert", mustAddList.size());
-      return moduleManager.createList(mustAddList, true, true,true, true)
+      return moduleManager.createList(mustAddList, true, null,null, true)
           .map(briefList);
     });
   }
 
   Future<List<ModuleDescriptor>> pull(PullDescriptor pd) {
     return getRemoteUrl(Arrays.asList(pd.getUrls()))
-        .compose(resUrl -> moduleManager.getModulesWithFilter(true, true, null)
+        .compose(resUrl -> moduleManager.getModulesWithFilter(null, null, null)
             .compose(resLocal -> {
               final String remoteUrl = resUrl.get(0);
               final String remoteVersion = resUrl.get(1);

--- a/okapi-core/src/main/java/org/folio/okapi/util/OkapiError.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/OkapiError.java
@@ -2,7 +2,7 @@ package org.folio.okapi.util;
 
 import org.folio.okapi.common.ErrorType;
 
-public class OkapiError extends Throwable {
+public class OkapiError extends RuntimeException {
   private final String msg;
   private final ErrorType type;
 

--- a/okapi-core/src/main/java/org/folio/okapi/util/TenantInstallOptions.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/TenantInstallOptions.java
@@ -2,23 +2,23 @@ package org.folio.okapi.util;
 
 public class TenantInstallOptions {
 
-  private boolean preRelease = false;
+  private Boolean preRelease = null;
   private boolean simulate = false;
   private boolean deploy = false;
   private boolean purge = false;
   private String tenantParameters;
-  private boolean npmSnapshot = false;
+  private Boolean npmSnapshot = null;
   private boolean depCheck = true;
   private String invoke;
   private boolean async = false;
   private boolean ignoreErrors = false;
   private boolean reinstall = false;
 
-  public void setPreRelease(boolean v) {
+  public void setPreRelease(Boolean v) {
     preRelease = v;
   }
 
-  public boolean getPreRelease() {
+  public Boolean getPreRelease() {
     return preRelease;
   }
 
@@ -54,11 +54,11 @@ public class TenantInstallOptions {
     return tenantParameters;
   }
 
-  public void setNpmSnapshot(boolean v) {
+  public void setNpmSnapshot(Boolean v) {
     npmSnapshot = v;
   }
 
-  public boolean getNpmSnapshot() {
+  public Boolean getNpmSnapshot() {
     return npmSnapshot;
   }
 

--- a/okapi-core/src/main/raml/okapi.raml
+++ b/okapi-core/src/main/raml/okapi.raml
@@ -373,12 +373,12 @@ types:
         default: true
       preRelease:
         description: Whether to allow pre-release modules in dependency check
-        type: boolean
+        enum: [true,false,only]
         required: false
         default: true
       npmSnapshot:
         description: Whether to allow NPM module snapshots in dependency check
-        type: boolean
+        enum: [true,false,only]
         required: false
         default: true
     body:
@@ -457,12 +457,12 @@ types:
         default: true
       preRelease:
         description: Whether to allow pre-release modules in dependency check
-        type: boolean
+        enum: [true,false,only]
         required: false
         default: true
       npmSnapshot:
         description: Whether to allow NPM module snapshots in dependency check
-        type: boolean
+        enum: [true,false,only]
         required: false
         default: true
     body:
@@ -511,7 +511,7 @@ types:
         required: false
       npmSnapshot:
         description: Whether to include NPM module snapshots
-        type: boolean
+        enum: [true,false,only]
         required: false
         default: true
       order:
@@ -524,7 +524,7 @@ types:
         required: false
       preRelease:
         description: Whether to include modules with pre-release info
-        type: boolean
+        enum: [true,false,only]
         required: false
         default: true
       provide:
@@ -734,7 +734,7 @@ types:
             required: false
           npmSnapshot:
             description: Whether to include NPM module snapshots
-            type: boolean
+            enum: [true,false,only]
             required: false
             default: true
           order:
@@ -747,7 +747,7 @@ types:
             required: false
           preRelease:
             description: Whether to include modules with pre-release info
-            type: boolean
+            enum: [true,false,only]
             required: false
             default: true
           provide:
@@ -1016,13 +1016,13 @@ types:
             required: false
             default: "true"
           npmSnapshot:
-            description: Whether to include NPM module snapshots (default:true).
-            type: boolean
+            description: Whether to include NPM module snapshots.
+            enum: [true,false,only]
             required: false
             default: true
           preRelease:
             description: Whether pre-releases should be considered for installation.
-            type: boolean
+            enum: [true,false,only]
             required: false
             default: true
           purge:

--- a/okapi-core/src/test/java/org/folio/okapi/PullTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/PullTest.java
@@ -252,6 +252,19 @@ public class PullTest {
 
     c = api.createRestAssured3();
     c.given().port(port2)
+        .header("Content-Type", "application/json")
+        .get("/_/proxy/modules?orderBy=id&order=desc&preRelease=only&npmSnapshot=only&latest=2")
+        .then().statusCode(200).log().ifValidationFails()
+        .body(equalTo("[ {" + LS
+            + "  \"id\" : \"module-c-1.0.10000\"," + LS
+            + "  \"name\" : \"C\"" + LS
+            + "} ]"));
+    Assert.assertTrue(
+        "raml: " + c.getLastReport().toString(),
+        c.getLastReport().isEmpty());
+
+    c = api.createRestAssured3();
+    c.given().port(port2)
       .header("Content-Type", "application/json")
       .get("/_/proxy/modules?orderBy=id&order=desc&preRelease=true&npmSnapshot=true&latest=2")
       .then().statusCode(200).log().ifValidationFails()


### PR DESCRIPTION
npmSnapshot/preRelease was previously a boolean, now an enum with
values "false", "true", "only". The fist 2 works exactly as before.
The new "only" filters by npmSnapshot/preRelease only.