### PR TITLE
OKAPI-1211 fix NPE in refreshtoken client

### DIFF
--- a/okapi-common/src/main/java/org/folio/okapi/common/refreshtoken/client/impl/LoginClient.java
+++ b/okapi-common/src/main/java/org/folio/okapi/common/refreshtoken/client/impl/LoginClient.java
@@ -126,7 +126,7 @@ public class LoginClient implements Client {
 
   static String body(HttpResponse<Buffer> httpResponse) {
     var buffer = httpResponse.bodyAsBuffer();
-    if (buffer.length() == 0) {
+    if (buffer == null || buffer.length() == 0) {
       return "";
     }
     var contentType = httpResponse.getHeader(HttpHeaders.CONTENT_TYPE);


### PR DESCRIPTION
https://vertx.io/docs/apidocs/io/vertx/ext/web/client/HttpResponse.html#bodyAsBuffer()

Weird that empty body should not be a buffer.