### PR TITLE
Fix httpClient test setup

### DIFF
--- a/okapi-common/src/test/java/org/folio/okapi/common/OkapiClientTest.java
+++ b/okapi-common/src/test/java/org/folio/okapi/common/OkapiClientTest.java
@@ -6,6 +6,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpResponseExpectation;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.json.JsonObject;
@@ -405,13 +406,8 @@ public class OkapiClientTest {
     context.assertTrue(server != null);
     HttpClient client = vertx.createHttpClient();
     client.request(HttpMethod.POST, PORT, LOCALHOST, URL + "/test1")
-    .compose(request -> {
-      request.end();
-      return request.response();
-    })
-    .onComplete(context.asyncAssertSuccess(response -> {
-      context.assertEquals(200, response.statusCode());
-    }));
+    .compose(request -> request.send().expecting(HttpResponseExpectation.SC_OK))
+    .onComplete(context.asyncAssertSuccess());
   }
 
 }

--- a/okapi-core/src/test/java/org/folio/okapi/DockerTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/DockerTest.java
@@ -78,12 +78,7 @@ public class DockerTest {
 
     HttpClient httpClient = vertx.createHttpClient();
     httpClient.request(HttpMethod.DELETE, port, "localhost", "/_/discovery/modules")
-      .compose(request -> {
-        request.end();
-        return request.response()
-            .expecting(HttpResponseExpectation.SC_NO_CONTENT);
-      })
-      .compose(response -> response.end())
+      .compose(request -> request.send().expecting(HttpResponseExpectation.SC_NO_CONTENT))
       .eventually(() -> vertx.undeploy(verticleId))
       .onComplete(context.asyncAssertSuccess());
   }

--- a/okapi-core/src/test/java/org/folio/okapi/EnvTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/EnvTest.java
@@ -57,12 +57,7 @@ public class EnvTest {
   @After
   public void tearDown(TestContext context) {
     httpClient.request(HttpMethod.DELETE, port, "localhost", "/_/discovery/modules")
-      .compose(request -> {
-        request.end();
-        return request.response()
-            .expecting(HttpResponseExpectation.SC_NO_CONTENT);
-      })
-      .compose(response -> response.end())
+      .compose(request -> request.send().expecting(HttpResponseExpectation.SC_NO_CONTENT))
       .eventually(() -> vertx.undeploy(verticleId))
       .onComplete(context.asyncAssertSuccess());
   }

--- a/okapi-core/src/test/java/org/folio/okapi/ModuleTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ModuleTest.java
@@ -181,12 +181,7 @@ public class ModuleTest {
       return;
     }
     httpClient.request(HttpMethod.DELETE, port, "localhost", "/_/discovery/modules")
-      .compose(request -> {
-        request.end();
-        return request.response()
-            .expecting(HttpResponseExpectation.SC_NO_CONTENT);
-      })
-      .compose(response -> response.end())
+      .compose(request -> request.send().expecting(HttpResponseExpectation.SC_NO_CONTENT))
       .eventually(() -> undeployMainVerticle())
       .onComplete(context.asyncAssertSuccess());
   }


### PR DESCRIPTION
https://jenkins-aws.indexdata.com/job/folio-org/job/okapi/job/master/925/execution/node/43/log/ failed with
```
[ERROR] org.folio.okapi.ModuleTest.testMultipleInterface
[INFO]   Run 1: PASS
[ERROR]   Run 2: ModuleTest.lambda$tearDown$2:189 » IllegalState
[INFO]   Run 3: PASS
```

Cause:

Wrong request and response flow composition, see
https://vertx.io/docs/vertx-core/java/#_request_and_response_flow_composition