### PR TITLE
OKAPI-1178: Vert.x 4.4.6 fixing netty-codec-http2 DoS (CVE-2023-44487)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.4.5</version> <!-- also update depending versions below! -->
+        <version>4.4.6</version> <!-- also update depending versions below! -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Upgrade Vertx from 4.4.5 to 4.4.6. This fixes quite a few bugs.

In addition this upgrades the Netty dependency from 4.1.97.Final to 4.1.100.Final fixing netty-codec-http2 Denial of Service (DoS):

https://vertx.io/blog/eclipse-vert-x-4-4-6/
https://netty.io/news/2023/10/10/4-1-100-Final.html

Okapi supports HTTP2 and is affected.