### PR TITLE
OKAPI-1100: Vert.x 4.3.1, micrometer 1.8.4, nuprocess 2.0.3, test deps

### DIFF
--- a/okapi-core/pom.xml
+++ b/okapi-core/pom.xml
@@ -191,13 +191,11 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
-      <version>3.11.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
-      <version>3.11.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -218,7 +216,7 @@
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
-      <version>4.1.1</version>
+      <version>4.2.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/okapi-core/src/test/java/org/folio/okapi/InstallTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/InstallTest.java
@@ -1,5 +1,9 @@
 package org.folio.okapi;
 
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
 import guru.nidi.ramltester.RamlDefinition;
 import guru.nidi.ramltester.RamlLoaders;
 import guru.nidi.ramltester.restassured3.RestAssuredClient;
@@ -31,9 +35,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import static io.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.*;
 
 @RunWith(VertxUnitRunner.class)
 public class InstallTest {
@@ -1193,23 +1194,20 @@ public class InstallTest {
         ), job);
 
     // initial module called once..
-    context.assertEquals(tModule.getOperations().get(0),
-        new JsonObject()
-            .put("module_to", module1)
-            .put("purge", false));
+    JsonObject operation = tModule.getOperations().get(0);
+    assertThat(operation.getString("module_to"), is(module1));
+    assertThat(operation.getBoolean("purge"), is(false));
 
     // second module called on upgrade
-    context.assertEquals(tModule2.getOperations().get(0),
-        new JsonObject()
-            .put("module_to", module2)
-            .put("module_from", module1)
-            .put("purge", false));
+    operation = tModule2.getOperations().get(0);
+    assertThat(operation.getString("module_to"), is(module2));
+    assertThat(operation.getString("module_from"), is(module1));
+    assertThat(operation.getBoolean("purge"), is(false));
 
     // second module called on purge
-    context.assertEquals(tModule2.getOperations().get(1),
-        new JsonObject()
-            .put("module_from", module2)
-            .put("purge", true));
+    operation = tModule2.getOperations().get(1);
+    assertThat(operation.getString("module_from"), is(module2));
+    assertThat(operation.getBoolean("purge"), is(true));
 
     tModule.stop().onComplete(context.asyncAssertSuccess());
     tModule2.stop().onComplete(context.asyncAssertSuccess());
@@ -1236,15 +1234,12 @@ public class InstallTest {
                 .put("stage", "done")
             )
         ), job);
-    context.assertEquals(tModule.getOperations().get(0),
-        new JsonObject()
-            .put("module_from", module)
-            .put("purge", true));
-
-    context.assertEquals(tModule.getOperations().get(1),
-        new JsonObject()
-            .put("module_to", module)
-            .put("purge", false));
+    JsonObject operation0 = tModule.getOperations().get(0);
+    assertThat(operation0.getString("module_from"), is(module));
+    assertThat(operation0.getBoolean("purge"), is(true));
+    JsonObject operation1 = tModule.getOperations().get(1);
+    assertThat(operation1.getString("module_to"), is(module));
+    assertThat(operation1.getBoolean("purge"), is(false));
     tModule.stop().onComplete(context.asyncAssertSuccess());
   }
 
@@ -1270,15 +1265,12 @@ public class InstallTest {
                 .put("stage", "done")
             )
         ), job);
-    context.assertEquals(tModule.getOperations().get(0),
-        new JsonObject()
-            .put("module_from", module)
-            .put("purge", true));
-
-    context.assertEquals(tModule.getOperations().get(1),
-        new JsonObject()
-            .put("module_to", module)
-            .put("purge", false));
+    JsonObject operation0 = tModule.getOperations().get(0);
+    assertThat(operation0.getString("module_from"), is(module));
+    assertThat(operation0.getBoolean("purge"), is(true));
+    JsonObject operation1 = tModule.getOperations().get(1);
+    assertThat(operation1.getString("module_to"), is(module));
+    assertThat(operation1.getBoolean("purge"), is(false));
     tModule.stop().onComplete(context.asyncAssertSuccess());
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.2.7</version> <!-- also update depending versions below! -->
+        <version>4.3.1</version> <!-- also update depending versions below! -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-bom</artifactId>
-        <version>1.6.3</version>  <!-- https://github.com/vert-x3/vertx-micrometer-metrics/blob/master/pom.xml#L41 -->
+        <version>1.8.4</version>  <!-- https://github.com/vert-x3/vertx-micrometer-metrics/blob/master/pom.xml#L41 -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -101,7 +101,7 @@
       <dependency>
         <groupId>com.zaxxer</groupId>
         <artifactId>nuprocess</artifactId>
-        <version>2.0.2</version>
+        <version>2.0.3</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
@@ -130,7 +130,14 @@
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers-bom</artifactId>
-        <version>1.16.3</version>
+        <version>1.17.2</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-bom</artifactId>
+        <version>4.6.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Upgrade vertx from 4.2.7 to 4.3.1.
Upgrade micrometer from 1.6.3 to 1.8.4.
Upgrade nuprocess from 2.0.2 to 2.0.3.
Upgrade several test dependencies.

In InstallTest rewrite tests so that they succeed regardless
whether the async install has completed or not. This is needed
for Vert.x 4.3.1.