### PR TITLE
Update hazelcast to support AWS IMDSv2

### DIFF
--- a/okapi-core/pom.xml
+++ b/okapi-core/pom.xml
@@ -133,11 +133,7 @@
     </dependency>
     <dependency>
       <groupId>com.hazelcast</groupId>
-      <artifactId>hazelcast-aws</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.hazelcast</groupId>
-      <artifactId>hazelcast-kubernetes</artifactId>
+      <artifactId>hazelcast</artifactId>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,13 +49,8 @@
       </dependency>
       <dependency>
         <groupId>com.hazelcast</groupId>
-        <artifactId>hazelcast-aws</artifactId>
-        <version>3.4</version>  <!-- https://github.com/hazelcast/hazelcast-aws#requirements -->
-      </dependency>
-      <dependency>
-        <groupId>com.hazelcast</groupId>
-        <artifactId>hazelcast-kubernetes</artifactId>
-        <version>2.2.3</version>  <!-- https://github.com/hazelcast/hazelcast-kubernetes#requirements-and-recommendations -->
+        <artifactId>hazelcast</artifactId>
+        <version>5.2.3</version>
       </dependency>
       <!-- END: versions that depend on the vertx-stack-depchain version -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
       <dependency>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast</artifactId>
-        <version>5.2.3</version>
+        <version>5.2.4</version>
       </dependency>
       <!-- END: versions that depend on the vertx-stack-depchain version -->
 


### PR DESCRIPTION
The [hazelcast-aws](https://github.com/hazelcast/hazelcast-aws) used by Okapi has been deprecated, and it does not support AWS IMDSv2. This PR updates Okapi to use [hazelcast ](https://github.com/hazelcast/hazelcast)where IMDSv2 support has been added since [v5.2.2](https://github.com/hazelcast/hazelcast/releases/tag/v5.2.2).