### PR TITLE
Property enable_system_auth checked for proxy calls

### DIFF
--- a/doc/guide.md
+++ b/doc/guide.md
@@ -2851,7 +2851,7 @@ leave it unmodified (default).
 This property appeared in Okapi 4.10.0; trace header was always enabled
 before 4.10.0.
 * `enable_system_auth`: Controls whether Okapi checks token by calling Auth module
-when invoking system interfaces such as `_tenant`.
+when invoking system interfaces such as `_tenant` or via regular proxy call.
 The value is a boolean - `true` for enable, `false` for disable.  Default is `true`.
 * `kube_config`: Filename/resource which is the Kubernetes configuration
 to use for Kubernetes integration. If defined, Okapi will perform

--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -230,7 +230,8 @@ public class ProxyService {
       logger.debug("getModulesForRequest: Checking {} '{}' '{}'",
           re.getPathPattern(), phase, re.getLevel());
 
-      if (skipAuth && phase != null && phase.equals(XOkapiHeaders.FILTER_AUTH)) {
+      if (phase != null && phase.equals(XOkapiHeaders.FILTER_AUTH)
+          && (skipAuth || !enableSystemAuth)) {
         logger.debug("Skipping auth, have cached token.");
         iter.remove();
       }

--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -511,7 +511,7 @@ public class ProxyService {
   }
 
   private void log(HttpClientRequest creq) {
-    logger.debug("{} {}", creq.getMethod().name(), creq.getURI());
+    logger.debug("{} {}", () -> creq.getMethod().name(), () -> creq.getURI());
     for (Map.Entry<String, String> next : creq.headers()) {
       logger.debug(" {}:{}", next.getKey(), next.getValue());
     }

--- a/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/ProxyService.java
@@ -511,7 +511,10 @@ public class ProxyService {
   }
 
   private void log(HttpClientRequest creq) {
-    logger.debug("{} {}", () -> creq.getMethod().name(), () -> creq.getURI());
+    if (! logger.isDebugEnabled()) {
+      return;
+    }
+    logger.debug("{} {}", creq.getMethod().name(), creq.getURI());
     for (Map.Entry<String, String> next : creq.headers()) {
       logger.debug(" {}:{}", next.getKey(), next.getValue());
     }


### PR DESCRIPTION
This property which should only be set to false for testing
purposes is now also checked when phase auth is called in proxy.