### PR TITLE
Pass replace property for permissions OKAPI-1151

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/bean/PermissionList.java
+++ b/okapi-core/src/main/java/org/folio/okapi/bean/PermissionList.java
@@ -1,17 +1,32 @@
 package org.folio.okapi.bean;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 /**
  * List of Permissions (and permission sets) belonging to a module. Used as a
  * parameter in the system request to initialize the permission module when a
  * module is being enabled for a tenant.
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class PermissionList {
   private final String moduleId; // The module that owns these permissions.
   private final Permission[] perms;
+  private final String[] replaces;
 
-  public PermissionList(String moduleId, Permission[] perms) {
+  /**
+   * Create permissions object representing body of _tenantPermissions service.
+   * @param moduleId module for which we pass permissions
+   * @param perms the permissions defined by the module
+   * @param replaces the modules that this one replaces (if any)
+   */
+  public PermissionList(String moduleId, Permission[] perms, String[] replaces) {
     this.moduleId = moduleId;
     this.perms = perms;
+    this.replaces = replaces;
+  }
+
+  public PermissionList(String moduleId, Permission[] perms) {
+    this(moduleId, perms, null);
   }
 
   public String getModuleId() {
@@ -22,4 +37,7 @@ public class PermissionList {
     return perms;
   }
 
+  public String[] getReplaces() {
+    return replaces;
+  }
 }

--- a/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
@@ -635,6 +635,15 @@ public class TenantManager implements Liveness {
           pl = new PermissionList(mdFrom.getId(), new Permission[0]);
         }
         break;
+      case "2.1":
+        if (mdTo != null) {
+          pl = new PermissionList(mdTo.getId(), mdTo.getExpandedPermissionSets(),
+              mdTo.getReplaces());
+        } else  {
+          // attempt an empty list for the module being disabled
+          pl = new PermissionList(mdFrom.getId(), new Permission[0]);
+        }
+        break;
       default:
         return Future.failedFuture(new OkapiError(ErrorType.USER,
             "Unknown version of _tenantPermissions interface in use " + permIntVer + "."));

--- a/okapi-core/src/test/java/org/folio/okapi/ModuleTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ModuleTest.java
@@ -1366,9 +1366,7 @@ public class ModuleTest {
     final String docEnable2 = "{" + LS
       + "  \"id\" : \"sample-module2-1\"" + LS
       + "}";
-    final String expPerms2 = "{ "
-      + "\"moduleId\" : \"sample-module2-1\", "
-      + "\"perms\" : null }";
+    final String expPerms2 = "{\"moduleId\" : \"sample-module2-1\"}";
 
     String locSampleEnable2 = given()
       .header("Content-Type", "application/json")


### PR DESCRIPTION
For _tenantPermissions 2.1, pass replaces property with modules that this replaces.

https://issues.folio.org/browse/OKAPI-1151