### PR TITLE
OKAPI-1181 Implement dependency check option

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
@@ -974,7 +974,9 @@ public class TenantManager implements Liveness {
       Map<String, ModuleDescriptor> modsEnabled, InstallJob job) {
 
     List<TenantModuleDescriptor> tml = job.getModules();
-    DepResolution.install(modsAvailable, modsEnabled, tml, options.getReinstall());
+    if (options.getDepCheck()) {
+      DepResolution.install(modsAvailable, modsEnabled, tml, options.getReinstall());
+    }
     if (options.getSimulate()) {
       return Future.succeededFuture(tml);
     }
@@ -1075,8 +1077,10 @@ public class TenantManager implements Liveness {
         continue;
       }
       ModuleDescriptor md = modsAvailable.get(tm.getId());
-      if (!depsOK(tm, md, getEnabledModules(t))) {
-        continue;
+      if (options.getDepCheck()) {
+        if (!depsOK(tm, md, getEnabledModules(t))) {
+          continue;
+        }
       }
       if (isExclusive(md)) {
         if (running.get() > 0) {

--- a/okapi-core/src/main/java/org/folio/okapi/util/ModuleUtil.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/ModuleUtil.java
@@ -36,6 +36,7 @@ public final class ModuleUtil {
     options.setIgnoreErrors(getParamBoolean(params, "ignoreErrors", false));
     options.setReinstall(getParamBoolean(params, "reinstall", false));
     options.setMaxParallel(getParamInteger(params, "parallel", 1));
+    options.setDepCheck(getParamBoolean(params, "depCheck", true));
     return options;
   }
 


### PR DESCRIPTION
## Purpose

Enable dependency check option

## Approach
Wire up the existing depCheck parameter to be surfaced when TenantInstallOptions class is created. When depCheck is false, skip dependency checking.