### PR TITLE
OKAPI-1172: Reduce excessive logging on deploy

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/managers/DeploymentManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/DeploymentManager.java
@@ -166,7 +166,7 @@ public class DeploymentManager {
         }
         descriptor.setEnv(nenv);
       }
-      logger.info("Deploy {} {}", md.getSrvcId(), Json.encodePrettily(descriptor));
+      logger.info("Deploy {} {}", md.getSrvcId(), md.getDescriptor().getDockerImage());
       String moduleUrl = "http://" + host + ":" + usePort;
       String moduleHost = host;
       if (descriptor.getDockerImage() != null) {

--- a/okapi-core/src/main/java/org/folio/okapi/managers/DiscoveryManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/DiscoveryManager.java
@@ -153,9 +153,9 @@ public class DiscoveryManager implements NodeListener {
    * </ol>
    */
   private Future<DeploymentDescriptor> addAndDeploy0(DeploymentDescriptor dd) {
-    String tmp = Json.encodePrettily(dd);
-    logger.info("addAndDeploy: {}", tmp);
     final String id = dd.getSrvcId();
+    logger.info("addAndDeploy: {} {} {}", dd.getNodeId(), id,
+        dd.getDescriptor() == null ? null : dd.getDescriptor().getDockerImage());
     if (id == null) {
       return Future.failedFuture(new OkapiError(ErrorType.USER, messages.getMessage("10800")));
     }


### PR DESCRIPTION
When Okapi deploys a module it logs the complete module descriptor.

This is too verbose. It is not needed because the information is available with `docker inspect`.