### PR TITLE
OKAPI-1255: Vertx 5.1.6, Netty 4.2.17 fixing vulns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>5.1.5</version>  <!-- also update depending versions below! -->
+        <version>5.1.6</version>  <!-- also update depending versions below! -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/OKAPI-1255

Bump Vert.x from 5.1.5 to 5.1.6 with several fixes: https://github.com/vert-x3/wiki/wiki/5.1.6-Release-Notes

The Vert.x bump transitively bumps Netty from 4.2.16.Final to 4.2.17.Final fixing multiple security vulnerabilities: https://netty.io/news/2026/08/04/4-2-17-Final.html
* [CVE-2026-XXXXX](https://github.com/netty/netty/security/advisories/GHSA-fccg-mwvh-qqg4) : algorithm inefficiency in io.netty:netty-handler
* [CVE-2026-XXXXX](https://github.com/netty/netty/security/advisories/GHSA-cc6x-ffm5-83wf) : improper NUL byte neutrolization in io.netty:netty-codec-socks
* [CVE-2026-XXXXX](https://github.com/netty/netty/security/advisories/GHSA-c4c3-7fpv-j4q5) : SNI bypass in io.netty:netty-handler
* [CVE-2026-59902](https://github.com/netty/netty/security/advisories/GHSA-2qj4-mmr9-4v2f) : memory exhaustion in io.netty:netty-transport-sctp
* [CVE-2026-59903](https://github.com/netty/netty/security/advisories/GHSA-8c42-7qj2-3j46) : cache poisoning & info disclosure in io.netty:netty-codec-http
* [CVE-2026-XXXXX](https://github.com/netty/netty/security/advisories/GHSA-43fm-7cxg-hf3j) : validation bypass in io.netty:netty-codec-mqtt
* [CVE-2026-XXXXX](https://github.com/netty/netty/security/advisories/GHSA-p85m-gvr3-788c) : improper hostname verification in io.netty:netty-handler