### PR TITLE
OKAPI-1245: Trillium: Vertx 5.0.12 fixing Netty vulns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>5.0.10</version>  <!-- also update depending versions below! -->
+        <version>5.0.12</version>  <!-- also update depending versions below! -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/OKAPI-1245

Upgrade Vert.x from 5.0.10 to 5.0.12. This transitively bumps Netty from 4.2.12.Final to 4.2.13.Final fixing

* CVE-2026-42583 https://github.com/advisories/GHSA-mj4r-2hfc-f8p6  – Netty Lz4FrameDecoder
* CVE-2026-42587 https://github.com/advisories/GHSA-f6hv-jmp6-3vwv  – Netty decompression bomb (br, zstd, or snappy)