### PR TITLE
OKAPI-1094: Update Vert.x from 4.2.6 to 4.2.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,16 +32,9 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.fasterxml.jackson</groupId>
-        <artifactId>jackson-bom</artifactId> <!-- remove for vertx >= 4.2.7 -->
-        <version>2.13.2.20220324</version> <!-- jackson-databind 2.13.2.1 fixing https://nvd.nist.gov/vuln/detail/CVE-2020-36518 -->
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.2.6</version> <!-- also update depending versions below! -->
+        <version>4.2.7</version> <!-- also update depending versions below! -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
This fixes a few bugs: https://github.com/vert-x3/wiki/wiki/4.2.7-Release-Notes

The explicit jackson-bom is no longer needed because
vertx-stack-depchain has been updated to latest jackson.