### PR TITLE
OKAPI-1251: Sunflower: micrometer 1.12.13 -> 1.15.12 fix CVE-2026-40984

### DIFF
--- a/okapi-common/pom.xml
+++ b/okapi-common/pom.xml
@@ -50,7 +50,7 @@
     </dependency>
     <dependency>
       <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-registry-prometheus</artifactId>
+      <artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/okapi-core/pom.xml
+++ b/okapi-core/pom.xml
@@ -98,7 +98,7 @@
     </dependency>
     <dependency>
       <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-registry-prometheus</artifactId>
+      <artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
     </dependency>
     <dependency>
       <groupId>io.micrometer</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
       <dependency>
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-bom</artifactId>
-        <version>1.12.13</version>  <!-- https://github.com/vert-x3/vertx-micrometer-metrics/blob/master/pom.xml#L41 -->
+        <version>1.15.12</version>  <!-- security fix https://spring.io/security/cve-2026-40984 -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/OKAPI-1251

Bump micrometer from 1.12.13 to 1.15.12.

This fixes https://spring.io/security/cve-2026-40984 Micrometer HTTP server instrumentations DoS vulnerability

See https://github.com/micrometer-metrics/micrometer/wiki/1.13-Migration-Guide#prometheus-java-client-0x-to-1x-upgrade why we need to change from micrometer-registry-prometheus to <artifactId>micrometer-registry-prometheus-simpleclient.