### PR TITLE
OKAPI-1088: jackson-databind 2.13.2.1, Vert.x 4.2.6, log4j 2.17.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.2.5</version> <!-- also update depending versions below! -->
+        <version>4.2.6</version> <!-- also update depending versions below! -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -57,12 +57,20 @@
         <artifactId>hazelcast-kubernetes</artifactId>
         <version>2.2.3</version>  <!-- https://github.com/hazelcast/hazelcast-kubernetes#requirements-and-recommendations -->
       </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId> <!-- remove for vertx >= 4.2.7 -->
+        <version>2.13.2.20220324</version> <!-- jackson-databind 2.13.2.1 fixing https://nvd.nist.gov/vuln/detail/CVE-2020-36518 -->
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <!-- END: versions that depend on the vertx-stack-depchain version -->
 
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.17.1</version>
+        <version>2.17.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Update jackson-databind from 2.13.1 to 2.13.2.1 fixing https://nvd.nist.gov/vuln/detail/CVE-2020-36518

Update Vert.x from 4.2.5 to 4.2.6.

Update log4j from 2.17.1 to 2.17.2.