### PR TITLE
Fix install fails migrating from Juniper to Kiwi OKAPI-1075

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/util/DepResolution.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/DepResolution.java
@@ -631,22 +631,23 @@ public final class DepResolution {
             // see if we can find a module that require the provided interface
             Map<String, ModuleDescriptor> modules =
                 findModuleWithProvidedInterface(modsAvailable, prov.interfaceDescriptor);
-            if (modules.size() > 1) {
-              errors.add(messages.getMessage("10210", entry.getKey(),
-                  req.moduleDescriptor.getId(),
-                  String.join(", ", modules.keySet())));
-              return false;
-            } else if (!modules.isEmpty()) {
-              ModuleDescriptor mdFound = modules.values().iterator().next();
-              String from = req.moduleDescriptor.getId();
-              stickyModules.add(mdFound.getId());
-              logger.info("Adding 2 to={} from={}", mdFound.getId(), from);
-              modsEnabled.remove(from);
-              modsEnabled.put(mdFound.getId(), mdFound);
-              addTenantModule(tml, mdFound.getId(), from,
-                  TenantModuleDescriptor.Action.enable);
-              return true;
+            for (String product : modules.keySet()) {
+              if (product.equals(req.moduleDescriptor.getProduct())) {
+                String from = req.moduleDescriptor.getId();
+                ModuleDescriptor mdFound = modules.get(product);
+                stickyModules.add(mdFound.getId());
+                logger.info("Adding 2 to={} from={}", mdFound.getId(), from);
+                modsEnabled.remove(from);
+                modsEnabled.put(mdFound.getId(), mdFound);
+                addTenantModule(tml, mdFound.getId(), from,
+                    TenantModuleDescriptor.Action.enable);
+                return true;
+              }
             }
+            modsEnabled.remove(req.moduleDescriptor.getId());
+            addTenantModule(tml, req.moduleDescriptor.getId(), null,
+                TenantModuleDescriptor.Action.disable);
+            return true;
           }
         }
         errors.add(messages.getMessage("10201", req.moduleDescriptor.getId(), entry.getKey(),

--- a/okapi-core/src/test/java/org/folio/okapi/util/DepResolutionTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/DepResolutionTest.java
@@ -900,7 +900,7 @@ public class DepResolutionTest {
 
     // patch to higher version with st given, but with multiple products to support it
     {
-      ModuleDescriptor ot101_alt = new ModuleDescriptor("ot-1.0.1");
+      ModuleDescriptor ot101_alt = new ModuleDescriptor("otA-1.0.1");
       ot101_alt.setRequires(ot101.getRequires());
 
       ModuleDescriptor os101_alt = new ModuleDescriptor("os-1.0.1");

--- a/okapi-core/src/test/java/org/folio/okapi/util/DepResolutionTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/DepResolutionTest.java
@@ -40,7 +40,6 @@ public class DepResolutionTest {
   private ModuleDescriptor mdD100;
   private ModuleDescriptor mdD110;
   private ModuleDescriptor mdD200;
-  private ModuleDescriptor mdDA200;
   private ModuleDescriptor mdE100;
   private ModuleDescriptor mdE110;
   private ModuleDescriptor mdE200;
@@ -122,10 +121,6 @@ public class DepResolutionTest {
 
     mdD200 = new ModuleDescriptor("moduleD-2.0.0");
     mdD200.setOptional(int20a);
-
-    mdDA200 = new ModuleDescriptor("moduleDA-2.0.0");
-    mdDA200.setOptional(int20a);
-    mdDA200.setRequires(new InterfaceDescriptor[]{new InterfaceDescriptor("unknown-interface", "2.0")});
 
     mdE100 = new ModuleDescriptor("moduleE-1.0.0");
     mdE100.setRequires(int10a);

--- a/okapi-core/src/test/java/org/folio/okapi/util/DepResolutionTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/DepResolutionTest.java
@@ -284,7 +284,7 @@ public class DepResolutionTest {
   @Test
   public void testInstallMajorBaseOptionalDisable() {
     List<TenantModuleDescriptor> tml = enableList(mdA200);
-    // note that mdD200 is not part of the lsit
+    // note that mdD200 is not part of the list
     DepResolution.install(map(mdA100, mdA110, mdA200, mdD100, mdD110),
         map(mdA100, mdD100), tml, false);
     assertThat(tml, contains(upgrade(mdA200, mdA100), disable(mdD100)));

--- a/okapi-core/src/test/java/org/folio/okapi/util/DepResolutionTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/DepResolutionTest.java
@@ -819,7 +819,7 @@ public class DepResolutionTest {
     testList.add(mdC);
     Assert.assertEquals("",
         DepResolution.checkAvailable(available.values(), testList, true));
-    Assert.assertTrue(testList.containsAll(List.of(mdC)));
+    Assert.assertTrue(testList.contains(mdC));
 
     Assert.assertEquals("", DepResolution.checkAvailable(map(mdC, mdD)));
 

--- a/okapi-core/src/test/java/org/folio/okapi/util/DepResolutionTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/DepResolutionTest.java
@@ -288,10 +288,9 @@ public class DepResolutionTest {
   public void testInstallMajorBaseOptionalError() {
     List<TenantModuleDescriptor> tml = enableList(mdA200);
     // note that mdD200 is not part of the lsit
-    OkapiError error = Assert.assertThrows(OkapiError.class,
-        () -> DepResolution.install(map(mdA100, mdA110, mdA200, mdD100, mdD110),
-        map(mdA100, mdD100), tml, false));
-    Assert.assertEquals("Incompatible version for module moduleD-1.0.0 interface int. Need 1.0. Have 2.0/moduleA-2.0.0", error.getMessage());
+    DepResolution.install(map(mdA100, mdA110, mdA200, mdD100, mdD110),
+        map(mdA100, mdD100), tml, false);
+    assertThat(tml, contains(disable(mdD100), upgrade(mdA200, mdA100)));
   }
 
   // upgrade base dependency and pull in module with unknown interface (results in error)
@@ -905,11 +904,9 @@ public class DepResolutionTest {
       ot101_alt.setRequires(ot101.getRequires());
 
       List<TenantModuleDescriptor> tml = enableList(st101);
-      OkapiError error = Assert.assertThrows(OkapiError.class,
-          () -> DepResolution.install(map(st100, st101, ot100, ot101, ot101_alt),
-              map(ot100, st100), tml, false));
-      Assert.assertEquals("interface int required by module ot-1.0.0 is provided by multiple products: ot, otA",
-          error.getMessage());
+      DepResolution.install(map(st100, st101, ot100, ot101, ot101_alt),
+              map(ot100, st100), tml, false);
+      assertThat(tml, contains(upgrade(st101, st100), upgrade(ot101, ot100)));
     }
   }
 

--- a/okapi-core/src/test/java/org/folio/okapi/util/DepResolutionTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/DepResolutionTest.java
@@ -900,11 +900,14 @@ public class DepResolutionTest {
 
     // patch to higher version with st given, but with multiple products to support it
     {
-      ModuleDescriptor ot101_alt = new ModuleDescriptor("otA-1.0.1");
+      ModuleDescriptor ot101_alt = new ModuleDescriptor("ot-1.0.1");
       ot101_alt.setRequires(ot101.getRequires());
 
+      ModuleDescriptor os101_alt = new ModuleDescriptor("os-1.0.1");
+      os101_alt.setRequires(ot101.getRequires());
+
       List<TenantModuleDescriptor> tml = enableList(st101);
-      DepResolution.install(map(st100, st101, ot100, ot101, ot101_alt),
+      DepResolution.install(map(st100, st101, ot100, ot101, ot101_alt, os101_alt),
               map(ot100, st100), tml, false);
       assertThat(tml, contains(upgrade(st101, st100), upgrade(ot101, ot100)));
     }

--- a/okapi-core/src/test/java/org/folio/okapi/util/DepResolutionTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/DepResolutionTest.java
@@ -287,12 +287,12 @@ public class DepResolutionTest {
   }
 
   @Test
-  public void testInstallMajorBaseOptionalError() {
+  public void testInstallMajorBaseOptionalDisable() {
     List<TenantModuleDescriptor> tml = enableList(mdA200);
     // note that mdD200 is not part of the lsit
     DepResolution.install(map(mdA100, mdA110, mdA200, mdD100, mdD110),
         map(mdA100, mdD100), tml, false);
-    assertThat(tml, contains(disable(mdD100), upgrade(mdA200, mdA100)));
+    assertThat(tml, contains(upgrade(mdA200, mdA100), disable(mdD100)));
   }
 
   // upgrade base dependency and pull in module with unknown interface (results in error)


### PR DESCRIPTION
Change strategy on conflicts and upgrade if possible on
same product and then turn to disable.

The problem in this case is ui-inventory-es that is left
over from Juniper and no longer part of Kiwi, but not really
replaced or disabled. The new behavior is to disable modules
with conflicts (that are not explicitly installed).