### PR TITLE
OKAPI-1253: Sunflower - Netty 4.1.136, Vertx 4.5.30, scram 3.3, log4j 2.26.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,14 +35,14 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.26.0</version>
+        <version>2.26.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.5.28</version> <!-- also update depending versions below! -->
+        <version>4.5.30</version> <!-- also update depending versions below! -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -108,7 +108,7 @@
       <dependency>
         <groupId>com.ongres.scram</groupId>
         <artifactId>scram-client</artifactId>
-        <version>3.2</version>
+        <version>3.3</version>
       </dependency>
       <dependency>
         <groupId>org.junit</groupId>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/OKAPI-1253

In the Sunflower branch 6.2 bump

* Vert.x from 4.5.28 to 4.5.30
  * Vert.x transitively bumps Netty from 4.1.135.Final to 4.1.136.Final
  * Vert.x transitively bumps jackson from 2.21.4 to 2.21.5
* log4j-bom from 2.26.0 to 2.26.1
* scram-client from 3.2 to 3.3

This fixes multiple security vulnerabilities:

* Vert.x: The default HTTP client redirect handler should strip sensitive headers identified by CVE-2026-15075
* Vert.x: Web client cross domain cookie injection identified by CVE-2026-15076
* [CVE-2026-XXXXX](https://github.com/netty/netty/security/advisories/GHSA-vhch-2wf3-m8rp): memory exhaustion in io.netty:netty-codec-stomp.
* CVE-2026-55833: zip bomb in io.netty:netty-codec-http.
* [CVE-2026-XXXXX](https://github.com/netty/netty/security/advisories/GHSA-gcjf-9mgh-3p7g): improper CR/LF neutrolization in io.netty:netty-codec-http (multipart).
* [CVE-2026-XXXXX](https://github.com/netty/netty/security/advisories/GHSA-wh89-7897-x99h): improper CR/LF neutrolization in io.netty:netty-codec-haproxy.
* CVE-2026-55851: memory exhaustion in io.netty:netty-codec-haproxy.
* CVE-2026-56745: memory exhaustion in io.netty:netty-codec-http.
* CVE-2026-56817: insecure defaults in XML parsing in io.netty:netty-codec-xml.
* [CVE-2026-XXXXX](https://github.com/netty/netty/security/advisories/GHSA-q4f6-jm68-57ww): memory exhaustion in io.netty:netty-codec-http.
* CVE-2026-56818: memory leak in io.netty:netty-codec-redis.
* CVE-2026-56819: memory leak in io.netty:netty-codec-http2.
* CVE-2026-55831: resource exhaustion/DoS in io.netty:netty-codec-http.
* [CVE-2026-XXXXX](https://github.com/netty/netty/security/advisories/GHSA-mfg7-5gfp-c4w3): memory leak in io.netty:netty-codec-dns.
* [CVE-2026-XXXXX](https://github.com/netty/netty/security/advisories/GHSA-558v-64gr-wgg4): infinite loop in io.netty:netty-codec-compression (bzip2).
* [CVE-2026-XXXXX](https://github.com/netty/netty/security/advisories/GHSA-c69g-56f8-xwqj): improper header neutralization in io.netty:netty-codec-http2.
* [CVE-2026-XXXXX](https://github.com/netty/netty/security/advisories/GHSA-4mp9-239f-g9hg): protocol version confusion in io.netty:netty-codec-http (websocket).
* CVE-2026-56746: improper access control in io.netty:netty-codec-http (CORS).
* CVE-2026-56822: time-of-check/time-of-use in io.netty:netty-handler-ssl-ocsp.
* [CVE-2026-XXXXX](https://github.com/netty/netty/security/advisories/GHSA-v74w-7mr3-4qg3): uncontrolled resource consumption in io.netty:netty-codec-xml.
* CVE-2026-56820: improper certificate validation in io.netty:netty-handler-ssl-ocsp.
* CVE-2026-56821: improper certificate revocation check in io.netty:netty-handler-ssl-ocsp.
* [CVE-2026-XXXXX](https://github.com/netty/netty/security/advisories/GHSA-3g8r-4pfx-jmfh): improper CR/LF neutrolization in io.netty:netty-codec-stomp.
* Jackson: Case-insensitive deserialization may use wrong @JsonIgnoreProperties [CVE-2026-54515]
* Jackson: Honor @JsonView for external-type-id (EXTERNAL_PROPERTY) properties [GHSA-mhm7-754m-9p8w]
* Jackson: @JsonView by-passed for @JsonUnwrapped Field/Setter properties [CVE-2026-59889]
* log4j: https://logging.apache.org/security.html#CVE-2026-49844 – Improper serialization of non-finite floating-point values in MapMessage.asJson()
* scram: GHSA-p9jg-fcr6-3mhf – CVE-2026-53712 – Silent channel-binding authentication downgrade via unsupported certificate algorithms