### PR TITLE
OKAPI-1142: HTTP idle timeout

### DIFF
--- a/dist/okapi.conf
+++ b/dist/okapi.conf
@@ -96,6 +96,10 @@ log4j_config="/etc/folio/okapi/log4j2.properties"
 # This value, if set, overrides the `waitIterations` in the launch descriptor.
 # deploy_waitIterations="60"
 
+# Time in seconds of neither sending nor receiving data after which
+# a proxied HTTP request is cancelled. Defaults to 0 that disables timeout.
+# idle_timeout="0"
+
 # Vert.x cache for classpath resource files
 # https://vertx.io/docs/vertx-core/java/#classpath
 vertx_cache_dir_base="/tmp/vertx-cache-okapi"

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -2864,6 +2864,8 @@ see [kubernetes](#kubernetes-integration) section.
 * `kube_namespace`: Kubernetes namespace to use. If omitted, `default` is used.
 * `kube_refresh_interval`: Time in milliseconds between Kubernetes endpoints
 poll. Default is 30000 (30 seconds).
+* `idle_timeout`: Time in seconds of neither sending nor receiving data after which
+a proxied HTTP request is cancelled. Defaults to 0 that disables timeout.
 
 #### Command
 

--- a/okapi-core/src/main/java/org/folio/okapi/ConfNames.java
+++ b/okapi-core/src/main/java/org/folio/okapi/ConfNames.java
@@ -16,6 +16,7 @@ public final class ConfNames {
   public static final String DOCKER_URL = "dockerUrl";
   public static final String ENABLE_TRACE_HEADERS = "trace_headers";
   public static final String ENABLE_SYSTEM_AUTH = "enable_system_auth";
+  public static final String IDLE_TIMEOUT = "idle_timeout";
   public static final String KUBE_CONFIG = "kube_config";
   public static final String KUBE_TOKEN = "kube_token";
   public static final String KUBE_SERVER_URL = "kube_server_url";


### PR DESCRIPTION
Option to configure an HTTP idle timeout for Okapi.

Netty and Vert.x disable it by default.

If enabled Okapi can log the API that is still open after a long time. This helps to investigate https://issues.folio.org/browse/OKAPI-1141

Approach:

HttpClientOptions.setIdleTimeout and configuration option in conf file and as command line parameter.