### PR TITLE
OKAPI-1189: Add "extensions" field to module descriptor

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/bean/ModuleDescriptor.java
+++ b/okapi-core/src/main/java/org/folio/okapi/bean/ModuleDescriptor.java
@@ -37,6 +37,7 @@ public class ModuleDescriptor implements Comparable<ModuleDescriptor> {
   private UiModuleDescriptor uiDescriptor;
   private LaunchDescriptor launchDescriptor;
   private ModuleId[] replaces;
+  private AnyDescriptor extensions;
 
   public ModuleDescriptor() {
   }
@@ -391,6 +392,14 @@ public class ModuleDescriptor implements Comparable<ModuleDescriptor> {
 
   public void setMetadata(AnyDescriptor metadata) {
     this.metadata = metadata;
+  }
+
+  public AnyDescriptor getExtensions() {
+    return extensions;
+  }
+
+  public void setExtensions(AnyDescriptor extensions) {
+    this.extensions = extensions;
   }
 
   public RoutingEntry[] getFilters() {

--- a/okapi-core/src/main/raml/ModuleDescriptor.json
+++ b/okapi-core/src/main/raml/ModuleDescriptor.json
@@ -80,6 +80,10 @@
     "launchDescriptor": {
       "description": "Default deployment for this module",
       "$ref": "LaunchDescriptor.json"
+    },
+    "extensions" : {
+      "description": "Sets extensions for ModuleDescriptor that can store custom or meta information.",
+      "type": "object"
     }
   },
   "required": ["id"]


### PR DESCRIPTION
**Overview**

Eureka has introduced new fields to the module descriptor in order to support the declarative specification of system/tenant users.  These changes are incompatible with Okapi.  After reviewing solutions, the decision was made to add a new field to the module descriptor “extensions”, and update the necessary code in both Eureka (mgr-*) and Okapi.  

See [wiki](https://folio-org.atlassian.net/wiki/spaces/FOLIJET/pages/141099068/Verify+that+Module+Descriptor+changes+are+backwards+compatible#Option-2-Add-new-property-into-ModuleDescriptor-called-%E2%80%9Cextensions%E2%80%9D%3A) for additional details.
[OKAPI-1189](https://folio-org.atlassian.net/browse/OKAPI-1189)

**Scope**

- Add the new “extensions” field
- Any necessary code and test updates