### PR TITLE
OKAPI-1168: stronger qualification for token cache

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@ Fixes:
 * [OKAPI-1149](https://issues.folio.org/browse/OKAPI-1149) FolioLoggingContext bootstrap NPE with debug log level
 * [OKAPI-1076](https://issues.folio.org/browse/OKAPI-1076) Sort interface versions when reporting mismatch
 * [OKAPI-1162](https://issues.folio.org/browse/OKAPI-1162) apt upgrade - OpenSSL 3.0.8 fixing 8 vulns
+* [OKAPI-1168](https://issues.folio.org/browse/OKAPI-1168) Stronger Qualification for Token Cache Hits For Authorization
 
 ## 5.0.0 2023-02-15
 
@@ -488,7 +489,7 @@ Some performance improvements in various areas.
  * [OKAPI-777](https://issues.folio.org/browse/OKAPI-777) ModuleId and SemVer toString updates, offer ModuleId.getSemVer
  * [OKAPI-774](https://issues.folio.org/browse/OKAPI-774) Switch from Future to Promise and others  (Vert.x 3.7 series)
  * Upgrade to Vert.x 3.8.3 from Vert.x 3.8.1
-  
+
 ## 2.33.0 2019-09-26
  * [OKAPI-763](https://issues.folio.org/browse/OKAPI-763) Prevent X-Okapi-Token from being returned in some cases
    where they are simply returned by mistake. This is a workaround

--- a/okapi-core/src/main/java/org/folio/okapi/util/TokenCache.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/TokenCache.java
@@ -54,7 +54,7 @@ public class TokenCache {
       String keyToken, String token) {
     long now = System.currentTimeMillis();
     CacheEntry entry = new CacheEntry(token, userId, xokapiPerms, now + ttl);
-    String key = genKey(method, path, keyToken);
+    String key = genKey(tenant, method, path, keyToken);
     MetricsHelper.recordTokenCacheCached(tenant, method, path, userId);
     logger.debug("Caching: {} -> {}", key, token);
     cache.put(key, entry);
@@ -71,7 +71,7 @@ public class TokenCache {
    * @return cache entry or null
    */
   public CacheEntry get(String tenant, String method, String path, String userId, String token) {
-    String key = genKey(method, path, token);
+    String key = genKey(tenant, method, path, token);
     CacheEntry ret = cache.get(key);
     if (ret == null) {
       MetricsHelper.recordTokenCacheMiss(tenant, method, path, userId);
@@ -89,9 +89,9 @@ public class TokenCache {
     }
   }
 
-  private String genKey(String method, String path, String token) {
+  private String genKey(String tenantId, String method, String path, String token) {
     String tok = token == null ? "null" : token.replaceAll("[\n\t\r]", "");
-    return (method + "|" + path + "|" + tok);
+    return (tenantId + "|" + method + "|" + path + "|" + tok);
   }
 
   public static Builder builder() {

--- a/okapi-core/src/test/java/org/folio/okapi/util/TokenCacheTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/TokenCacheTest.java
@@ -94,4 +94,24 @@ public class TokenCacheTest {
     cache.put("tenant", "method", "path", "userId", "xokapiPerms", "bar", "barTok");
     assertEquals(cap - 2, cache.size());
   }
+
+  @Test
+  public void testDifferentTenantsSameToken() {
+    TokenCache cache = TokenCache.builder()
+        .withMaxSize(2)
+        .build();
+
+    // create a cache item for tenant A
+    cache.put("tenantA", "method", "path", "userId", "xokapiPerms", "foo", "fooTok");
+    assertEquals("fooTok", cache.get("tenantA", "method", "path", "userId", "foo").token);
+    assertEquals(1, cache.size());
+
+    // cache should not return an item for tenant B
+    assertNull(cache.get("tenantB", "method", "path", "userId", "foo"));
+
+    // create a cache item for tenant B
+    cache.put("tenantB", "method", "path", "userId", "xokapiPerms", "foo", "fooTok");
+    assertEquals("fooTok", cache.get("tenantB", "method", "path", "userId", "foo").token);
+    assertEquals(2, cache.size());
+  }
 }


### PR DESCRIPTION
See https://issues.folio.org/browse/OKAPI-1168

Utilize tenant id when retrieving cache item