### PR TITLE
OKAPI-1209 fix install when replacing module

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/util/DepResolution.java
+++ b/okapi-core/src/main/java/org/folio/okapi/util/DepResolution.java
@@ -735,10 +735,12 @@ public final class DepResolution {
         result.add(tm);
       }
     }
-    if (!tml.isEmpty()) {
-      // it would be good to analyze this further with the interfaces that are problematic
-      throw new OkapiError(ErrorType.USER, "Some modules cannot be topological sorted: "
+    for (TenantModuleDescriptor tm : tml) {
+      if (tm.getAction() == TenantModuleDescriptor.Action.enable) {
+        // it would be good to analyze this further with the interfaces that are problematic
+        throw new OkapiError(ErrorType.USER, "Some modules cannot be topological sorted: "
           + tml.stream().map(TenantModuleDescriptor::getId).collect(Collectors.joining(", ")));
+      }
     }
     tml.addAll(result);
   }

--- a/okapi-core/src/test/java/org/folio/okapi/util/DepResolutionTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/DepResolutionTest.java
@@ -1508,7 +1508,7 @@ public class DepResolutionTest {
 
   @Test
   public void replaceModules() {
-    // mdE100 is an interface proviced by both mdA100 and mdB
+    // mdE100 is an interface provided by both mdA100 and mdB
     List<TenantModuleDescriptor> tml = enableList(mdE100, mdA100);
     DepResolution.install(map(mdA100, mdB, mdE100), map(), tml, false);
     assertThat(tml, contains(enable(mdA100), enable(mdE100)));

--- a/okapi-core/src/test/java/org/folio/okapi/util/DepResolutionTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/DepResolutionTest.java
@@ -1505,4 +1505,15 @@ public class DepResolutionTest {
     DepResolution.install(map(mdA, modOkapiB, mdOkapi), map(), tml4, false);
     assertThat(tml4, contains(enable(modOkapiB), enable(mdA)));
   }
+
+  @Test
+  public void replaceModules() {
+    // mdE100 is an interface proviced by both mdA100 and mdB
+    List<TenantModuleDescriptor> tml = enableList(mdE100, mdA100);
+    DepResolution.install(map(mdA100, mdB, mdE100), map(), tml, false);
+    assertThat(tml, contains(enable(mdA100), enable(mdE100)));
+    tml = enableList(mdB);
+    DepResolution.install(map(mdA100, mdB, mdE100), map(mdA100, mdE100), tml, false);
+    assertThat(tml, contains(disable(mdA100), enable(mdB)));
+  }
 }


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/OKAPI-1209

The topological sort does not properly take into account when it's safe to disable a module and the dep check considers it's not safe to remove it, despite a "new" module offers the same interface The strategy is to allow "remaining" modules to be disabled in the end.