### PR TITLE
OKAPI-1254: Bump log4j 2.25.4 -> 2.26.1 fixing CVE-2026-49844

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.25.4</version>
+        <version>2.26.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/OKAPI-1254

https://logging.apache.org/security.html#CVE-2026-49844