### PR TITLE
Postgres 16, workflow, TESTCONTAINERS_POSTGRES_IMAGE, error reporting

### DIFF
--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -1,0 +1,26 @@
+name: postgres
+on:
+  workflow_dispatch:
+    inputs:
+      postgres:
+        description: "List of postgres container images, to be injected as TESTCONTAINERS_POSTGRES_IMAGE"
+        default: '["postgres:16-alpine", "postgres:18-alpine"]'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        postgres: ${{ fromJSON(github.event.inputs.postgres) }}
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: maven
+      - run: mvn --batch-mode verify
+        env:
+          TESTCONTAINERS_POSTGRES_IMAGE: ${{ matrix.postgres }}

--- a/okapi-core/src/test/java/org/folio/okapi/ModuleTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ModuleTest.java
@@ -15,6 +15,7 @@ import org.apache.logging.log4j.Logger;
 import org.folio.okapi.common.OkapiLogger;
 import org.folio.okapi.common.UrlDecoder;
 import org.folio.okapi.common.XOkapiHeaders;
+import org.folio.okapi.util.PgTestBase;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -135,9 +136,7 @@ public class ModuleTest {
     switch (value) {
       case "postgres":
         if (postgresSQLContainer == null) {
-          postgresSQLContainer = new PostgreSQLContainer<>("postgres:12-alpine")
-              .withStartupAttempts(STARTUP_ATTEMPTS);
-          postgresSQLContainer.start();
+          postgresSQLContainer = PgTestBase.createPostgreSQLContainer();
         }
         conf.put("postgres_username", postgresSQLContainer.getUsername());
         conf.put("postgres_password", postgresSQLContainer.getPassword());

--- a/okapi-core/src/test/java/org/folio/okapi/service/impl/PostgresHandleTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/service/impl/PostgresHandleTest.java
@@ -30,6 +30,9 @@ class PostgresHandleTest extends PgTestBase implements WithAssertions {
   static void exec(String... command) {
     try {
       ExecResult execResult = POSTGRESQL_CONTAINER.execInContainer(command);
+      if (execResult.getExitCode() != 0) {
+        throw new RuntimeException(String.join(" ", command) + " " + execResult);
+      }
       OkapiLogger.get().debug(() -> String.join(" ", command) + " " + execResult);
     } catch (InterruptedException | IOException | UnsupportedOperationException e) {
       throw new RuntimeException(e);
@@ -54,7 +57,7 @@ class PostgresHandleTest extends PgTestBase implements WithAssertions {
     MountableFile serverCrtFile = MountableFile.forClasspathResource("server.crt");
     POSTGRESQL_CONTAINER.copyFileToContainer(serverKeyFile, KEY_PATH);
     POSTGRESQL_CONTAINER.copyFileToContainer(serverCrtFile, CRT_PATH);
-    exec("chown", "postgres.postgres", KEY_PATH, CRT_PATH);
+    exec("chown", "postgres:postgres", KEY_PATH, CRT_PATH);
     exec("chmod", "400", KEY_PATH, CRT_PATH);
     exec("cp", "-p", CONF_PATH, CONF_BAK_PATH);
 

--- a/okapi-core/src/test/java/org/folio/okapi/util/PgTestBase.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/PgTestBase.java
@@ -7,11 +7,21 @@ import org.testcontainers.containers.PostgreSQLContainer;
  * Singleton PostgreSQL instance from testcontainers.org.
  */
 public abstract class PgTestBase extends TestBase {
-  public static final PostgreSQLContainer<?> POSTGRESQL_CONTAINER;
+  private static final String DEFAULT_POSTGRESQL_IMAGE_NAME = "postgres:16-alpine";
+  private static final String POSTGRESQL_IMAGE_NAME =
+      System.getenv().getOrDefault("TESTCONTAINERS_POSTGRES_IMAGE", DEFAULT_POSTGRESQL_IMAGE_NAME);
+  /**
+   * Testcontainers startup config workaround for podman:
+   * https://github.com/testcontainers/testcontainers-java/issues/6640#issuecomment-1431636203
+   */
+  private static final int STARTUP_ATTEMPTS = 3;
+  public static final PostgreSQLContainer<?> POSTGRESQL_CONTAINER = createPostgreSQLContainer();
 
-  static {
-    POSTGRESQL_CONTAINER = new PostgreSQLContainer<>("postgres:12-alpine");
-    POSTGRESQL_CONTAINER.start();
+  public static PostgreSQLContainer<?> createPostgreSQLContainer() {
+    var container = new PostgreSQLContainer<>(POSTGRESQL_IMAGE_NAME)
+        .withStartupAttempts(STARTUP_ATTEMPTS);
+    container.start();
+    return container;
   }
 
   public static PgConnectOptions getPgConnectOptions() {


### PR DESCRIPTION
Test upgrades:

* Upgrade postgres from 12 to 16.
* Fix chown syntax in postgres container.
* Add error reporting for execInContainer.
* Add GitHub Actions workflow for TESTCONTAINERS_POSTGRES_IMAGE.