### PR TITLE
OKAPI-1183: Vert.x 4.4.8 fixing CVE-2024-1023

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.4.6</version> <!-- also update depending versions below! -->
+        <version>4.4.8</version> <!-- also update depending versions below! -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -51,14 +51,14 @@
       <dependency>
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-bom</artifactId>
-        <version>1.11.4</version>  <!-- https://github.com/vert-x3/vertx-micrometer-metrics/blob/master/pom.xml#L41 -->
+        <version>1.11.5</version>  <!-- https://github.com/vert-x3/vertx-micrometer-metrics/blob/master/pom.xml#L41 -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast</artifactId>
-        <version>5.3.2</version>  <!-- https://github.com/vert-x3/vertx-hazelcast/blob/4.x/.github/workflows/ci-4.x.yml -->
+        <version>5.3.5</version>  <!-- https://github.com/vert-x3/vertx-hazelcast/blob/4.x/.github/workflows/ci-4.x.yml -->
       </dependency>
       <!-- END: versions that depend on the vertx-stack-depchain version -->
 


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/OKAPI-1183

Upgrade Vert.x from 4.4.6 to 4.4.8.

The Vert.x upgrade fixes a memory leak in Vert.x HTTP client caused by Netty FastThreadLocal: https://access.redhat.com/security/cve/cve-2024-1023

Vert.x 4.4.8 upgrades micrometer from 1.11.4 to 1.11.5: https://github.com/vert-x3/vertx-micrometer-metrics/blob/4.4.8/pom.xml#L41

Upgrade hazelcast from 5.3.2 to 5.3.5 to fix improper access control: CVE-2023-4586

Vert.x has been tested with hazelcast 5.3.5: https://github.com/vert-x3/vertx-hazelcast/blob/4.x/.github/workflows/ci-4.x.yml#L20