### PR TITLE
OKAPI-1244: Vertx 4.5.27, log4j 2.26.0 fixing vulns (Sunflower)

### DIFF
--- a/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/ProxyTest.java
@@ -3984,7 +3984,8 @@ public class ProxyTest {
     given()
         .header("Content-Type", "application/json")
         .body("{\"id\":").post("/_/proxy/import/modules")
-        .then().statusCode(400).body(containsString("Expected `[` but found `{`"));
+        .then().statusCode(400)
+        .body(containsString("Cannot deserialize value of type `org.folio.okapi.bean.ModuleDescriptor[]`"));
 
     given()
         .header("Content-Type", "application/json")

--- a/okapi-core/src/test/java/org/folio/okapi/util/JsonDecoderTest.java
+++ b/okapi-core/src/test/java/org/folio/okapi/util/JsonDecoderTest.java
@@ -1,30 +1,26 @@
 package org.folio.okapi.util;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.startsWith;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
 import io.vertx.core.json.DecodeException;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 class JsonDecoderTest {
 
-  @Test
-  void decode() {
+  @ParameterizedTest
+  @CsvSource({
+    "'{}', 'line: 1, column: 1]'",
+    "'\n\n\n\n\n\n\n\n\n         {}', 'line: 10, column: 10]'",
+  })
+  void decode(String json, String expectedLocation) {
     DecodeException e = assertThrowsExactly(DecodeException.class,
-        () -> JsonDecoder.decode("{}", String[].class));
-    assertThat(e.getMessage(), is("Expected `[` but found `{` when trying to deserialize "
-        + "an array of java.lang.String at line: 1, column: 1"));
-    assertThat(e.getCause().getMessage(), startsWith("Failed to decode:Cannot deserialize"));
-  }
-
-  @Test
-  void decodeWithLocation() {
-    DecodeException e = assertThrowsExactly(DecodeException.class,
-        () -> JsonDecoder.decode("\n\n\n\n\n\n\n\n\n         {}", String[].class));
-    assertThat(e.getMessage(), is("Expected `[` but found `{` when trying to deserialize "
-        + "an array of java.lang.String at line: 10, column: 10"));
-    assertThat(e.getCause().getMessage(), startsWith("Failed to decode:Cannot deserialize"));
+        () -> JsonDecoder.decode(json, String[].class));
+    assertThat(e.getMessage(), containsString("Cannot deserialize value of type `java.lang.String[]`"));
+    assertThat(e.getMessage(), containsString(expectedLocation));
+    assertThat(e.getCause().getMessage(), containsString("Cannot deserialize value of type `java.lang.String[]`"));
+    assertThat(e.getCause().getMessage(), containsString(expectedLocation));
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -35,14 +35,14 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.24.3</version>
+        <version>2.26.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.5.23</version> <!-- also update depending versions below! -->
+        <version>4.5.27</version> <!-- also update depending versions below! -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/OKAPI-1244

For Sunflower branch b6.2:

Bump Vert.x from 4.5.23 to 4.5.27 fixing multiple vulnerabilities:

* CVE-2026-33871 https://github.com/advisories/GHSA-w9fj-cfpg-grvv  – Netty HTTP/2 CONTINUATION Frame Flood DoS
* CVE-2026-42583 https://github.com/advisories/GHSA-mj4r-2hfc-f8p6  – Netty Lz4FrameDecoder
* CVE-2026-42587 https://github.com/advisories/GHSA-f6hv-jmp6-3vwv  – Netty decompression bomb (br, zstd, or snappy)

Bump log4j from 2.24.3 to 2.26.0 fixing a vulnerability in Okapi’s JSON logging:

* CVE-2026-34481 https://github.com/advisories/GHSA-w35j-pv5h-q9q9 – MapMessage/JsonTemplateLayout