### PR TITLE
OKAPI-1098: Fix Jakarta Expression Language validation (CVE-2021-28170)

### DIFF
--- a/okapi-core/pom.xml
+++ b/okapi-core/pom.xml
@@ -85,6 +85,15 @@
       <artifactId>cron-utils</artifactId>
     </dependency>
     <dependency>
+      <!-- Remove this dependency when cron-utils ships with jakarta.el >= 3.0.4!
+           https://github.com/jmrozanec/cron-utils/issues/517
+           https://github.com/jmrozanec/cron-utils/pull/518
+      -->
+      <groupId>org.glassfish</groupId>
+      <artifactId>jakarta.el</artifactId>
+      <version>3.0.4</version>
+    </dependency>
+    <dependency>
       <groupId>com.ongres.scram</groupId>
       <artifactId>client</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,12 @@
       <dependency>
         <groupId>com.cronutils</groupId>
         <artifactId>cron-utils</artifactId>
+        <!--
+          After upgrading cron-utils to a version with fixed org.glassfish:jakarta.el
+          remove the org.glassfish:jakarta.el dependency in okapi-core/pom.xml!
+          https://github.com/jmrozanec/cron-utils/issues/517
+          https://github.com/jmrozanec/cron-utils/pull/518
+        -->
         <version>9.1.6</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
Bump org.glassfish:javax.el:3.0.1-b12 to org.glassfish:jakarta.el:3.0.4 fixing a bug in the Jakarta Expression Language implementation that enables invalid EL expressions to be evaluated as if they were valid: https://nvd.nist.gov/vuln/detail/CVE-2021-28170

Note that the artifact has been renamed from javax.el to jakarta.el: https://mvnrepository.com/artifact/org.glassfish/javax.el