### PR TITLE
OKAPI-1164: ctx.request().path() log injection in okapi-test-module

### DIFF
--- a/okapi-test-module/src/main/java/org/folio/okapi/sample/MainVerticle.java
+++ b/okapi-test-module/src/main/java/org/folio/okapi/sample/MainVerticle.java
@@ -143,13 +143,19 @@ public class MainVerticle extends AbstractVerticle {
     ctx.request().resume();
   }
 
+  @SuppressWarnings("javasecurity:S5145")  // suppress
+  // "Change this code to not log user-controlled data.
+  //  Logging should not be vulnerable to injection attacks"
+  // because Okapi validates the path against the ModuleDescriptor,
+  // and this module is used for unit tests only.
+  private void log(String method, String path, String tenant) {
+    logger.info("{} {} to okapi-test-module for tenant {}", method, path, tenant);
+  }
+
   private void myTenantHandle(RoutingContext ctx) {
     String tenant = ctx.request().getHeader(XOkapiHeaders.TENANT);
     String meth = ctx.request().method().name();
-    if (logger.isInfoEnabled()) {
-      logger.info("{} {} to okapi-est-module for tenant {}",
-          meth, ctx.request().path(), tenant);
-    }
+    log(meth, ctx.request().path(), tenant);
     tenantParameters = null;
     if (ctx.request().method().equals(HttpMethod.DELETE)) {
       ctx.response().setStatusCode(204);


### PR DESCRIPTION
https://github.com/folio-org/okapi/blob/v5.0.1/okapi-test-module/src/main/java/org/folio/okapi/sample/MainVerticle.java#L150-L151

Sonar reports

```
Change this code to not log user-controlled data.
Logging should not be vulnerable to injection attacks javasecurity:S5145
https://sonarcloud.io/organizations/folio-org/rules?open=javasecurity%3AS5145&rule_key=javasecurity%3AS5145
```

The security vulnerability is a bit concerning.