### PR TITLE
Handle parallel=1 in sequence OKAPI-1077

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
@@ -992,7 +992,13 @@ public class TenantManager implements Liveness {
     if (options.getDeploy()) {
       future = future.compose(x -> autoDeploy(t, job, modsAvailable, tml));
     }
-    future = future.compose(x -> jobInvoke(t, pc, options, tml, modsAvailable, modsEnabled, job));
+    if (options.getMaxParallel() == 1) {
+      for (TenantModuleDescriptor tm : tml) {
+        future = future.compose(x -> jobInvokeSingle(t, pc, options, tm, modsAvailable, job));
+      }
+    } else {
+      future = future.compose(x -> jobInvoke(t, pc, options, tml, modsAvailable, modsEnabled, job));
+    }
 
     // if we are really upgrading permissions do a refresh last
     for (TenantModuleDescriptor tm : tml) {


### PR DESCRIPTION
The default case (parallel=1) was using the generic algorithm, but
that seems not to complete in reference builds.