### PR TITLE
OKAPI-1192: commons-io 2.16.1

### DIFF
--- a/okapi-core/pom.xml
+++ b/okapi-core/pom.xml
@@ -127,6 +127,15 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- raml-tester uses vulnerable commons-io 2.2:
+         https://security.snyk.io/package/maven/commons-io:commons-io/2.2
+    -->
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.16.1</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-hazelcast</artifactId>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/OKAPI-1192

raml-tester uses vulnerable commons-io 2.2: <https://security.snyk.io/package/maven/commons-io:commons-io/2.2>

Bump this test dependency from 2.2 to current 2.16.1.