### PR TITLE
OKAPI-1125: Vert.x 4.3.4, micrometer 1.9.4, log4j 2.19.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.3.3</version> <!-- also update depending versions below! -->
+        <version>4.3.4</version> <!-- also update depending versions below! -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-bom</artifactId>
-        <version>1.9.3</version>  <!-- https://github.com/vert-x3/vertx-micrometer-metrics/blob/master/pom.xml#L41 -->
+        <version>1.9.4</version>  <!-- https://github.com/vert-x3/vertx-micrometer-metrics/blob/master/pom.xml#L41 -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -62,7 +62,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.17.2</version>
+        <version>2.19.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -86,7 +86,7 @@
       <dependency>
         <groupId>io.rest-assured</groupId>
         <artifactId>rest-assured</artifactId>
-        <version>4.5.1</version>
+        <version>5.2.0</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>
@@ -96,7 +96,7 @@
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
-        <version>3.22.0</version>
+        <version>3.23.1</version>
       </dependency>
       <dependency>
         <groupId>com.zaxxer</groupId>
@@ -117,21 +117,21 @@
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>5.8.2</version>
+        <version>5.9.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers-bom</artifactId>
-        <version>1.17.2</version>
+        <version>1.17.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-bom</artifactId>
-        <version>4.6.0</version>
+        <version>4.8.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Upgrade Vertx from 4.3.3 to 4.3.4. This indirectly upgrades jackson-bom from 2.13.2.1 to 2.13.4 fixing a Denial of Service (DoS) vulnerabilities in jackson-databind: https://nvd.nist.gov/vuln/detail/CVE-2022-42003 , https://nvd.nist.gov/vuln/detail/CVE-2022-42004

Upgrade micrometer from 1.9.3 to 1.9.4.

Upgrade log4j from 2.17.2 to 2.19.0.

Upgrade several test dependencies.