### PR TITLE
OKAPI-1122: nuprocess 2.0.5 fixing Arbitrary Command Injection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
       <dependency>
         <groupId>com.zaxxer</groupId>
         <artifactId>nuprocess</artifactId>
-        <version>2.0.3</version>
+        <version>2.0.5</version>
         <scope>compile</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
Upgrade nuprocess from 2.0.3 to 2.0.5 to fix a Arbitrary Command Injection vulnerability:
https://nvd.nist.gov/vuln/detail/CVE-2022-39243