### PR TITLE
Compress Okapi responses > 16K OKAPI-1079

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -990,7 +990,7 @@ public class ProxyService {
     clientsEnd(bcontent, clientRequestList);
     try {
       internalModule.internalService(req, pc)
-          .compose(resp -> {
+          .map(resp -> {
             int statusCode = pc.getCtx().response().getStatusCode();
             if (statusCode == 200 && resp.isEmpty()) {
               // Say "no content", if there isn't any

--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -961,16 +961,16 @@ public class ProxyService {
 
   static Buffer compressInternalResponse(RoutingContext ctx, Buffer respBuf) {
     String acceptEncoding = ctx.request().getHeader("Accept-Encoding");
-    int sz = respBuf.length();
+    int uncompressedSize = respBuf.length();
     if (acceptEncoding != null && acceptEncoding.contains("gzip")
-        && sz > CONTENT_COMPRESS_MIN_SIZE) {
+        && uncompressedSize > CONTENT_COMPRESS_MIN_SIZE) {
       try {
-        ByteArrayOutputStream dst = new ByteArrayOutputStream();
-        GZIPOutputStream src = new GZIPOutputStream(dst);
-        src.write(respBuf.getBytes());
-        src.close();
-        respBuf = Buffer.buffer(dst.toByteArray());
-        logger.info("Compressed {} {}", sz, respBuf.length());
+        ByteArrayOutputStream compressedStream = new ByteArrayOutputStream();
+        GZIPOutputStream uncompressedStream = new GZIPOutputStream(compressedStream);
+        uncompressedStream.write(respBuf.getBytes());
+        uncompressedStream.close();
+        respBuf = Buffer.buffer(compressedStream.toByteArray());
+        logger.info("Compressed {} bytes to {} bytes", uncompressedSize, respBuf.length());
         ctx.response().putHeader("Content-Encoding", "gzip");
       } catch (IOException e) {
         throw new UncheckedIOException(e);

--- a/okapi-core/src/main/java/org/folio/okapi/managers/PullManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/PullManager.java
@@ -4,6 +4,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.RequestOptions;
 import io.vertx.core.json.Json;
@@ -33,8 +34,16 @@ public class PullManager {
   private final ModuleManager moduleManager;
   private final Messages messages = Messages.getInstance();
 
+  /**
+   * Construct pull manager.
+   * @param vertx Vert.x handle to use for client
+   * @param moduleManager module manager to use for adding modules locally
+   */
   public PullManager(Vertx vertx, ModuleManager moduleManager) {
-    this.httpClient = new FuturisedHttpClient(vertx);
+    HttpClientOptions options = new HttpClientOptions()
+        .setTryUseCompression(true)
+        .setMaxPoolSize(2); // suffice as pull is normally not performed concurrently
+    this.httpClient = new FuturisedHttpClient(vertx, options);
     this.moduleManager = moduleManager;
   }
 


### PR DESCRIPTION
HttpClient for pull operation has compression enabled.

With a client in Europe and a server in US, I see a speed again of about 30% for the pull operation as a whole with this.