### PR TITLE
OKAPI-1198: Increase max URI length from 4096 to 8192

### DIFF
--- a/okapi-core/src/test/java/org/folio/okapi/MainVerticleTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/MainVerticleTest.java
@@ -3,9 +3,15 @@ package org.folio.okapi;
 import static io.restassured.RestAssured.get;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import io.netty.handler.codec.DecoderResult;
 import io.restassured.RestAssured;
 import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.BeforeAll;
@@ -46,5 +52,21 @@ class MainVerticleTest {
         .then()
         .statusCode(431)
         .body(is("Your HTTP request header fields are too large."));
+  }
+
+  @Test
+  void default400() {
+    var httpServerRequest = mock(HttpServerRequest.class);
+    var decoderResult = mock(DecoderResult.class);
+    var httpServerResponse = mock(HttpServerResponse.class);
+    when(httpServerRequest.decoderResult()).thenReturn(decoderResult);
+    when(httpServerRequest.response()).thenReturn(httpServerResponse);
+    when(httpServerResponse.setStatusCode(400)).thenReturn(httpServerResponse);
+
+    MainVerticle.invalidRequestHandler(httpServerRequest);
+
+    verify(httpServerResponse).setStatusCode(400);
+    verify(httpServerResponse).end();
+    verify(httpServerResponse).close();
   }
 }


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/OKAPI-1198

Okapi and Kong have different URI max lengths:

* Okapi is based on Netty and Netty has 4096: https://github.com/netty/netty/blob/netty-4.1.115.Final/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java#L146
* Kong is based on Nginx and Nginx has 8k = 8192: https://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers

The same for modules:

* Vert.x modules are based on Netty with a limit of 4096.
* Spring Boot modules are based on Tomcat with a limit of 8k=8192: https://tomcat.apache.org/tomcat-10.1-doc/config/http.html#Attributes_Standard%20Implementation_maxHttpHeaderSize

Increase Okapi’s URI max length from 4096 to 8192 so that Spring Boot modules don’t get restricted by Okapi.

Add a body to these two HTTP response codes so that some error text is shown in the UI, for details see https://folio-org.atlassian.net/browse/UISINVCOMP-43 :

* 413 Your request URI is too long.
* 431 Your HTTP request header fields are too large.