### PR TITLE
OKAPI-1150: Vert.x 4.3.7, Netty 4.1.86 fixing CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.3.6</version> <!-- also update depending versions below! -->
+        <version>4.3.7</version> <!-- also update depending versions below! -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -56,14 +56,6 @@
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-kubernetes</artifactId>
         <version>2.2.3</version>  <!-- https://github.com/hazelcast/hazelcast-kubernetes#requirements-and-recommendations -->
-      </dependency>
-      <dependency>
-        <!-- Remove this dependency after upgrading to Vert.x >= 4.3.7 that ships with netty >= 4.1.86.Final -->
-        <groupId>io.netty</groupId>
-        <artifactId>netty-bom</artifactId>
-        <version>4.1.86.Final</version>
-        <type>pom</type>
-        <scope>import</scope>
       </dependency>
       <!-- END: versions that depend on the vertx-stack-depchain version -->
 


### PR DESCRIPTION
Vert.x 4.3.7 comes with Netty 4.1.86 fixing CVE-2022-41881, CVE-2022-41915: https://vertx.io/blog/eclipse-vert-x-4-3-7/