### PR TITLE
OKAPI-1200 fix ModuleTest.testInitdatabaseBadCredentials fails

### DIFF
--- a/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
@@ -226,8 +226,8 @@ public class MainVerticle extends AbstractVerticle {
     fut.onComplete(x -> {
       if (x.failed()) {
         logger.error(x.cause().getMessage());
-      }
-      if (initMode != InitMode.NORMAL) {
+      } else if (initMode != InitMode.NORMAL) {
+        // no failure, must stop the Verticle from going further if initdatabase or similar
         vertx.close();
       }
       promise.handle(x);

--- a/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
+++ b/okapi-core/src/main/java/org/folio/okapi/MainVerticle.java
@@ -226,8 +226,10 @@ public class MainVerticle extends AbstractVerticle {
     fut.onComplete(x -> {
       if (x.failed()) {
         logger.error(x.cause().getMessage());
-      } else if (initMode != InitMode.NORMAL) {
-        // no failure, must stop the Verticle from going further if initdatabase or similar
+      } else if (initMode == InitMode.NORMAL) {
+        // normal startup, no errors
+      } else {
+        // must stop the Verticle from going further if initdatabase or similar
         vertx.close();
       }
       promise.handle(x);


### PR DESCRIPTION
On initdatabase failure we do not need stop the Verticle. It is stopped already because a failure is returned.