### PR TITLE
OKAPI-1148: includeTimeMillis in log4j2-json.properties

### DIFF
--- a/okapi-core/src/main/resources/log4j2-json.properties
+++ b/okapi-core/src/main/resources/log4j2-json.properties
@@ -12,6 +12,7 @@ appender.full.layout.type = JSONLayout
 appender.full.layout.compact = true
 appender.full.layout.eventEol = true
 appender.full.layout.stacktraceAsString = true
+appender.full.layout.includeTimeMillis = true
 
 ## Folio fields
 appender.full.layout.requestId.type = KeyValuePair
@@ -36,6 +37,7 @@ appender.empty.layout.type = JSONLayout
 appender.empty.layout.compact = true
 appender.empty.layout.eventEol = true
 appender.empty.layout.stacktraceAsString = true
+appender.empty.layout.includeTimeMillis = true
 
 rootLogger.level = info
 rootLogger.appenderRefs = empty


### PR DESCRIPTION
All modules should use the same log format:

https://issues.folio.org/browse/ARCH-20
https://wiki.folio.org/display/DD/Logging

The JSON log format is missing the milliseconds.

This has already been fixed for folio-spring-base and RMB: https://issues.folio.org/browse/FOLSPRINGB-45
https://github.com/folio-org/folio-spring-base/pull/73/files https://issues.folio.org/browse/RMB-959

The same fix should been applied to Okapi's log4j2-json.properties.