### PR TITLE
okapi interface is a normal interface OKAPI-1199

### DIFF
--- a/doc/guide.md
+++ b/doc/guide.md
@@ -3013,8 +3013,7 @@ detailed ModuleDescriptor in version 1.10.0.
 The internal module is always available, but only enabled by default
 for `supertenant`.
 Other tenants must enable the okapi module to use the Okapi API.
-Individual modules should require optionally or explicitly the
-`okapi` interface.
+Individual modules should add the `okapi` interface to the `"requires"` or `"optional"` property of their module descriptor.
 
 ### Deployment
 

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -3010,6 +3010,12 @@ expected that this interface will remain fairly stable over time.
 The internal module was introduced in Okapi version 1.9.0, and a fully
 detailed ModuleDescriptor in version 1.10.0.
 
+The internal module is always available, but only enabled by default
+for `supertenant`.
+Other tenants must enable the okapi module to use the Okapi API.
+Individual modules should require optionally or explicitly the
+`okapi` interface.
+
 ### Deployment
 
 Deployment is specified by schemas

--- a/okapi-core/src/main/java/org/folio/okapi/managers/InternalModule.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/InternalModule.java
@@ -119,7 +119,6 @@ public class InternalModule {
         + " }, {"
         + "   \"id\" : \"okapi\","
         + "   \"version\" : \"" + INTERFACE_VERSION + "\","
-        + "   \"interfaceType\" : \"internal\","
         + "   \"handlers\" : [ "
         // Deployment service
         + "   {"

--- a/okapi-core/src/test/java/org/folio/okapi/util/DepResolutionTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/DepResolutionTest.java
@@ -1486,7 +1486,7 @@ public class DepResolutionTest {
     List<TenantModuleDescriptor> tml1 = enableList(mdA);
     OkapiError error = Assert.assertThrows(OkapiError.class,
         () -> DepResolution.install(map(mdA), map(), tml1, false));
-    Assert.assertEquals("interface okapi required by module modA-1.0.0 not found", error.getMessage());
+    assertThat(error.getMessage(), is("interface okapi required by module modA-1.0.0 not found"));
 
     ModuleDescriptor mdOkapi = InternalModule.moduleDescriptor("1.0");
     List<TenantModuleDescriptor> tml2 = enableList(mdA);
@@ -1499,7 +1499,7 @@ public class DepResolutionTest {
     List<TenantModuleDescriptor> tml3 = enableList(mdA);
     error = Assert.assertThrows(OkapiError.class,
       () -> DepResolution.install(map(mdA, modOkapiB, mdOkapi), map(), tml3, false));
-      Assert.assertEquals("interface okapi required by module modA-1.0.0 is provided by multiple products: okapi, modB", error.getMessage());
+    assertThat(error.getMessage(), is("interface okapi required by module modA-1.0.0 is provided by multiple products: okapi, modB"));
 
     List<TenantModuleDescriptor> tml4 = enableList(mdA, modOkapiB);
     DepResolution.install(map(mdA, modOkapiB, mdOkapi), map(), tml4, false);

--- a/okapi-core/src/test/java/org/folio/okapi/util/DepResolutionTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/DepResolutionTest.java
@@ -1493,16 +1493,16 @@ public class DepResolutionTest {
     DepResolution.install(map(mdA, mdOkapi), map(mdOkapi), tml2, false);
     assertThat(tml2, contains(enable(mdA)));
 
-    ModuleDescriptor mdB = new ModuleDescriptor("modB-1.0.0");
-    mdB.setProvides(new InterfaceDescriptor[]{intOkapi});
+    ModuleDescriptor modOkapiB = new ModuleDescriptor("modB-1.0.0");
+    modOkapiB.setProvides(new InterfaceDescriptor[]{intOkapi});
 
     List<TenantModuleDescriptor> tml3 = enableList(mdA);
     error = Assert.assertThrows(OkapiError.class,
-      () -> DepResolution.install(map(mdA, mdB, mdOkapi), map(), tml3, false));
+      () -> DepResolution.install(map(mdA, modOkapiB, mdOkapi), map(), tml3, false));
       Assert.assertEquals("interface okapi required by module modA-1.0.0 is provided by multiple products: okapi, modB", error.getMessage());
 
-    List<TenantModuleDescriptor> tml4 = enableList(mdA, mdB);
-    DepResolution.install(map(mdA, mdB, mdOkapi), map(), tml4, false);
-    assertThat(tml4, contains(enable(mdB), enable(mdA)));
+    List<TenantModuleDescriptor> tml4 = enableList(mdA, modOkapiB);
+    DepResolution.install(map(mdA, modOkapiB, mdOkapi), map(), tml4, false);
+    assertThat(tml4, contains(enable(modOkapiB), enable(mdA)));
   }
 }


### PR DESCRIPTION
Before this commit, modules could not really require the interface as it was not considered in dependency resolution (install).