### PR TITLE
OKAPI-1109: Log to /var/log/folio/okapi/okapi.log, not STDOUT, in Debian

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -63,7 +63,8 @@ install-stamp: build
 	$(INSTALLDIR)  $(OKAPIROOT)/etc/default
 	$(INSTALLFILE) dist/okapi.conf $(OKAPICONF)/
 	$(INSTALLFILE) dist/hazelcast.xml $(OKAPICONF)/
-	$(INSTALLFILE) okapi-core/src/main/resources/log4j2.properties $(OKAPICONF)/
+	$(INSTALLFILE) dist/log4j2.properties $(OKAPICONF)/
+	$(INSTALLFILE) okapi-core/src/main/resources/log4j2.properties $(OKAPICONF)/log4j2-syslog.properties
 	$(INSTALLFILE) okapi-core/src/main/resources/log4j2-json.properties $(OKAPICONF)/
 	$(INSTALLFILE) dist/okapi.env $(OKAPIROOT)/etc/default/okapi
 	$(INSTALLFILE) debian/okapi.service $(OKAPISYSD)/

--- a/dist/log4j2.properties
+++ b/dist/log4j2.properties
@@ -1,0 +1,26 @@
+status = error
+name = PropertiesConfig
+packages = org.folio.okapi.common.logging
+
+filters = threshold
+
+filter.threshold.type = ThresholdFilter
+filter.threshold.level = info
+
+appenders = f
+
+appender.f.type = RollingFile
+appender.f.name = File
+appender.f.fileName = /var/log/folio/okapi/okapi.log
+appender.f.filePattern = /var/log/folio/okapi/okapi-%i.log
+appender.f.layout.type = PatternLayout
+appender.f.layout.pattern = %d{HH:mm:ss} [$${FolioLoggingContext:requestid}] [$${FolioLoggingContext:tenantid}] [$${FolioLoggingContext:userid}] [$${FolioLoggingContext:moduleid}] %-5p %-20.20C{1} %m%n
+appender.f.policies.type = Policies
+appender.f.policies.size.type = SizeBasedTriggeringPolicy
+appender.f.policies.size.size = 20MB
+appender.f.strategy.type = DefaultRollOverStrategy
+appender.f.strategy.max = 10
+
+rootLogger.level = info
+rootLogger.appenderRefs = f
+rootLogger.appenderRef.f.ref = File


### PR DESCRIPTION
Since OKAPI-902 released with Okapi 4.12.1 the Debian Okapi package no longer logs to /var/log/folio/okapi/okapi.log but to STDOUT ending in /var/log/syslog.

The log entries look like this:

```
Jul 01 13:41:17 esx-243 okapi.sh[560237]: 13:41:17 [] [] [] [] INFO  ?                    834705/testb RES 200 33893us test-basic-1.0.0 http://localhost:9131/testb
```

And they are mixed with log messages from other processes.

Revert to okapi.log to avoid duplicate data in log lines and to have Okapi log separate from other logs.