### PR TITLE
refreshtoken client sets X-Okapi-Tenant

### DIFF
--- a/okapi-common/src/main/java/org/folio/okapi/common/refreshtoken/client/impl/LoginClient.java
+++ b/okapi-common/src/main/java/org/folio/okapi/common/refreshtoken/client/impl/LoginClient.java
@@ -173,6 +173,7 @@ public class LoginClient implements Client {
   @Override
   public Future<HttpRequest<Buffer>> getToken(HttpRequest<Buffer> request) {
     return getToken().map(token -> {
+      request.putHeader(XOkapiHeaders.TENANT, tenant);
       request.putHeader(XOkapiHeaders.TOKEN, token);
       return request;
     });

--- a/okapi-common/src/main/java/org/folio/okapi/common/refreshtoken/client/impl/RefreshClient.java
+++ b/okapi-common/src/main/java/org/folio/okapi/common/refreshtoken/client/impl/RefreshClient.java
@@ -74,6 +74,7 @@ public class RefreshClient implements Client {
   @Override
   public Future<HttpRequest<Buffer>> getToken(HttpRequest<Buffer> request) {
     return getToken().map(token -> {
+      request.putHeader(XOkapiHeaders.TENANT, tenant);
       request.putHeader(XOkapiHeaders.TOKEN, token);
       return request;
     });

--- a/okapi-common/src/test/java/org/folio/okapi/common/refreshtoken/client/impl/LoginClientTest.java
+++ b/okapi-common/src/test/java/org/folio/okapi/common/refreshtoken/client/impl/LoginClientTest.java
@@ -156,7 +156,7 @@ public class LoginClientTest {
         response.end("No token provided");
         return;
       }
-      if (request.getHeader(XOkapiHeaders.TENANT) == null) {
+      if (!TENANT_OK.equals(request.getHeader(XOkapiHeaders.TENANT))) {
         response.setStatusCode(401);
         response.putHeader("Content-Type", "text/plain");
         response.end("No tenant header provided");

--- a/okapi-common/src/test/java/org/folio/okapi/common/refreshtoken/client/impl/LoginClientTest.java
+++ b/okapi-common/src/test/java/org/folio/okapi/common/refreshtoken/client/impl/LoginClientTest.java
@@ -156,6 +156,12 @@ public class LoginClientTest {
         response.end("No token provided");
         return;
       }
+      if (request.getHeader(XOkapiHeaders.TENANT) == null) {
+        response.setStatusCode(401);
+        response.putHeader("Content-Type", "text/plain");
+        response.end("No tenant header provided");
+        return;
+      }
       if (!"text/xml".equals(request.getHeader("Content-Type"))) {
         response.setStatusCode(400);
         response.putHeader("Content-Type", "text/plain");

--- a/okapi-common/src/test/java/org/folio/okapi/common/refreshtoken/client/impl/LoginClientTest.java
+++ b/okapi-common/src/test/java/org/folio/okapi/common/refreshtoken/client/impl/LoginClientTest.java
@@ -159,7 +159,7 @@ public class LoginClientTest {
       if (!TENANT_OK.equals(request.getHeader(XOkapiHeaders.TENANT))) {
         response.setStatusCode(401);
         response.putHeader("Content-Type", "text/plain");
-        response.end("No tenant header provided");
+        response.end("X-Okapi-Header mismatch");
         return;
       }
       if (!"text/xml".equals(request.getHeader("Content-Type"))) {

--- a/okapi-common/src/test/java/org/folio/okapi/common/refreshtoken/client/impl/RefreshClientTest.java
+++ b/okapi-common/src/test/java/org/folio/okapi/common/refreshtoken/client/impl/RefreshClientTest.java
@@ -135,7 +135,7 @@ public class RefreshClientTest {
       if (!TENANT_OK.equals(request.getHeader(XOkapiHeaders.TENANT))) {
         response.setStatusCode(401);
         response.putHeader("Content-Type", "text/plain");
-        response.end("No tenant header provided");
+        response.end("X-Okapi-Header mismatch");
         return;
       }
       if (!"text/xml".equals(request.getHeader("Content-Type"))) {

--- a/okapi-common/src/test/java/org/folio/okapi/common/refreshtoken/client/impl/RefreshClientTest.java
+++ b/okapi-common/src/test/java/org/folio/okapi/common/refreshtoken/client/impl/RefreshClientTest.java
@@ -132,6 +132,12 @@ public class RefreshClientTest {
         response.end("No token provided");
         return;
       }
+      if (request.getHeader(XOkapiHeaders.TENANT) == null) {
+        response.setStatusCode(401);
+        response.putHeader("Content-Type", "text/plain");
+        response.end("No tenant header provided");
+        return;
+      }
       if (!"text/xml".equals(request.getHeader("Content-Type"))) {
         response.setStatusCode(400);
         response.putHeader("Content-Type", "text/plain");

--- a/okapi-common/src/test/java/org/folio/okapi/common/refreshtoken/client/impl/RefreshClientTest.java
+++ b/okapi-common/src/test/java/org/folio/okapi/common/refreshtoken/client/impl/RefreshClientTest.java
@@ -45,7 +45,7 @@ public class RefreshClientTest {
 
   private static final String TENANT_OK = "diku";
 
-  private static final String VALID_REFRESH_TOKEN = "diku";
+  private static final String VALID_REFRESH_TOKEN = "dikucookie";
 
   WebClient webClient;
 
@@ -132,7 +132,7 @@ public class RefreshClientTest {
         response.end("No token provided");
         return;
       }
-      if (request.getHeader(XOkapiHeaders.TENANT) == null) {
+      if (!TENANT_OK.equals(request.getHeader(XOkapiHeaders.TENANT))) {
         response.setStatusCode(401);
         response.putHeader("Content-Type", "text/plain");
         response.end("No tenant header provided");
@@ -251,7 +251,7 @@ public class RefreshClientTest {
             .expect(SC_CREATED))
         .onComplete(context.asyncAssertFailure(cause ->
           assertThat(cause.getMessage(), is("Token refresh failed. POST /authn/refresh "
-              + "for tenant 'diku' and refreshtoken 'invalid: diku' returned status 404: Not found"))
+              + "for tenant 'diku' and refreshtoken 'invalid: dikucookie' returned status 404: Not found"))
         ));
   }
 
@@ -263,7 +263,7 @@ public class RefreshClientTest {
             .expect(SC_CREATED))
         .onComplete(context.asyncAssertFailure(cause ->
             assertThat(cause.getMessage(), is("Token refresh failed. POST /authn/refresh "
-                + "for tenant 'diku' and refreshtoken 'invalid: diku' did not return access token"))
+                + "for tenant 'diku' and refreshtoken 'invalid: dikucookie' did not return access token"))
         ));
   }
 


### PR DESCRIPTION
although this information is already part of value in X-Okapi-Token.

This is required as folio module sidecar requires X-Okapi-Tenant to be set.