### PR TITLE
Remove wagon-ssh

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,19 +166,6 @@
   </dependencyManagement>
 
   <build>
-    <extensions>
-      <extension>
-        <groupId>org.apache.maven.wagon</groupId>
-        <artifactId>wagon-ssh</artifactId>
-        <version>3.5.3</version>
-      </extension>
-      <extension>
-        <groupId>org.apache.maven.wagon</groupId>
-        <artifactId>wagon-ssh-external</artifactId>
-        <version>3.5.3</version>
-      </extension>
-    </extensions>
-
     <pluginManagement>
       <plugins>
 


### PR DESCRIPTION
We no longer use scp://maven.indexdata.com therefore we no longer need wagon-ssh:

https://github.com/folio-org/okapi/commit/3084caa1d0f33883affb305d410aaca7ba1fe42f