### PR TITLE
Add try/catch to fix null pointer in logging context usage OKAPI-1149

### DIFF
--- a/okapi-common/src/main/java/org/folio/okapi/common/logging/FolioLoggingContext.java
+++ b/okapi-common/src/main/java/org/folio/okapi/common/logging/FolioLoggingContext.java
@@ -61,17 +61,21 @@ public class FolioLoggingContext implements StrLookup {
    */
   @Override
   public String lookup(LogEvent event, String key) {
-    if (key == null) {
-      throw new IllegalArgumentException("Key cannot be null");
-    }
-    Context ctx = Vertx.currentContext();
-    if (ctx != null) {
-      String val = ctx.getLocal(LOGGING_VAR_PREFIX + key);
-      if (val != null) {
-        return val;
+    try {
+      if (key == null) {
+        throw new IllegalArgumentException("Key cannot be null");
       }
+      Context ctx = Vertx.currentContext();
+      if (ctx != null) {
+        String val = ctx.getLocal(LOGGING_VAR_PREFIX + key);
+        if (val != null) {
+          return val;
+        }
+      }
+      return EMPTY_VALUE;
+    } catch (NullPointerException e) {
+      return EMPTY_VALUE;
     }
-    return EMPTY_VALUE;
   }
 
   /**

--- a/okapi-common/src/main/java/org/folio/okapi/common/logging/FolioLoggingContext.java
+++ b/okapi-common/src/main/java/org/folio/okapi/common/logging/FolioLoggingContext.java
@@ -61,6 +61,7 @@ public class FolioLoggingContext implements StrLookup {
    */
   @Override
   public String lookup(LogEvent event, String key) {
+    // needs try/catch until fixed: https://github.com/eclipse-vertx/vert.x/issues/4611
     try {
       if (key == null) {
         throw new IllegalArgumentException("Key cannot be null");

--- a/okapi-common/src/test/java/org/folio/okapi/common/logging/CurrentContextTest.java
+++ b/okapi-common/src/test/java/org/folio/okapi/common/logging/CurrentContextTest.java
@@ -1,0 +1,26 @@
+package org.folio.okapi.common.logging;
+
+import io.vertx.core.Vertx;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ * OKAPI-1149 test case.
+ *
+ * <p>Test with
+ * <pre><code>
+ *  cd okapi-common
+ *  mvn -Dtest=CurrentContextTest test
+ * </code></pre>
+ * It does not test in junit terms. See the log!
+ */
+public class CurrentContextTest {
+
+  @Test
+  public void checkCurrentContext() {
+    assertThat(Vertx.currentContext(), is(nullValue()));
+  }
+}

--- a/okapi-common/src/test/resources/log4j2.properties
+++ b/okapi-common/src/test/resources/log4j2.properties
@@ -1,18 +1,19 @@
 status = error
 name = PropertiesConfig
+packages = org.folio.okapi.common.logging
 
 filters = threshold
 
 filter.threshold.type = ThresholdFilter
-filter.threshold.level = info
+filter.threshold.level = debug
 
 appenders = console
 
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{HH:mm:ss} %-5p %-20.20C{1} %m%n
+appender.console.layout.pattern = %d{HH:mm:ss} [$${FolioLoggingContext:requestid}] [$${FolioLoggingContext:tenantid}] [$${FolioLoggingContext:userid}] [$${FolioLoggingContext:moduleid}] %-5p %-20.20C{1} %m%n
 
-rootLogger.level = info
+rootLogger.level = debug
 rootLogger.appenderRefs = info
 rootLogger.appenderRef.stdout.ref = STDOUT


### PR DESCRIPTION
Not elegant with no automatic tests.. This runs without logged exceptions:

    mvn -Dtest=CurrentContextTest test