### PR TITLE
OKAPI-1250: Sunflower: Vertx 4.5.28 fixing Netty vulns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.5.27</version> <!-- also update depending versions below! -->
+        <version>4.5.28</version> <!-- also update depending versions below! -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/OKAPI-1250

For Sunflower (okapi b6.2) bump Vert.x from 4.5.27 to 4.5.28.

This transitively bumps Netty from 4.1.133.Final to 4.1.135.Final https://github.com/netty/netty/releases/tag/netty-4.1.135.Final fixing multiple security vulnerabilities:

* CVE-2026-48059: memory exhaustion in io.netty:netty-codec-haproxy (high).
* CVE-2026-47691: DNS cache poisoning in io.netty:netty-resolver-dns (high).
* CVE-2026-50560: DDoS in io.netty:netty-codec-http2.
* CVE-2026-50011: memory exhaustion in io.netty:netty-codec-redis (high).
* CVE-2026-44250: memory exhaustion in io.netty:netty-codec-redis (high).
* CVE-2026-44890: memory exhaustion in io.netty:netty-codec-redis (high).
* CVE-2026-44249: IPv6 subnet filter bypass in io.netty:netty-handler (high).
* CVE-2026-50020: request smuggling in io.netty:netty-codec-http.
* CVE-2026-44893: memory leak in io.netty:netty-codec-haproxy (high).
* CVE-2026-50010: TLS hostname verification accidentally disabled in io.netty:netty-handler (high).
* CVE-2026-45673: DNS cache poisoning in io.netty:netty-resolver-dns.
* CVE-2026-45416: excessive memory usage from SNIHandler in io.netty:netty-handler (high).
* CVE-2026-45536: file descriptor leak in io.netty:netty-transport-native-epoll and io.netty:netty-transport-native-kqueue.
* CVE-2026-45674: DNS cache poisoning in io.netty:netty-resolver-dns (high).
* CVE-2026-46340: memory exhaustion in io.netty:netty-transport-sctp (high).
* CVE-2026-47244: denial of service in io.netty:netty-codec-http2.
* CVE-2026-48006: memory exhaustion in io.netty:netty-codec-redis (high).
* CVE-2026-48043: memory exhaustion in io.netty:netty-codec-http2.