### PR TITLE
OKAPI-1177: Disable reduced pom in shade plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,7 @@
           <artifactId>maven-shade-plugin</artifactId>
           <version>3.5.0</version>
           <configuration>
+            <createDependencyReducedPom>false</createDependencyReducedPom>
             <filters>
               <filter>
                 <artifact>*:*</artifact>


### PR DESCRIPTION
Recent version of maven-shade-plugin automatically create a reduced pom.xml.

This results in missing dependenies or unwanted old versions when a library like okapi-common is used.

Disabling reduced poms keeps the old behaviour.