### PR TITLE
OKAPI-1210 default action is enable

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
+++ b/okapi-core/src/main/java/org/folio/okapi/managers/TenantManager.java
@@ -921,8 +921,7 @@ public class TenantManager implements Liveness {
     if (tml != null) {
       for (TenantModuleDescriptor tm : tml) {
         if (tm.getAction() == null) {
-          return Future.failedFuture(new OkapiError(ErrorType.USER,
-              messages.getMessage("10405", tm.getId())));
+          tm.setAction(Action.enable);
         }
       }
     }

--- a/okapi-core/src/main/raml/TenantModuleDescriptor.json
+++ b/okapi-core/src/main/raml/TenantModuleDescriptor.json
@@ -15,7 +15,7 @@
       "type": "string"
     },
     "action" : {
-      "description": "Module action",
+      "description": "Module action, default value is enable",
       "type" : "string",
       "enum" : [ "enable", "disable", "uptodate", "suggest", "conflict" ]
     },

--- a/okapi-core/src/main/resources/infra-messages/Messages_en.properties
+++ b/okapi-core/src/main/resources/infra-messages/Messages_en.properties
@@ -39,7 +39,6 @@
 10402=No _tenant interface found for {0}
 10403=No module provides {0}
 10404=Not implemented: action = {0}
-10405=Missing action for id {0}
 10406=Cannot delete non-completed job {0}
 10407=Missing DELETE method for tenant interface version 2 for module {0}
 10408=Missing id property in JSON response for module {0}: {1} {2}

--- a/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
@@ -597,17 +597,9 @@ public class ProxyTest {
       .header("Content-Type", "application/json")
       .body(docBasic_1_0_0).post("/_/proxy/modules").then().statusCode(201);
 
-    /* missing action so this will fail */
     api.createRestAssured3().given()
       .header("Content-Type", "application/json")
       .body("[ {\"id\" : \"basic-module-1.0.0\"} ]")
-      .post("/_/proxy/tenants/" + okapiTenant + "/install?deploy=true")
-      .then().statusCode(400)
-      .body(equalTo("Missing action for id basic-module-1.0.0"));
-
-    api.createRestAssured3().given()
-      .header("Content-Type", "application/json")
-      .body("[ {\"id\" : \"basic-module-1.0.0\", \"action\" : \"enable\"} ]")
       .post("/_/proxy/tenants/" + okapiTenant + "/install?deploy=true")
       .then().statusCode(200)
       .body(equalTo("[ {" + LS


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/OKAPI-1210

Very often, the install has just enable all the way. If the action can be omitted, then the list of enabled modules for tenant can be straight up fed to install for, say, another tenant.