### PR TITLE
Unit test fixes for slow server

### DIFF
--- a/okapi-core/src/test/java/org/folio/okapi/InstallTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/InstallTest.java
@@ -87,7 +87,7 @@ public class InstallTest {
   }
 
   JsonObject pollComplete(TestContext context, String path) {
-    for (int i = 0; i < 20; i++) {
+    for (int i = 1; i < 20; i++) {
       RestAssuredClient c = api.createRestAssured3();
       logger.info("poll {}", i);
 
@@ -100,7 +100,7 @@ public class InstallTest {
         return job;
       }
       Async async = context.async();
-      vertx.setTimer(300, x -> async.complete());
+      vertx.setTimer(200 * i, x -> async.complete());
       async.await();
     }
     return new JsonObject();

--- a/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
@@ -2583,9 +2583,9 @@ public class ProxyTest {
 
     timerDelaySum.clear();
 
-    Awaitility.await().atMost(1, TimeUnit.SECONDS).untilAsserted(
+    Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(
         () -> Assertions.assertThat(timerDelaySum.get(1)).isGreaterThan(0));
-    Awaitility.await().atMost(1, TimeUnit.SECONDS).untilAsserted(
+    Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(
         () -> Assertions.assertThat(timerDelaySum.get(2)).isGreaterThan(2));
     Assertions.assertThat(timerDelaySum.containsKey(0)).isFalse();
 
@@ -2649,10 +2649,6 @@ public class ProxyTest {
       .post("/_/proxy/tenants/" + okapiTenant + "/install?deploy=true")
       .then().statusCode(200).log().ifValidationFails();
 
-    try {
-      TimeUnit.MILLISECONDS.sleep(100);
-    } catch (InterruptedException ex) {
-    }
 
     // check that timer gone
     api.createRestAssured3().given()

--- a/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
@@ -2474,11 +2474,11 @@ public class ProxyTest {
       .post("/_/proxy/tenants/" + okapiTenant + "/install?deploy=true")
       .then().statusCode(200);
 
-    Awaitility.await().atMost(1, TimeUnit.SECONDS).untilAsserted(
+    Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(
         () -> Assertions.assertThat(timerDelaySum.get(0)).isGreaterThan(1));
-    Awaitility.await().atMost(1, TimeUnit.SECONDS).untilAsserted(
+    Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(
         () -> Assertions.assertThat(timerDelaySum.get(1)).isGreaterThan(2));
-    Awaitility.await().atMost(1, TimeUnit.SECONDS).untilAsserted(
+    Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(
         () -> Assertions.assertThat(timerDelaySum.get(2)).isGreaterThan(2));
 
     api.createRestAssured3().given()
@@ -2716,13 +2716,12 @@ public class ProxyTest {
         .post("/_/proxy/tenants/" + okapiTenant + "/install?deploy=true")
         .then().statusCode(200);
 
-    try {
-      TimeUnit.MILLISECONDS.sleep(50);
-    } catch (InterruptedException ex) {
-    }
-    Assertions.assertThat(timerDelaySum.get(0)).isGreaterThan(1);
-    Assertions.assertThat(timerDelaySum.get(1)).isGreaterThan(1);
-    Assertions.assertThat(timerDelaySum.get(2)).isGreaterThan(2);
+    Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(
+        () -> Assertions.assertThat(timerDelaySum.get(0)).isGreaterThan(1));
+    Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(
+        () -> Assertions.assertThat(timerDelaySum.get(1)).isGreaterThan(1));
+    Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(
+        () -> Assertions.assertThat(timerDelaySum.get(2)).isGreaterThan(2));
 
     // disable and remove tenant as well
     api.createRestAssured3().given()


### PR DESCRIPTION
This PR tunes tests a bit so Okapi can complete its test with a relatively slow server.

The slow server being based on AMD A10 Micro-6700T.