### PR TITLE
Log in milliseconds follow-up OKAPI-1072

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
@@ -425,8 +425,8 @@ public class TenantManager implements Liveness {
               });
         })
         .onSuccess(res -> logger.info(
-            "Activation of module '{}' for tenant '{}' completed successfully in {} seconds",
-            md.getId(), tenant.getId(), (System.currentTimeMillis() - startTime) / 1000L))
+            "Activation of module '{}' for tenant '{}' completed successfully in {} ms",
+            md.getId(), tenant.getId(), System.currentTimeMillis() - startTime))
         .onFailure(e -> logger.warn(
             "Activation of module '{}' for tenant '{}' failed: {}", md.getId(), tenant.getId(),
             e.getMessage()));


### PR DESCRIPTION
The original value in seconds is often 0 and it seems better
to log a more precise value of the time it takes.