### PR TITLE
OKAPI-1095: HttpClientFactory (with WebClientFactory)

### DIFF
--- a/okapi-common/src/main/java/org/folio/okapi/common/HttpClientFactory.java
+++ b/okapi-common/src/main/java/org/folio/okapi/common/HttpClientFactory.java
@@ -1,0 +1,37 @@
+package org.folio.okapi.common;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientOptions;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Factory for HttpClient instances to avoid web socket leaks.
+ */
+public final class HttpClientFactory {
+  private static final Map<Vertx, HttpClient> clients = new ConcurrentHashMap<>();
+
+  private HttpClientFactory() {
+    throw new UnsupportedOperationException("Utility classes cannot be instantiated");
+  }
+
+  /**
+   * Get a WebClient, returns the same instance for the same Vertx instance.
+   *
+   * <p>The webClientOptions parameter is only used when creating the WebClient,
+   * the options of an existing WebClient are not changed.
+   */
+  public static HttpClient getHttpClient(Vertx vertx, HttpClientOptions httpClientOptions) {
+    return clients.computeIfAbsent(vertx, x -> vertx.createHttpClient(httpClientOptions));
+  }
+
+  /**
+   * Get a WebClient, returns the same instance for the same Vertx instance.
+   *
+   * <p>It doesn't reset WebClientOptions when returning an existing WebClient.
+   */
+  public static HttpClient getHttpClient(Vertx vertx) {
+    return getHttpClient(vertx, new HttpClientOptions());
+  }
+}

--- a/okapi-common/src/main/java/org/folio/okapi/common/WebClientFactory.java
+++ b/okapi-common/src/main/java/org/folio/okapi/common/WebClientFactory.java
@@ -21,15 +21,20 @@ public final class WebClientFactory {
    *
    * <p>The webClientOptions parameter is only used when creating the WebClient,
    * the options of an existing WebClient are not changed.
+   *
+   * <p>It uses {@code HttpClientFactory} for the underlying {@code HttpClient}.
    */
   public static WebClient getWebClient(Vertx vertx, WebClientOptions webClientOptions) {
-    return clients.computeIfAbsent(vertx, x -> WebClient.create(vertx, webClientOptions));
+    var httpClient = HttpClientFactory.getHttpClient(vertx, webClientOptions);
+    return clients.computeIfAbsent(vertx, x -> WebClient.wrap(httpClient, webClientOptions));
   }
 
   /**
    * Get a WebClient, returns the same instance for the same Vertx instance.
    *
    * <p>It doesn't reset WebClientOptions when returning an existing WebClient.
+   *
+   * <p>It uses {@code HttpClientFactory} for the underlying {@code HttpClient}.
    */
   public static WebClient getWebClient(Vertx vertx) {
     return getWebClient(vertx, new WebClientOptions());

--- a/okapi-common/src/test/java/org/folio/okapi/common/HttpClientFactoryTest.java
+++ b/okapi-common/src/test/java/org/folio/okapi/common/HttpClientFactoryTest.java
@@ -1,0 +1,70 @@
+package org.folio.okapi.common;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.folio.okapi.testing.UtilityClassTester;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(VertxExtension.class)
+class HttpClientFactoryTest {
+
+  @Test
+  void isUtilityClass() {
+    UtilityClassTester.assertUtilityClass(HttpClientFactory.class);
+  }
+
+  @Test
+  void getHttpClient() {
+    Vertx vertxA = Vertx.vertx();
+    Vertx vertxB = Vertx.vertx();
+    HttpClient httpClientA1 = HttpClientFactory.getHttpClient(vertxA);
+    HttpClient httpClientB1 = HttpClientFactory.getHttpClient(vertxB);
+    HttpClient httpClientA2 = HttpClientFactory.getHttpClient(vertxA);
+    HttpClient httpClientB2 = HttpClientFactory.getHttpClient(vertxB);
+    assertThat(httpClientA1, is(httpClientA2));
+    assertThat(httpClientB1, is(httpClientB2));
+    assertThat(httpClientA1, is(not(httpClientB1)));
+  }
+
+  Future<String> get(HttpClient httpClient) {
+    return WebClient.wrap(httpClient).get("/").send().map(res -> res.bodyAsString());
+  }
+
+  @Test
+  void getHttpClientWithOptions(Vertx vertx1, VertxTestContext vtc) {
+    var vertx2 = Vertx.vertx();
+    var options1 = new HttpClientOptions().setDefaultPort(8001);
+    var options2 = new HttpClientOptions().setDefaultPort(8002);
+    var options3 = new HttpClientOptions().setDefaultPort(8003);
+    var httpClient1 = HttpClientFactory.getHttpClient(vertx1, options1);
+    var httpClient2 = HttpClientFactory.getHttpClient(vertx2, options2);
+    var httpClient3 = HttpClientFactory.getHttpClient(vertx1, options3);
+
+    vertx1.createHttpServer()
+        .requestHandler(request -> request.response().end("1"))
+        .listen(8001)
+        .compose(x -> {
+          return vertx1.createHttpServer()
+              .requestHandler(request -> request.response().end("2"))
+              .listen(8002);
+        })
+        .compose(x -> get(httpClient1))
+        .onComplete(vtc.succeeding(res -> assertThat(res, is("1"))))
+        .compose(x -> get(httpClient2))
+        .onComplete(vtc.succeeding(res -> assertThat(res, is("2"))))
+        .compose(x -> get(httpClient3))
+        .onComplete(vtc.succeeding(res -> assertThat(res, is("1"))))
+        .onSuccess(x -> vtc.completeNow());
+  }
+}
+


### PR DESCRIPTION
Provide a HttpClientFactory similar to WebClientFactory. They should share the same HttpClients.

Quote from https://vertx.io/docs/vertx-web-client/java/ :

> The HttpClient should be used when fine grained control over the HTTP requests/responses is necessary.
> The Web Client does not provide a WebSocket API, the Vert.x Core HttpClient should be used. It also does not handle cookies at the moment.

Adding support for HttpClient will cover all uses cases and allows for a smoother transition to these non-leaking factories.