### PR TITLE
OKAPI-1249: Trillium vulns: Vertx 5.1.3, micrometer 1.16.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>5.1.1</version>  <!-- also update depending versions below! -->
+        <version>5.1.3</version>  <!-- also update depending versions below! -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -49,7 +49,7 @@
       <dependency>
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-bom</artifactId>
-        <version>1.16.5</version>  <!-- https://github.com/vert-x3/vertx-micrometer-metrics/blob/master/pom.xml#L39 -->
+        <version>1.16.6</version>  <!-- https://github.com/vert-x3/vertx-micrometer-metrics/blob/master/pom.xml#L39 -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/OKAPI-1249

Bump Vert.x from 5.1.1 to 5.1.3.

The Vert.x bump transitively bumps micrometer from 1.16.5 to 1.16.6: https://github.com/vert-x3/vertx-micrometer-metrics/compare/5.1.1...5.1.3

The micrometer version bump fixes security vulnerabilities:

* CVE-2026-40983 – https://github.com/advisories/GHSA-w737-wx49-qj23
* CVE-2026-40984 – https://github.com/advisories/GHSA-g3pr-3p32-fp23